### PR TITLE
assert request params in code_scanning_test

### DIFF
--- a/pkg/github/code_scanning_test.go
+++ b/pkg/github/code_scanning_test.go
@@ -156,9 +156,15 @@ func Test_ListCodeScanningAlerts(t *testing.T) {
 		{
 			name: "successful alerts listing",
 			mockedClient: mock.NewMockedHTTPClient(
-				mock.WithRequestMatch(
+				mock.WithRequestMatchHandler(
 					mock.GetReposCodeScanningAlertsByOwnerByRepo,
-					mockAlerts,
+					expectQueryParams(t, map[string]string{
+						"ref":      "main",
+						"state":    "open",
+						"severity": "high",
+					}).andThen(
+						mockResponse(t, http.StatusOK, mockAlerts),
+					),
 				),
 			),
 			requestArgs: map[string]interface{}{


### PR DESCRIPTION
## Context

This makes use of the new helper functionality to assert the right  code scanning parameters are passed to the GH API request.