### PR TITLE
Prefer already-defined endpoint mock

### DIFF
--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -517,11 +517,6 @@ func Test_GetCommit(t *testing.T) {
 			},
 		},
 	}
-	// This one currently isn't defined in the mock package we're using.
-	var mockEndpointPattern = mock.EndpointPattern{
-		Pattern: "/repos/{owner}/{repo}/commits/{sha}",
-		Method:  "GET",
-	}
 
 	tests := []struct {
 		name           string
@@ -535,7 +530,7 @@ func Test_GetCommit(t *testing.T) {
 			name: "successful commit fetch",
 			mockedClient: mock.NewMockedHTTPClient(
 				mock.WithRequestMatchHandler(
-					mockEndpointPattern,
+					mock.GetReposCommitsByOwnerByRepoByRef,
 					mockResponse(t, http.StatusOK, mockCommit),
 				),
 			),
@@ -551,7 +546,7 @@ func Test_GetCommit(t *testing.T) {
 			name: "commit fetch fails",
 			mockedClient: mock.NewMockedHTTPClient(
 				mock.WithRequestMatchHandler(
-					mockEndpointPattern,
+					mock.GetReposCommitsByOwnerByRepoByRef,
 					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 						w.WriteHeader(http.StatusNotFound)
 						_, _ = w.Write([]byte(`{"message": "Not Found"}`))


### PR DESCRIPTION
Went to cut a PR upstream and realized I missed [this pre-defined endpoint pattern](https://github.com/migueleliasweb/go-github-mock/blob/master/src/mock/endpointpattern.go#L2875-L2878) when checking for work on #216.