### PR TITLE
Clarify create_pull_request_review input schema definition for: 'position'

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -600,8 +600,9 @@ func createPullRequestReview(client *github.Client, t translations.TranslationHe
 								"description": "path to the file",
 							},
 							"position": map[string]interface{}{
-								"type":        "number",
-								"description": "line number in the file",
+								"type": "number",
+								"description": `number of lines down from the first "@@" hunk header in the diff. The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the diff continues to increase through lines of whitespace and additional hunks.
+								This value is not the same as the line number in the file.`,
 							},
 							"body": map[string]interface{}{
 								"type":        "string",


### PR DESCRIPTION
## Why
I have been playing with github's mcp server, and have found that it is incapable of adding comments due to:
```
McpError: MCP error -32603: failed to create pull request review: POST https://api.github.com/repos/owner/name/pulls/pullId/reviews: 422 Unprocessable Entity [{Resource: Field: Code: Message:Pull request review thread position is invalid and Pull request review thread diff hunk can't be blank}]
```
This is because the current definition for the `position` input parameter is wrong:
```
    line number in the file
```

This is a clear misconception, as even the github [api documentation states a `Note`](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request) specifying that the position is NOT the line number in the file, but of the diff.

## What
I have changed the description to better reflect what the input actually is. I have based it on the REST API documentation, and my tests.

## How
I have used: `claude-3-5-sonnet-latest` with a simple loop:
- it is given a pr and the tool to get the file for more context
- When all files have been looked at, it is asked to create a pr review

The description is a bit longer than I would have liked, but I have seen that it has a hard time understanding what this position actually means, and this has given the best results.

## Alternatives
- Changing this position to be the line of the file. Thought that would require changing how the REST API endpoint works, and is not so simple, as a single fine line, might have multiple positions in a diff (ex. when there is a deletion and addition)
- A similar description that works better (that requires testing a broader set of cases than I have)