### PR TITLE
chore: Remove unnecessary trailing periods from descriptions

### DIFF
--- a/cmd/mcpcurl/README.md
+++ b/cmd/mcpcurl/README.md
@@ -49,7 +49,7 @@ Available Commands:
   create_repository     Create a new GitHub repository in your account
   fork_repository       Fork a GitHub repository to your account or specified organization
   get_file_contents     Get the contents of a file or directory from a GitHub repository
-  get_issue             Get details of a specific issue in a GitHub repository.
+  get_issue             Get details of a specific issue in a GitHub repository
   get_issue_comments    Get comments for a GitHub issue
   list_commits          Get list of commits of a branch in a GitHub repository
   list_issues           List issues in a GitHub repository with filtering options
@@ -74,7 +74,7 @@ Get help for a specific tool:
 
 ```bash
  % ./mcpcurl --stdio-server-cmd "docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN mcp/github" tools get_issue --help
-Get details of a specific issue in a GitHub repository.
+Get details of a specific issue in a GitHub repository
 
 Usage:
   mcpcurl tools get_issue [flags]

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -17,18 +17,18 @@ import (
 // getIssue creates a tool to get details of a specific issue in a GitHub repository.
 func getIssue(client *github.Client, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_issue",
-			mcp.WithDescription(t("TOOL_GET_ISSUE_DESCRIPTION", "Get details of a specific issue in a GitHub repository.")),
+			mcp.WithDescription(t("TOOL_GET_ISSUE_DESCRIPTION", "Get details of a specific issue in a GitHub repository")),
 			mcp.WithString("owner",
 				mcp.Required(),
-				mcp.Description("The owner of the repository."),
+				mcp.Description("The owner of the repository"),
 			),
 			mcp.WithString("repo",
 				mcp.Required(),
-				mcp.Description("The name of the repository."),
+				mcp.Description("The name of the repository"),
 			),
 			mcp.WithNumber("issue_number",
 				mcp.Required(),
-				mcp.Description("The number of the issue."),
+				mcp.Description("The number of the issue"),
 			),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
There were no periods elsewhere, I aligned everything by removing the period.