### PR TITLE
Indicate Go API stability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,10 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
     - `prNumber`: Pull request number (string, required)
     - `path`: File or directory path (string, optional)
 
+## Library Usage
+
+The exported Go API of this module should currently be considered unstable, and subject to breaking changes. In the future, we may offer stability; please file an issue if there is a use case where this would be valuable.
+
 ## License
 
 This project is licensed under the terms of the MIT open source license. Please refer to [MIT](./LICENSE) for the full terms.


### PR DESCRIPTION
## Description

Some identifiers were recently exported for internal use, but this is not a commitment to a stable API, so let's document that.
