### PR TITLE
Allow passing through server options

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -19,8 +19,11 @@ type GetClientFn func(context.Context) (*github.Client, error)
 // NewServer creates a new GitHub MCP server with the specified GH client and logger.
 func NewServer(getClient GetClientFn, version string, readOnly bool, t translations.TranslationHelperFunc, opts ...server.ServerOption) *server.MCPServer {
 	// Add default options
-	opts = append(opts, server.WithResourceCapabilities(true, true))
-	opts = append(opts, server.WithLogging())
+	defaultOpts := []server.ServerOption{
+		server.WithResourceCapabilities(true, true),
+		server.WithLogging(),
+	}
+	opts = append(defaultOpts, opts...)
 
 	// Create a new MCP server
 	s := server.NewMCPServer(

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -17,13 +17,17 @@ import (
 type GetClientFn func(context.Context) (*github.Client, error)
 
 // NewServer creates a new GitHub MCP server with the specified GH client and logger.
-func NewServer(getClient GetClientFn, version string, readOnly bool, t translations.TranslationHelperFunc) *server.MCPServer {
+func NewServer(getClient GetClientFn, version string, readOnly bool, t translations.TranslationHelperFunc, opts ...server.ServerOption) *server.MCPServer {
+	// Add default options
+	opts = append(opts, server.WithResourceCapabilities(true, true))
+	opts = append(opts, server.WithLogging())
+
 	// Create a new MCP server
 	s := server.NewMCPServer(
 		"github-mcp-server",
 		version,
-		server.WithResourceCapabilities(true, true),
-		server.WithLogging())
+		opts...,
+	)
 
 	// Add GitHub Resources
 	s.AddResourceTemplate(GetRepositoryResourceContent(getClient, t))


### PR DESCRIPTION
Adds support the the underlying mcp-go `ServerOptions` so that [hook functions](https://github.com/mark3labs/mcp-go/blob/main/server/hooks.go#L84-L107) can be attached to the server.