### PR TITLE
Use a config filename that is different from the binary name

### DIFF
--- a/pkg/translations/translations.go
+++ b/pkg/translations/translations.go
@@ -24,7 +24,7 @@ func TranslationHelper() (TranslationHelperFunc, func()) {
 	v.AutomaticEnv()
 
 	// Load from JSON file
-	v.SetConfigName("github-mcp-server")
+	v.SetConfigName("github-mcp-server-config")
 	v.SetConfigType("json")
 	v.AddConfigPath(".")
 
@@ -59,9 +59,9 @@ func TranslationHelper() (TranslationHelperFunc, func()) {
 		}
 }
 
-// dump translationKeyMap to a json file called github-mcp-server.json
+// dump translationKeyMap to a json file called github-mcp-server-config.json
 func DumpTranslationKeyMap(translationKeyMap map[string]string) error {
-	file, err := os.Create("github-mcp-server.json")
+	file, err := os.Create("github-mcp-server-config.json")
 	if err != nil {
 		return fmt.Errorf("error creating file: %v", err)
 	}


### PR DESCRIPTION
## Description

This was causing issues in the Docker container, where viper looks for a filename, without considering the extension, resulting in it trying to parse the binary itself as JSON:

```
➜ github-mcp-server git:(main) ✗ docker run -itt -e GITHUB_PERSONAL_ACCESS_TOKEN=foo github/github-mcp-server
2025/03/28 10:04:19 Could not read JSON config: While parsing config: invalid character '\x7f' looking for beginning of value
```

There are probably more robust options out there, like looking in config dirs (XDG, if this was ever user installed) but this is the simplest path to fix the error.