### PR TITLE
Pretty-print JSONL text responses in `mcpcurl`

### DIFF
--- a/cmd/mcpcurl/main.go
+++ b/cmd/mcpcurl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,8 +11,6 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
-
-	"crypto/rand"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -161,7 +160,7 @@ func main() {
 	_ = rootCmd.MarkPersistentFlagRequired("stdio-server-cmd")
 
 	// Add global flag for pretty printing
-	rootCmd.PersistentFlags().Bool("pretty", true, "Pretty print MCP response (only for JSON responses)")
+	rootCmd.PersistentFlags().Bool("pretty", true, "Pretty print MCP response (only for JSON or JSONL responses)")
 
 	// Add the tools command to the root command
 	rootCmd.AddCommand(toolsCmd)
@@ -426,17 +425,27 @@ func printResponse(response string, prettyPrint bool) error {
 	// Extract text from content items of type "text"
 	for _, content := range resp.Result.Content {
 		if content.Type == "text" {
-			// Unmarshal the text content
-			var textContent map[string]interface{}
-			if err := json.Unmarshal([]byte(content.Text), &textContent); err != nil {
-				return fmt.Errorf("failed to parse text content: %w", err)
+			var textContentObj map[string]interface{}
+			err := json.Unmarshal([]byte(content.Text), &textContentObj)
+
+			if err == nil {
+				prettyText, err := json.MarshalIndent(textContentObj, "", "  ")
+				if err != nil {
+					return fmt.Errorf("failed to pretty print text content: %w", err)
+				}
+				fmt.Println(string(prettyText))
+			} else {
+				var textContentList []interface{}
+				if err := json.Unmarshal([]byte(content.Text), &textContentList); err != nil {
+					return fmt.Errorf("failed to parse text content as a list: %w", err)
+				}
+				// Pretty print the array content
+				prettyText, err := json.MarshalIndent(textContentList, "", "  ")
+				if err != nil {
+					return fmt.Errorf("failed to pretty print array content: %w", err)
+				}
+				fmt.Println(string(prettyText))
 			}
-			// Pretty print the text content
-			prettyText, err := json.MarshalIndent(textContent, "", "  ")
-			if err != nil {
-				return fmt.Errorf("failed to pretty print text content: %w", err)
-			}
-			fmt.Println(string(prettyText))
 		}
 	}
 


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

### Before change:
```bash
$ ./mcpcurl --stdio-server-cmd "./github-mcp-server stdio" tools list_pull_requests --owner github --repo github-mcp-server --page 1 --perPage 1 --pretty
error printing response: failed to parse text content: json: cannot unmarshal array into Go value of type map[string]interface {}
```

### After change:
```bash
$ ./mcpcurl --stdio-server-cmd "./github-mcp-server stdio" tools list_pull_requests --owner github --repo github-mcp-server --page 1 --perPage 1 --pretty
[
  {
    "_links": {
      "comments": {
        "href": "https://api.github.com/repos/github/github-mcp-server/issues/235/comments"
      },
      "commits": {
        "href": "https://api.github.com/repos/github/github-mcp-server/pulls/235/commits"
      },
      "html": {
        "href": "https://github.com/github/github-mcp-server/pull/235"
      },
      "issue": {
        "href": "https://api.github.com/repos/github/github-mcp-server/issues/235"
      },
      "review_comment": {
        "href": "https://api.github.com/repos/github/github-mcp-server/pulls/comments{/number}"
      },
      "review_comments": {
        "href": "https://api.github.com/repos/github/github-mcp-server/pulls/235/comments"
      },
      "self": {
        "href": "https://api.github.com/repos/github/github-mcp-server/pulls/235"
      },
      "statuses": {
        "href": "https://api.github.com/repos/github/github-mcp-server/statuses/908e3b05fab6777cf3aae284896a61d3b727c844"
      }
    },
    "author_association": "CONTRIBUTOR",
    ...
```