### PR TITLE
Gitignore .vscode except launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,12 @@
 cmd/github-mcp-server/github-mcp-server
 
 # VSCode
-.vscode/mcp.json
+.vscode/*
+!.vscode/launch.json
 
 # Added by goreleaser init:
 dist/
 __debug_bin*
 
-# Go 
+# Go
 vendor


### PR DESCRIPTION
## Description

Currently we gitignore `.vscode/mcp.json` because people are often developing this server in a vscode instance that has MCP configured. We also include a [`launch.json`](https://github.com/github/github-mcp-server/blob/9fa582d8d63522d70ce8f3af58265effb9645323/.vscode/launch.json) to aid in debugging.

What I'd like to do is allowlist just the `launch.json`, to require very intentional addition of vscode files. For example, I was surprised to see this:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .vscode/.mcp.json.swp
```