### PR TITLE
Notice for Docker engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ More about using MCP server tools in VS Code's [agent mode documentation](https:
 
 ### Usage with Claude Desktop
 
+Keep in mind Docker engine has to run in background before running Claude Desktop App if you are using Windows.
+
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
Docker engine needs to run in background before Claude Desktop App. Even if you run Claude Desktop as adminstrator , this will still not run docker engine .

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes 232,279`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:

I think adding this into readme would reduce the number of incoming issues as there a Windows users which think Docker needs to be run inside WSL