### PR TITLE
dev: easily run servers with current code

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,32 @@
+{
+    "inputs": [
+        {
+            "id": "github-pat",
+            "type": "promptString",
+            "description": "Github Personal Access Token",
+            "password": true
+        }
+    ],
+    "servers": {
+        "github-mcp-server-dev": {
+            "type": "stdio",
+            "command": "./src/github.com/github/github-mcp-server/script/go-run",
+            "args": [
+                // ""
+            ],
+            "env": {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github-pat}"
+            }
+        },
+        "github-mcp-server-docker-dev": {
+            "type": "stdio",
+            "command": "./src/github.com/github/github-mcp-server/script/docker-build-run",
+            "args": [
+                // ""
+            ],
+            "env": {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github-pat}"
+            }
+        }
+    }
+}

--- a/script/docker-build-run
+++ b/script/docker-build-run
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd "${0%/*}"
+cd ../
+echo "Running go-run.sh in $(pwd)"
+
+docker build . --tag ghcr.io/github/github-mcp-server:dev 
+docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server:dev ./github-mcp-server stdio

--- a/script/go-run
+++ b/script/go-run
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd "${0%/*}"
+cd ../
+echo "Running go-run.sh in $(pwd)"
+
+go run cmd/github-mcp-server/main.go stdio


### PR DESCRIPTION
This is more of an idea worth sharing than something we need to merge, but I made scripts that let me run the latest code easily against VSCode.

I think perhaps instead of committing the `.vscode/mpc.json` it might make more sense to add to `.gitignore` and just have the scripts handy, because I couldn't get it to dynamically find the directory.

Thought I'd share though as it's a nice way to test.