### PR TITLE
Add Github MCP Server hosting in README w/ Klavis AI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ More about using MCP server tools in VS Code's [agent mode documentation](https:
 }
 ```
 
+### Usage with Hosted Server
+
+You may also use a hosted GitHub MCP server, which provides a single endpoint for streamlined integration (e.g. [Klavis AI](https://klavis.ai))
+
 ### Build from source
 
 If you don't have Docker, you can use `go build` to build the binary in the


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

We've [hosted](https://www.klavis.ai/mcp-servers) a Github MCP server on our website that you can try out for free! At KlavisAI (YC X25), we're building open-source MCP clients and servers. We've even open-sourced an SSE version of the MCP server here: https://github.com/Klavis-AI/klavis.

Let us know if it's okay to mention this in your README. Thanks a lot!
