### PR TITLE
Fix handling nil values for optional string array parameters,

### DIFF
--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -468,10 +468,10 @@ func Test_CreateIssue(t *testing.T) {
 				),
 			),
 			requestArgs: map[string]interface{}{
-				"owner": "owner",
-				"repo":  "repo",
-				"title": "Minimal Issue",
-				"assignees": nil,	// Expect no failure with nil optional value.
+				"owner":     "owner",
+				"repo":      "repo",
+				"title":     "Minimal Issue",
+				"assignees": nil, // Expect no failure with nil optional value.
 			},
 			expectError: false,
 			expectedIssue: &github.Issue{

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -471,6 +471,7 @@ func Test_CreateIssue(t *testing.T) {
 				"owner": "owner",
 				"repo":  "repo",
 				"title": "Minimal Issue",
+				"assignees": nil,	// Expect no failure with nil optional value.
 			},
 			expectError: false,
 			expectedIssue: &github.Issue{

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -232,12 +232,12 @@ func OptionalIntParamWithDefault(r mcp.CallToolRequest, p string, d int) (int, e
 // 1. Checks if the parameter is present in the request, if not, it returns its zero-value
 // 2. If it is present, iterates the elements and checks each is a string
 func OptionalStringArrayParam(r mcp.CallToolRequest, p string) ([]string, error) {
-    // Check if the parameter is present in the request
+	// Check if the parameter is present in the request
 	if _, ok := r.Params.Arguments[p]; !ok {
 		return []string{}, nil
 	}
 
-    switch v := r.Params.Arguments[p].(type) {
+	switch v := r.Params.Arguments[p].(type) {
 	case nil:
 		return []string{}, nil
 	case []string:

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -232,12 +232,14 @@ func OptionalIntParamWithDefault(r mcp.CallToolRequest, p string, d int) (int, e
 // 1. Checks if the parameter is present in the request, if not, it returns its zero-value
 // 2. If it is present, iterates the elements and checks each is a string
 func OptionalStringArrayParam(r mcp.CallToolRequest, p string) ([]string, error) {
-	// Check if the parameter is present in the request
+    // Check if the parameter is present in the request
 	if _, ok := r.Params.Arguments[p]; !ok {
 		return []string{}, nil
 	}
 
-	switch v := r.Params.Arguments[p].(type) {
+    switch v := r.Params.Arguments[p].(type) {
+	case nil:
+		return []string{}, nil
 	case []string:
 		return v, nil
 	case []any:


### PR DESCRIPTION
When attempting to use Claude for MCP tooling, any optional arrays it currently submits a nil value instead of an empty array which results in a returned error. This change adjusts that to return an empty array instead of an error for nil optional arrays.

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: https://github.com/github/github-mcp-server/issues/193
