### PR TITLE
chore: set build arg for publishing version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,13 +7,13 @@ name: Docker
 
 on:
   schedule:
-    - cron: '27 0 * * *'
+    - cron: "27 0 * * *"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -21,10 +21,8 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,7 +41,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: "v2.2.4"
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -82,6 +80,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+          build-args:
+            VERSION: ${{ github.ref_name }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG VERSION="dev"
 
 FROM golang:1.23.7 AS build
+# allow this step access to build arg
+ARG VERSION
 # Set the working directory
 WORKDIR /build
 # Copy the current directory contents into the working directory


### PR DESCRIPTION
The version build arg needs to be passed through to the correct layer in the docker image build, and the build arg also needs to be passed through to the image build from the actions workflow.