### PR TITLE
fix: run lint in all circumstances

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,19 +1,7 @@
 name: Lint
 on:
   push:
-    paths:
-      - "**.go"
-      - go.mod
-      - go.sum
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths:
-      - "**.go"
-      - go.mod
-      - go.sum
-    paths-ignore:
-      - '**.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
We need to run the linter in all circumstances, otherwise it cannot be a required check.