### PR TITLE
fix: mention "me" and "my" in `get_me` description

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -85,7 +85,7 @@ func NewServer(client *github.Client, readOnly bool, t translations.TranslationH
 // getMe creates a tool to get details of the authenticated user.
 func getMe(client *github.Client, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_me",
-			mcp.WithDescription(t("TOOL_GET_ME_DESCRIPTION", "Get details of the authenticated GitHub user")),
+			mcp.WithDescription(t("TOOL_GET_ME_DESCRIPTION", "Get details of the authenticated GitHub user. Use this when a request include \"me\", \"my\"...")),
 			mcp.WithString("reason",
 				mcp.Description("Optional: reason the session was created"),
 			),


### PR DESCRIPTION
I was having trouble getting things like `list my private repos` or `list the commits on my repo X` working. Explicitly mentioning "me" and "my" in the tool description for `get_me` seems to have helped a lot.