### PR TITLE
feat: enable secret protection

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -58,6 +59,7 @@ func NewServer(client *github.Client, readOnly bool, t translations.TranslationH
 	}
 
 	// Add GitHub tools - Repositories
+	s.AddTool(getRepositorySettings(client, t))
 	s.AddTool(searchRepositories(client, t))
 	s.AddTool(getFileContents(client, t))
 	s.AddTool(listCommits(client, t))
@@ -67,6 +69,7 @@ func NewServer(client *github.Client, readOnly bool, t translations.TranslationH
 		s.AddTool(forkRepository(client, t))
 		s.AddTool(createBranch(client, t))
 		s.AddTool(pushFiles(client, t))
+		s.AddTool(toggleSecretProtectionFeatures(client, t))
 	}
 
 	// Add GitHub tools - Search
@@ -157,7 +160,9 @@ func requiredParam[T comparable](r mcp.CallToolRequest, p string) (T, error) {
 		return zero, fmt.Errorf("parameter %s is not of type %T", p, zero)
 	}
 
-	if r.Params.Arguments[p].(T) == zero {
+	// Check if the parameter is not empty, i.e: non-zero value
+	// Note: This check is not applicable for bool type, as false is a valid value
+	if r.Params.Arguments[p].(T) == zero && reflect.TypeOf(zero).Kind() != reflect.Bool {
 		return zero, fmt.Errorf("missing required parameter: %s", p)
 
 	}


### PR DESCRIPTION
Enable checking of repository settings, and add a specific tool for toggling secret scanning settings only.

https://github.com/user-attachments/assets/46a67ec8-a0e5-4e61-b8db-067c93238ddd

Advanced Security is a pre-requisite for using this on private repos (and or Secret Protection SKU when it launches next week), so we will need to handle those quirks.

I had to make some manual http calls, because the go wrapper does not wrap this feature.

TODO before merge:

- [ ] decide on cleanest way to handle the public/private repo stuff where there is a pre-requisite to enabling secret protection
- [ ] we could just have a catch-all configuration setting endpoint, with the massive number of possible settings?
- [ ] I can make all fields optional, but the annoying thing is that you can't have push protection on, without secret protection. The API is not conducive to wrapping neatly in a tool, but I must find a way.
- [ ] can we also enable Code Scanning default setup?
- [ ] add tests
