### PR TITLE
small doc change : fixing formatting in list of tool functions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `page`: Page number, for files in the commit (number, optional)
   - `perPage`: Results per page, for files in the commit (number, optional)
 
-  - **search_code** - Search for code across GitHub repositories
+- **search_code** - Search for code across GitHub repositories
   - `query`: Search query (string, required)
   - `sort`: Sort field (string, optional)
   - `order`: Sort order (string, optional)


### PR DESCRIPTION


search_code was misalligned. fixed it in README.
<img width="792" alt="Screenshot 2025-04-19 at 9 00 07 PM" src="https://github.com/user-attachments/assets/171db115-9df1-4060-9acf-790ee7692b79" />

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
