### PR TITLE
fix array schemas

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -522,6 +522,25 @@ func createPullRequestReview(client *github.Client, t translations.TranslationHe
 				mcp.Description("SHA of commit to review"),
 			),
 			mcp.WithArray("comments",
+				mcp.Items(
+					map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"path": map[string]interface{}{
+								"type":        "string",
+								"description": "path to the file",
+							},
+							"position": map[string]interface{}{
+								"type":        "number",
+								"description": "line number in the file",
+							},
+							"body": map[string]interface{}{
+								"type":        "string",
+								"description": "comment body",
+							},
+						},
+					},
+				),
 				mcp.Description("Line-specific comments array of objects, each object with path (string), position (number), and body (string)"),
 			),
 		),

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -432,6 +432,20 @@ func pushFiles(client *github.Client, t translations.TranslationHelperFunc) (too
 			),
 			mcp.WithArray("files",
 				mcp.Required(),
+				mcp.Items(
+					map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"path": map[string]interface{}{
+								"type":        "string",
+								"description": "path to the file",
+							},
+							"content": map[string]interface{}{
+								"type":        "string",
+								"description": "file content",
+							},
+						},
+					}),
 				mcp.Description("Array of file objects to push, each object with path (string) and content (string)"),
 			),
 			mcp.WithString("message",


### PR DESCRIPTION
## Context

This PR adds schemas for the the array items. Without this, we were creating schemas where arrays didn't have their items specified. This caused issues in 4o.