### PR TITLE
set user agent for client requests

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -101,6 +101,7 @@ func runStdioServer(readOnly bool, logger *log.Logger, logCommands bool, exportT
 		logger.Fatal("GITHUB_PERSONAL_ACCESS_TOKEN not set")
 	}
 	ghClient := gogithub.NewClient(nil).WithAuthToken(token)
+	ghClient.UserAgent = "github-mcp-server/1.0"
 
 	// Check GH_HOST env var first, then fall back to viper config
 	host := os.Getenv("GH_HOST")


### PR DESCRIPTION
Set a User-Agent "github-mcp-server/1.0" for Client requests.

This overrides https://github.com/google/go-github/blob/0710d0b66118875dd853e35fdbeadf32f0264376/github/github.go#L36 and is set in https://github.com/google/go-github/blob/0710d0b66118875dd853e35fdbeadf32f0264376/github/github.go#L423

I wish there was a way to dynamically set the version, but I don't know of a sane way to pull the GitHub release version so starting with 1.0

With this being built directly in the command I don't have a good way to write a test in code, a future refactor could help with that.

