### PR TITLE
fix: added `reason` argument to `get_me` function

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -58,6 +58,9 @@ func NewServer(client *github.Client) *server.MCPServer {
 func getMe(client *github.Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_me",
 			mcp.WithDescription("Get details of the authenticated user."),
+			mcp.WithString("reason",
+				mcp.Description("Optional: reason the session was created"),
+			),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			user, resp, err := client.Users.Get(ctx, "")


### PR DESCRIPTION
The `mark3labs/mcp-go` library has a bug where it will error when there are no arguments specified for a tool. This adds a `reason` argument, which works around that bug but is also somewhat helpful for debugging and potentially even returns better results because the LLM can see why it decided to call the tool.