### PR TITLE
Add installation instructions for Homebrew and CLI usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,33 @@ automation and interaction capabilities for developers and tools.
 2. [Create a GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new).
 The MCP server can use many of the GitHub APIs, so enable the permissions that you feel comfortable granting your AI tools (to learn more about access tokens, please check out the [documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)).
 
-
-
 ## Installation
+
+### Homebew (Mac)
+
+```
+brew install github-mcp-server
+```
+
+#### Using the CLI After Homebrew Installation
+
+After installing with Homebrew, you can run the server with:
+
+```
+# Set your GitHub token
+export GITHUB_PERSONAL_ACCESS_TOKEN=<github_token>
+```
+
+```
+# Run the server in stdio mode
+github-mcp-server stdio
+```
+
+For more options and commands:
+
+```
+github-mcp-server --help
+```
 
 ### Usage with VS Code
 


### PR DESCRIPTION
This pull request updates the `README.md` file to include new installation instructions for the GitHub MCP server using Homebrew on Mac. It also provides details on how to set up and use the server after installation.

Key changes:

* Added a new section for Homebrew installation, including commands to install the GitHub MCP server (`README.md`).
* Included instructions on setting the GitHub personal access token and running the server in stdio mode (`README.md`).
* Provided additional commands and options for using the server (`README.md`).<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
