### PR TITLE
Pre-reqs for docker use include auth to ghcr.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ automation and interaction capabilities for developers and tools.
 ## Prerequisites
 
 1. To run the server in a container, you will need to have [Docker](https://www.docker.com/) installed.
-2. Once Docker is installed, you will also need to ensure Docker is running.
+2. Once Docker is installed, you will also need to ensure Docker is running, and that you are [logged in to the GitHub Container Registry (ghcr.io)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
 3. Lastly you will need to [Create a GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new).
 The MCP server can use many of the GitHub APIs, so enable the permissions that you feel comfortable granting your AI tools (to learn more about access tokens, please check out the [documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)).
 


### PR DESCRIPTION
To pull the image, you need docker to be logged in to ghcr.io; this PR links in the README to instructions for doing that.