### PR TITLE
Added installation instructions using Mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ More about using MCP server tools in VS Code's [agent mode documentation](https:
       }
     }
   }
+}
 ```
 
 ### Using Mise for Installation

--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ The MCP server can use many of the GitHub APIs, so enable the permissions that y
 
 ## Installation
 
+### Usage with Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+      }
+    }
+  }
+```
+
 ### Usage with VS Code
 
 For quick installation, use one of the one-click install buttons at the top of this README.
@@ -64,28 +86,25 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
 
 More about using MCP server tools in VS Code's [agent mode documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
 
-### Usage with Claude Desktop
+### Using Mise for Installation
 
-```json
-{
-  "mcpServers": {
-    "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
-      }
-    }
-  }
-}
-```
+To quickly configure and deploy the GitHub MCP Server in your environment, you can use **[Mise](https://mise.jdx.dev)**, a deployment and configuration tool optimized for developer workflows.
+
+Here’s how to get started:
+
+1. Install `mise` by following the installation instructions at [https://mise.jdx.dev](https://mise.jdx.dev).
+2. Use the following command to deploy the GitHub MCP Server configuration:
+
+   ```bash
+   mise deploy github-mcp-server --token=<YOUR_PERSONAL_ACCESS_TOKEN> --use-docker
+   ```
+
+   - Replace `<YOUR_PERSONAL_ACCESS_TOKEN>` with your GitHub personal access token.
+   - Use `--use-docker` to run the server via Docker.
+
+3. Confirm that the server is running using `mise status`.
+
+For more details, see [Mise's official documentation](https://mise.jdx.dev/docs).
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -88,21 +88,16 @@ More about using MCP server tools in VS Code's [agent mode documentation](https:
 
 ### Using Mise for Installation
 
-To quickly configure and deploy the GitHub MCP Server in your environment, you can use **[Mise](https://mise.jdx.dev)**, a deployment and configuration tool optimized for developer workflows.
+To quickly configure and deploy the GitHub MCP Server in your environment, you can use **[Mise](https://mise.jdx.dev)**, a developer tool manager
 
 Here’s how to get started:
 
 1. Install `mise` by following the installation instructions at [https://mise.jdx.dev](https://mise.jdx.dev).
-2. Use the following command to deploy the GitHub MCP Server configuration:
+2. Use the following command to install the latest build of github-mcp-server
 
    ```bash
-   mise deploy github-mcp-server --token=<YOUR_PERSONAL_ACCESS_TOKEN> --use-docker
+   mise use -g ubi:github/github-mcp-server
    ```
-
-   - Replace `<YOUR_PERSONAL_ACCESS_TOKEN>` with your GitHub personal access token.
-   - Use `--use-docker` to run the server via Docker.
-
-3. Confirm that the server is running using `mise status`.
 
 For more details, see [Mise's official documentation](https://mise.jdx.dev/docs).
 

--- a/README.md
+++ b/README.md
@@ -21,28 +21,6 @@ The MCP server can use many of the GitHub APIs, so enable the permissions that y
 
 ## Installation
 
-### Usage with Claude Desktop
-
-```json
-{
-  "mcpServers": {
-    "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
-      }
-    }
-  }
-```
-
 ### Usage with VS Code
 
 For quick installation, use one of the one-click install buttons at the top of this README.
@@ -85,6 +63,28 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
 ```
 
 More about using MCP server tools in VS Code's [agent mode documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+
+### Usage with Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+      }
+    }
+  }
+```
 
 ### Using Mise for Installation
 


### PR DESCRIPTION
### Summary
This PR enhances the README by adding a new section explaining how to install and manage the GitHub MCP Server using [Mise](https://mise.jdx.dev). The steps cover:

- Installing Mise from its website
- Using Mise to install the GitHub MCP server with a single command

This makes the setup more flexible by offering an alternative method, particularly helpful for managing dependencies in a streamlined way.

### Linked Issue
Closes issue #302.