### PR TITLE
Add "Mark notification as done" functionality

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -97,6 +97,7 @@ func NewServer(getClient GetClientFn, version string, readOnly bool, t translati
 	if !readOnly {
 		s.AddTool(MarkNotificationRead(getClient, t))
 		s.AddTool(MarkAllNotificationsRead(getClient, t))
+		s.AddTool(MarkNotificationDone(getClient, t))
 	}
 
 	return s


### PR DESCRIPTION
### Add `MarkNotificationAsDone` to notifications tooling

**Note:** Target branch is `notifications-tooling` https://github.com/github/github-mcp-server/pull/225

#### Feature added

- `mark_notification_done: Mark a specific notification thread as done

#### Technical implementation

- I largely copied `mark_notification_read`
- For the param `threadId`, `WithNumber` ran into some issues, so I kept the param as a string. I'm open to suggestions.