### PR TITLE
Update CODEOWNERS to github-mcp-server team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @juruen @sammorrowdrums @williammartin @toby
+* @github/github-mcp-server


### PR DESCRIPTION
## Description

Update CODEOWNERS so that it references a team with membership controlled internaly.
