### PR TITLE
feat: add tool for checking if PR is merged

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -53,6 +53,7 @@ func NewServer(getClient GetClientFn, version string, readOnly bool, t translati
 	// Add GitHub tools - Pull Requests
 	s.AddTool(GetPullRequest(getClient, t))
 	s.AddTool(ListPullRequests(getClient, t))
+	s.AddTool(IsPullRequestMerged(getClient, t))
 	s.AddTool(GetPullRequestFiles(getClient, t))
 	s.AddTool(GetPullRequestStatus(getClient, t))
 	s.AddTool(GetPullRequestComments(getClient, t))
@@ -179,7 +180,6 @@ func requiredParam[T comparable](r mcp.CallToolRequest, p string) (T, error) {
 
 	if r.Params.Arguments[p].(T) == zero {
 		return zero, fmt.Errorf("missing required parameter: %s", p)
-
 	}
 
 	return r.Params.Arguments[p].(T), nil


### PR DESCRIPTION
This PR adds a tool for checking if a pull request is merged.

Closes: #240

Implementation detail: two possible responses from the API endpoint:
- 204: has been merged
- 404: either has not been merged, or PR does not exists. **Note:** I could not find a way to discern between these two cases - happy to hear your thoughts/suggestions on how to potentially fix this.

# Example output
```bash
$ ./mcpcurl --stdio-server-cmd "./github-mcp-server stdio" tools is_pull_request_merged --owner github --repo github-mcp-server --pullNumber 235
{
  "status": "Pull request not merged or does not exist."
}
~/projects/my-mcp/github-mcp-server main ⇡2 !3 ?7                                                                                                                              04:26:28 PM
$ ./mcpcurl --stdio-server-cmd "./github-mcp-server stdio" tools is_pull_request_merged --owner github --repo github-mcp-server --pullNumber 239
{
  "status": "Pull request is merged."
}
```
