### PR TITLE
fix issue with pagination in search_repositories

### DIFF
--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -36,7 +36,7 @@ func searchRepositories(client *github.Client, t translations.TranslationHelperF
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-			perPage, err := optionalIntParamWithDefault(request, "per_page", 30)
+			perPage, err := optionalIntParamWithDefault(request, "perPage", 30)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -72,9 +72,9 @@ func Test_SearchRepositories(t *testing.T) {
 				),
 			),
 			requestArgs: map[string]interface{}{
-				"query":    "golang test",
-				"page":     float64(2),
-				"per_page": float64(10),
+				"query":   "golang test",
+				"page":    float64(2),
+				"perPage": float64(10),
 			},
 			expectError:    false,
 			expectedResult: mockSearchResult,


### PR DESCRIPTION
Closes: #105

This PR makes sure that the `perPage` parameter in `search_repositories` is honored. Otherwise, we were always getting 30 results.