### PR TITLE
fix: add required fields for OpenAI API

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -591,7 +591,9 @@ func createPullRequestReview(client *github.Client, t translations.TranslationHe
 			mcp.WithArray("comments",
 				mcp.Items(
 					map[string]interface{}{
-						"type": "object",
+						"type":                 "object",
+						"additionalProperties": false,
+						"required":             []string{"path", "position", "body"},
 						"properties": map[string]interface{}{
 							"path": map[string]interface{}{
 								"type":        "string",

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -488,7 +488,9 @@ func pushFiles(client *github.Client, t translations.TranslationHelperFunc) (too
 				mcp.Required(),
 				mcp.Items(
 					map[string]interface{}{
-						"type": "object",
+						"type":                 "object",
+						"additionalProperties": false,
+						"required":             []string{"path", "content"},
 						"properties": map[string]interface{}{
 							"path": map[string]interface{}{
 								"type":        "string",


### PR DESCRIPTION
The OpenAI function calling API [requires](https://platform.openai.com/docs/guides/function-calling?api-mode=chat#strict-mode) that `additionalProperties: false` and `required: []` be set for arrays.