### PR TITLE
add iologger for debugging purposes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,12 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -21,6 +23,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/pkg/log/io.go
+++ b/pkg/log/io.go
@@ -1,0 +1,45 @@
+package log
+
+import (
+	"io"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// IOLogger is a wrapper around io.Reader and io.Writer that can be used
+// to log the data being read and written from the underlying streams
+type IOLogger struct {
+	reader io.Reader
+	writer io.Writer
+	logger *log.Logger
+}
+
+// NewIOLogger creates a new IOLogger instance
+func NewIOLogger(r io.Reader, w io.Writer, logger *log.Logger) *IOLogger {
+	return &IOLogger{
+		reader: r,
+		writer: w,
+		logger: logger,
+	}
+}
+
+// Read reads data from the underlying io.Reader and logs it.
+func (l *IOLogger) Read(p []byte) (n int, err error) {
+	if l.reader == nil {
+		return 0, io.EOF
+	}
+	n, err = l.reader.Read(p)
+	if n > 0 {
+		l.logger.Infof("[stdin]: received %d bytes: %s", n, string(p[:n]))
+	}
+	return n, err
+}
+
+// Write writes data to the underlying io.Writer and logs it.
+func (l *IOLogger) Write(p []byte) (n int, err error) {
+	if l.writer == nil {
+		return 0, io.ErrClosedPipe
+	}
+	l.logger.Infof("[stdout]: sending %d bytes: %s", len(p), string(p))
+	return l.writer.Write(p)
+}

--- a/pkg/log/io_test.go
+++ b/pkg/log/io_test.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggedReadWriter(t *testing.T) {
+	t.Run("Read method logs and passes data", func(t *testing.T) {
+		// Setup
+		inputData := "test input data"
+		reader := strings.NewReader(inputData)
+
+		// Create logger with buffer to capture output
+		var logBuffer bytes.Buffer
+		logger := log.New()
+		logger.SetOutput(&logBuffer)
+		logger.SetFormatter(&log.TextFormatter{
+			DisableTimestamp: true,
+		})
+
+		lrw := NewIOLogger(reader, nil, logger)
+
+		// Test Read
+		buf := make([]byte, 100)
+		n, err := lrw.Read(buf)
+
+		// Assertions
+		assert.NoError(t, err)
+		assert.Equal(t, len(inputData), n)
+		assert.Equal(t, inputData, string(buf[:n]))
+		assert.Contains(t, logBuffer.String(), "[stdin]")
+		assert.Contains(t, logBuffer.String(), inputData)
+	})
+
+	t.Run("Write method logs and passes data", func(t *testing.T) {
+		// Setup
+		outputData := "test output data"
+		var writeBuffer bytes.Buffer
+
+		// Create logger with buffer to capture output
+		var logBuffer bytes.Buffer
+		logger := log.New()
+		logger.SetOutput(&logBuffer)
+		logger.SetFormatter(&log.TextFormatter{
+			DisableTimestamp: true,
+		})
+
+		lrw := NewIOLogger(nil, &writeBuffer, logger)
+
+		// Test Write
+		n, err := lrw.Write([]byte(outputData))
+
+		// Assertions
+		assert.NoError(t, err)
+		assert.Equal(t, len(outputData), n)
+		assert.Equal(t, outputData, writeBuffer.String())
+		assert.Contains(t, logBuffer.String(), "[stdout]")
+		assert.Contains(t, logBuffer.String(), outputData)
+	})
+}


### PR DESCRIPTION
## Context

This PR introduces an `IOLogger` struct that logs all `stdin` and `stdout` interactions between the client and the server.  

This feature is particularly useful for debugging, as it provides visibility into the exact input and output exchanged between the client and the server.  

By default, logging is disabled but can be enabled by setting the `enable-command-logging` flag to `true`. I considered enabling it only when the log level is set to `debug`, but decided that having a separate toggle would be preferable due to potential privacy concerns.