### PR TITLE
Remove non-existent README property

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `description`: Repository description (string, optional)
   - `private`: Whether the repository is private (boolean, optional)
   - `auto_init`: Auto-initialize with README (boolean, optional)
-  - `gitignore_template`: Gitignore template name (string, optional)
 
 - **get_file_contents** - Get contents of a file or directory
 


### PR DESCRIPTION
## Description

Accidentally lost this commit from https://github.com/github/github-mcp-server/pull/89 because I didn't realise that it hadn't been merged into `main` when I force pushed. Whoops!