### PR TITLE
add experimental get_latest_version tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,12 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `state`: Alert state (string, optional)
   - `severity`: Alert severity (string, optional)
 
+### Version
+
+- **get_latest_version** - Get the latest version of the GitHub MCP server to see if you are up to date
+
+  - No parameters required for this tool
+
 ## Resources
 
 ### Repository Content


### PR DESCRIPTION
## Context

This is an experimental feature that adds a new tool to check whether there's a newer version of the GitHub MCP server available.

The purpose of this PR is to gather feedback on whether we would like to have something like this. I see this as a moderately  useful, but temporary,  feature until this problem is solved by better means.

It exposes a tool that does the job  by checking the latest available version of the GitHub MCP server to compare it against the current version.

Here's in action:

![Screenshot 2025-04-08 at 07 47 24](https://github.com/user-attachments/assets/e7d5d4c1-a2bc-4d75-8251-1472a40da195)

![Screenshot 2025-04-08 at 07 47 31](https://github.com/user-attachments/assets/8b051c2e-b238-4b38-9ec5-977d032df2aa)

Note that we could tweak the response to point to the README, or a section in the README about updating.
