### PR TITLE
pretty print json

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -39,6 +41,7 @@ var (
 			logFile := viper.GetString("log-file")
 			readOnly := viper.GetBool("read-only")
 			exportTranslations := viper.GetBool("export-translations")
+			prettyPrintJSON := viper.GetBool("pretty-print-json")
 			logger, err := initLogger(logFile)
 			if err != nil {
 				stdlog.Fatal("Failed to initialize logger:", err)
@@ -49,6 +52,7 @@ var (
 				logger:             logger,
 				logCommands:        logCommands,
 				exportTranslations: exportTranslations,
+				prettyPrintJSON:    prettyPrintJSON,
 			}
 			if err := runStdioServer(cfg); err != nil {
 				stdlog.Fatal("failed to run stdio server:", err)
@@ -66,6 +70,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("enable-command-logging", false, "When enabled, the server will log all command requests and responses to the log file")
 	rootCmd.PersistentFlags().Bool("export-translations", false, "Save translations to a JSON file")
 	rootCmd.PersistentFlags().String("gh-host", "", "Specify the GitHub hostname (for GitHub Enterprise etc.)")
+	rootCmd.PersistentFlags().Bool("pretty-print-json", false, "Pretty print JSON output")
 
 	// Bind flag to viper
 	_ = viper.BindPFlag("read-only", rootCmd.PersistentFlags().Lookup("read-only"))
@@ -73,6 +78,7 @@ func init() {
 	_ = viper.BindPFlag("enable-command-logging", rootCmd.PersistentFlags().Lookup("enable-command-logging"))
 	_ = viper.BindPFlag("export-translations", rootCmd.PersistentFlags().Lookup("export-translations"))
 	_ = viper.BindPFlag("gh-host", rootCmd.PersistentFlags().Lookup("gh-host"))
+	_ = viper.BindPFlag("pretty-print-json", rootCmd.PersistentFlags().Lookup("pretty-print-json"))
 
 	// Add subcommands
 	rootCmd.AddCommand(stdioCmd)
@@ -106,6 +112,20 @@ type runConfig struct {
 	logger             *log.Logger
 	logCommands        bool
 	exportTranslations bool
+	prettyPrintJSON    bool
+}
+
+// JSONPrettyPrintWriter is a Writer that pretty prints input to indented JSON
+type JSONPrettyPrintWriter struct {
+	writer io.Writer
+}
+
+func (j JSONPrettyPrintWriter) Write(p []byte) (n int, err error) {
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, p, "", "\t"); err != nil {
+		return 0, err
+	}
+	return j.writer.Write(prettyJSON.Bytes())
 }
 
 func runStdioServer(cfg runConfig) error {
@@ -159,6 +179,9 @@ func runStdioServer(cfg runConfig) error {
 			in, out = loggedIO, loggedIO
 		}
 
+		if cfg.prettyPrintJSON {
+			out = JSONPrettyPrintWriter{writer: out}
+		}
 		errC <- stdioServer.Listen(ctx, in, out)
 	}()
 


### PR DESCRIPTION
- **create a config struct for running the server**
- **pretty print json**

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: #113

Introduces a new flag `pretty-print-json` which will format json output from the server for easier visualization.
As the list of configuration options was growing, I opted to add a config struct instead of adding one more to the pile.

(partial output in the screenshot below)
<img width="998" alt="Screenshot 2025-04-04 at 5 30 41 PM" src="https://github.com/user-attachments/assets/5561289a-64f1-4d9d-a6b6-5dfe0c6e8025" />


With all of this code in main, there isn't a good way to add tests here and it felt a bit out of place to add to pkg/github/server.go
A refactor would be very helpful to make this easier.

I did not add a new option to the launch.json for it, as I feel like it is still best to be disabled by default.

A future enhancement might be to incorporate https://github.com/cli/go-gh/blob/61bf393cf4aeea6d00a6251390f5f67f5b67e727/pkg/jsonpretty/format.go