### PR TITLE
enhancement: add tool to request reviewers for pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `draft`: Create as draft PR (boolean, optional)
   - `maintainer_can_modify`: Allow maintainer edits (boolean, optional)
 
+- **request_pull_request_reviewers** - Request reviewers for a pull request
+
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `pull_number`: Pull request number (number, required)
+  - `reviewers`: GitHub usernames of reviewers to request (string[], optional*)
+  - `team_reviewers`: GitHub team names to request review from (string[], optional*)
+
+    - At least one of `reviewers` or `team_reviewers` must be provided
+
 - **add_pull_request_review_comment** - Add a review comment to a pull request or reply to an existing comment
 
   - `owner`: Repository owner (string, required)
@@ -297,6 +307,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `commit_id`: The SHA of the commit to comment on (string, required unless using in_reply_to)
   - `path`: The relative path to the file that necessitates a comment (string, required unless using in_reply_to)
   - `line`: The line of the blob in the pull request diff that the comment applies to (number, optional)
+
   - `side`: The side of the diff to comment on (LEFT or RIGHT) (string, optional)
   - `start_line`: For multi-line comments, the first line of the range (number, optional)
   - `start_side`: For multi-line comments, the starting side of the diff (LEFT or RIGHT) (string, optional)

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -64,6 +64,7 @@ func NewServer(getClient GetClientFn, version string, readOnly bool, t translati
 		s.AddTool(CreatePullRequest(getClient, t))
 		s.AddTool(UpdatePullRequest(getClient, t))
 		s.AddTool(AddPullRequestReviewComment(getClient, t))
+		s.AddTool(RequestPullRequestReviewers(getClient, t))
 	}
 
 	// Add GitHub tools - Repositories


### PR DESCRIPTION
This pull request introduces a new feature to request reviewers for a pull request in the GitHub MCP tool. The changes include updates to the documentation, implementation of the new tool, and corresponding tests. Below are the most important changes:

### New Feature Implementation:

* [`pkg/github/pullrequests.go`](diffhunk://#diff-c2e2a7250ef597d08ee5d429159bc89c4b862a7ed6cbcf30b8231a3ec599d190R1181-R1269): Added the `RequestPullRequestReviewers` function to create a tool for requesting reviewers for a pull request. This includes defining the tool's input schema, extracting parameters, and making the API call to GitHub.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R291-R300): Updated to include documentation for the new `request_pull_request_reviewers` tool, detailing its parameters and usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R291-R300) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R310)

### Test Cases:

* [`pkg/github/pullrequests_test.go`](diffhunk://#diff-efebb180e5ae7933bb1c29403a3c82937a5716357f0c9538781f23770635872fR1919-R2101): Added tests for the new `RequestPullRequestReviewers` function to verify the tool definition and various scenarios, including successful requests and error handling.

### Server Integration:

* [`pkg/github/server.go`](diffhunk://#diff-b6e388e2a018b4bc415a18e7dd986e6b7730931af9d26c37ba4be38988e421edR67): Integrated the new `RequestPullRequestReviewers` tool into the server setup, ensuring it is available for use.

Closes: [#259](https://github.com/github/github-mcp-server/issues/259)
