### PR TITLE
Add clarity to the "Build from source" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,24 @@ More about using MCP server tools in VS Code's [agent mode documentation](https:
 
 ### Build from source
 
-If you don't have Docker, you can use `go` to build the binary in the
-`cmd/github-mcp-server` directory, and use the `github-mcp-server stdio`
-command with the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable set to
-your token.
+If you don't have Docker, you can use `go build` to build the binary in the
+`cmd/github-mcp-server` directory, and use the `github-mcp-server stdio` command with the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable set to your token. To specify the output location of the build, use the `-o` flag. You should configure your server to use the built executable as its `command`. For example:
+
+```JSON
+{
+  "mcp": {
+    "servers": {
+      "github": {
+        "command": "/path/to/github-mcp-server",
+        "args": ["stdio"],
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+        }
+      }
+    }
+  }
+}
+```
 
 ## GitHub Enterprise Server
 


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

In working on contributing to https://github.com/github/github-mcp-server/pull/225, I found this area of the instructions could use more clarity. Hopefully this is clearer and provides additional instructions on how to specify the output location of the build and configure the server to use the built executable.