### PR TITLE
feat: add fork filter parameter to repository search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `query`: Search query (string, required)
   - `sort`: Sort field (string, optional)
   - `order`: Sort order (string, optional)
+  - `fork`: Fork filter: 'true' to include forks, 'only' to show only forks, 'false' to exclude forks (default) (string, optional)
   - `page`: Page number (number, optional)
   - `perPage`: Results per page (number, optional)
 

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -88,6 +88,8 @@ func Test_SearchRepositories(t *testing.T) {
 						"q":        "golang test",
 						"page":     "1",
 						"per_page": "30",
+						// Note: Not specifying 'fork' parameter here, which verifies that
+						// when 'fork' is not provided in the request, it's not added to the query parameters
 					}).andThen(
 						mockResponse(t, http.StatusOK, mockSearchResult),
 					),
@@ -95,6 +97,69 @@ func Test_SearchRepositories(t *testing.T) {
 			),
 			requestArgs: map[string]interface{}{
 				"query": "golang test",
+			},
+			expectError:    false,
+			expectedResult: mockSearchResult,
+		},
+		{
+			name: "repository search with fork parameter",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.GetSearchRepositories,
+					expectQueryParams(t, map[string]string{
+						"q":        "golang test fork:only",
+						"page":     "1",
+						"per_page": "30",
+					}).andThen(
+						mockResponse(t, http.StatusOK, mockSearchResult),
+					),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"query": "golang test",
+				"fork":  "only",
+			},
+			expectError:    false,
+			expectedResult: mockSearchResult,
+		},
+		{
+			name: "repository search with fork parameter (true)",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.GetSearchRepositories,
+					expectQueryParams(t, map[string]string{
+						"q":        "golang test fork:true",
+						"page":     "1",
+						"per_page": "30",
+					}).andThen(
+						mockResponse(t, http.StatusOK, mockSearchResult),
+					),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"query": "golang test",
+				"fork":  "true",
+			},
+			expectError:    false,
+			expectedResult: mockSearchResult,
+		},
+		{
+			name: "repository search with fork parameter (false)",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.GetSearchRepositories,
+					expectQueryParams(t, map[string]string{
+						"q":        "golang test",
+						"page":     "1",
+						"per_page": "30",
+					}).andThen(
+						mockResponse(t, http.StatusOK, mockSearchResult),
+					),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"query": "golang test",
+				"fork":  "false",
 			},
 			expectError:    false,
 			expectedResult: mockSearchResult,


### PR DESCRIPTION
This pull request introduces a new feature to filter repository search results by fork status. The changes include updates to the `README.md`, the main search function, and the test cases to support this new functionality.

New feature for fork filtering:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R349): Added a description for the new `fork` parameter in the search query options.

Code updates for fork filtering:

* [`pkg/github/search.go`](diffhunk://#diff-e04395f56eed769ce5cfb9a06e8ca344dd8f9a10c438f9381008cf60e1d78228R8-R22): Imported the `strings` package and added the `containsForkFilter` function to check for existing fork filters in the query. Updated the `SearchRepositories` function to include the `fork` parameter and modify the query accordingly. [[1]](diffhunk://#diff-e04395f56eed769ce5cfb9a06e8ca344dd8f9a10c438f9381008cf60e1d78228R8-R22) [[2]](diffhunk://#diff-e04395f56eed769ce5cfb9a06e8ca344dd8f9a10c438f9381008cf60e1d78228R31-R61)

Test updates for fork filtering:

* [`pkg/github/search_test.go`](diffhunk://#diff-2a95e72dad22e527ccbac69c480e962a18a22dc2074a4b7c40b7fe99ebe92e83R91-R92): Added new test cases to verify the behavior of the `fork` parameter in repository searches, including scenarios where the parameter is not provided, set to 'only', 'true', or 'false'. [[1]](diffhunk://#diff-2a95e72dad22e527ccbac69c480e962a18a22dc2074a4b7c40b7fe99ebe92e83R91-R92) [[2]](diffhunk://#diff-2a95e72dad22e527ccbac69c480e962a18a22dc2074a4b7c40b7fe99ebe92e83R104-R166)

