### PR TITLE
chore: pass version through to server

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -158,7 +158,7 @@ func runStdioServer(cfg runConfig) error {
 	t, dumpTranslations := translations.TranslationHelper()
 
 	// Create
-	ghServer := github.NewServer(ghClient, cfg.readOnly, t)
+	ghServer := github.NewServer(ghClient, version, cfg.readOnly, t)
 	stdioServer := server.NewStdioServer(ghServer)
 
 	stdLogger := stdlog.New(cfg.logger.Writer(), "stdioserver", 0)

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -15,11 +15,11 @@ import (
 )
 
 // NewServer creates a new GitHub MCP server with the specified GH client and logger.
-func NewServer(client *github.Client, readOnly bool, t translations.TranslationHelperFunc) *server.MCPServer {
+func NewServer(client *github.Client, version string, readOnly bool, t translations.TranslationHelperFunc) *server.MCPServer {
 	// Create a new MCP server
 	s := server.NewMCPServer(
 		"github-mcp-server",
-		"0.0.1",
+		version,
 		server.WithResourceCapabilities(true, true),
 		server.WithLogging())
 


### PR DESCRIPTION
Just noticed that this was not wired up, and it should be. The server has a version param that was still hard-coded.