### PR TITLE
feat: read-only flag

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -32,12 +32,14 @@ var (
 		Long:  `Start a server that communicates via standard input/output streams using JSON-RPC messages.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			logFile := viper.GetString("log-file")
+			readOnly := viper.GetBool("read-only")
+			exportTranslations := viper.GetBool("export-translations")
 			logger, err := initLogger(logFile)
 			if err != nil {
 				stdlog.Fatal("Failed to initialize logger:", err)
 			}
 			logCommands := viper.GetBool("enable-command-logging")
-			if err := runStdioServer(logger, logCommands, viper.GetBool("export-translations")); err != nil {
+			if err := runStdioServer(readOnly, logger, logCommands, exportTranslations); err != nil {
 				stdlog.Fatal("failed to run stdio server:", err)
 			}
 		},
@@ -48,11 +50,13 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	// Add global flags that will be shared by all commands
+	rootCmd.PersistentFlags().Bool("read-only", false, "Restrict the server to read-only operations")
 	rootCmd.PersistentFlags().String("log-file", "", "Path to log file")
 	rootCmd.PersistentFlags().Bool("enable-command-logging", false, "When enabled, the server will log all command requests and responses to the log file")
 	rootCmd.PersistentFlags().Bool("export-translations", false, "Save translations to a JSON file")
 
 	// Bind flag to viper
+	viper.BindPFlag("read-only", rootCmd.PersistentFlags().Lookup("read-only"))
 	viper.BindPFlag("log-file", rootCmd.PersistentFlags().Lookup("log-file"))
 	viper.BindPFlag("enable-command-logging", rootCmd.PersistentFlags().Lookup("enable-command-logging"))
 	viper.BindPFlag("export-translations", rootCmd.PersistentFlags().Lookup("export-translations"))
@@ -84,7 +88,7 @@ func initLogger(outPath string) (*log.Logger, error) {
 	return logger, nil
 }
 
-func runStdioServer(logger *log.Logger, logCommands bool, exportTranslations bool) error {
+func runStdioServer(readOnly bool, logger *log.Logger, logCommands bool, exportTranslations bool) error {
 	// Create app context
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -98,8 +102,8 @@ func runStdioServer(logger *log.Logger, logCommands bool, exportTranslations boo
 
 	t, dumpTranslations := translations.TranslationHelper()
 
-	// Create server
-	ghServer := github.NewServer(ghClient, t)
+	// Create
+	ghServer := github.NewServer(ghClient, readOnly, t)
 	stdioServer := server.NewStdioServer(ghServer)
 
 	stdLogger := stdlog.New(logger.Writer(), "stdioserver", 0)

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 // NewServer creates a new GitHub MCP server with the specified GH client and logger.
-func NewServer(client *github.Client, t translations.TranslationHelperFunc) *server.MCPServer {
+func NewServer(client *github.Client, readOnly bool, t translations.TranslationHelperFunc) *server.MCPServer {
 	// Create a new MCP server
 	s := server.NewMCPServer(
 		"github-mcp-server",
@@ -35,29 +35,36 @@ func NewServer(client *github.Client, t translations.TranslationHelperFunc) *ser
 
 	// Add GitHub tools - Issues
 	s.AddTool(getIssue(client, t))
-	s.AddTool(addIssueComment(client, t))
-	s.AddTool(createIssue(client, t))
 	s.AddTool(searchIssues(client, t))
 	s.AddTool(listIssues(client, t))
+	if !readOnly {
+		s.AddTool(createIssue(client, t))
+		s.AddTool(addIssueComment(client, t))
+		s.AddTool(createIssue(client, t))
+	}
 
 	// Add GitHub tools - Pull Requests
 	s.AddTool(getPullRequest(client, t))
 	s.AddTool(listPullRequests(client, t))
-	s.AddTool(mergePullRequest(client, t))
 	s.AddTool(getPullRequestFiles(client, t))
 	s.AddTool(getPullRequestStatus(client, t))
-	s.AddTool(updatePullRequestBranch(client, t))
 	s.AddTool(getPullRequestComments(client, t))
 	s.AddTool(getPullRequestReviews(client, t))
+	if !readOnly {
+		s.AddTool(mergePullRequest(client, t))
+		s.AddTool(updatePullRequestBranch(client, t))
+	}
 
 	// Add GitHub tools - Repositories
-	s.AddTool(createOrUpdateFile(client, t))
 	s.AddTool(searchRepositories(client, t))
-	s.AddTool(createRepository(client, t))
 	s.AddTool(getFileContents(client, t))
-	s.AddTool(forkRepository(client, t))
-	s.AddTool(createBranch(client, t))
 	s.AddTool(listCommits(client, t))
+	if !readOnly {
+		s.AddTool(createOrUpdateFile(client, t))
+		s.AddTool(createRepository(client, t))
+		s.AddTool(forkRepository(client, t))
+		s.AddTool(createBranch(client, t))
+	}
 
 	// Add GitHub tools - Search
 	s.AddTool(searchCode(client, t))


### PR DESCRIPTION
Add a read-only flag and gate endpoints that would otherwise write behind it, so that people can avoid the risk that an LLM can write to their GitHub account entirely.