### PR TITLE
feat: Add support for Git tag operations

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -81,4 +81,6 @@ FAIL
 
 The current test suite is intentionally very limited in scope. This is because the maintenance costs on e2e tests tend to increase significantly over time. To read about some challenges with GitHub integration tests, see [go-github integration tests README](https://github.com/google/go-github/blob/5b75aa86dba5cf4af2923afa0938774f37fa0a67/test/README.md). We will expand this suite circumspectly!
 
-Currently, visibility into failures is not particularly good.
+The tests are quite repetitive and verbose. This is intentional as we want to see them develop more before committing to abstractions.
+
+Currently, visibility into failures is not particularly good. We're hoping that we can pull apart the mcp-go client and have it hook into streams representing stdio without requiring an exec. This way we can get breakpoints in the debugger easily.

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -1528,3 +1528,257 @@ func Test_ListBranches(t *testing.T) {
 		})
 	}
 }
+
+func Test_ListTags(t *testing.T) {
+	// Verify tool definition once
+	mockClient := github.NewClient(nil)
+	tool, _ := ListTags(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+
+	assert.Equal(t, "list_tags", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "repo")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo"})
+
+	// Setup mock tags for success case
+	mockTags := []*github.RepositoryTag{
+		{
+			Name: github.Ptr("v1.0.0"),
+			Commit: &github.Commit{
+				SHA: github.Ptr("abc123"),
+				URL: github.Ptr("https://api.github.com/repos/owner/repo/commits/abc123"),
+			},
+			ZipballURL: github.Ptr("https://github.com/owner/repo/zipball/v1.0.0"),
+			TarballURL: github.Ptr("https://github.com/owner/repo/tarball/v1.0.0"),
+		},
+		{
+			Name: github.Ptr("v0.9.0"),
+			Commit: &github.Commit{
+				SHA: github.Ptr("def456"),
+				URL: github.Ptr("https://api.github.com/repos/owner/repo/commits/def456"),
+			},
+			ZipballURL: github.Ptr("https://github.com/owner/repo/zipball/v0.9.0"),
+			TarballURL: github.Ptr("https://github.com/owner/repo/tarball/v0.9.0"),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		mockedClient   *http.Client
+		requestArgs    map[string]interface{}
+		expectError    bool
+		expectedTags   []*github.RepositoryTag
+		expectedErrMsg string
+	}{
+		{
+			name: "successful tags list",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatch(
+					mock.GetReposTagsByOwnerByRepo,
+					mockTags,
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+			},
+			expectError:  false,
+			expectedTags: mockTags,
+		},
+		{
+			name: "list tags fails",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.GetReposTagsByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+						_, _ = w.Write([]byte(`{"message": "Internal Server Error"}`))
+					}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to list tags",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup client with mock
+			client := github.NewClient(tc.mockedClient)
+			_, handler := ListTags(stubGetClientFn(client), translations.NullTranslationHelper)
+
+			// Create call request
+			request := createMCPRequest(tc.requestArgs)
+
+			// Call handler
+			result, err := handler(context.Background(), request)
+
+			// Verify results
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Parse the result and get the text content if no error
+			textContent := getTextResult(t, result)
+
+			// Parse and verify the result
+			var returnedTags []*github.RepositoryTag
+			err = json.Unmarshal([]byte(textContent.Text), &returnedTags)
+			require.NoError(t, err)
+
+			// Verify each tag
+			require.Equal(t, len(tc.expectedTags), len(returnedTags))
+			for i, expectedTag := range tc.expectedTags {
+				assert.Equal(t, *expectedTag.Name, *returnedTags[i].Name)
+				assert.Equal(t, *expectedTag.Commit.SHA, *returnedTags[i].Commit.SHA)
+			}
+		})
+	}
+}
+
+func Test_GetTag(t *testing.T) {
+	// Verify tool definition once
+	mockClient := github.NewClient(nil)
+	tool, _ := GetTag(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+
+	assert.Equal(t, "get_tag", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "repo")
+	assert.Contains(t, tool.InputSchema.Properties, "tag")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo", "tag"})
+
+	mockTagRef := &github.Reference{
+		Ref: github.Ptr("refs/tags/v1.0.0"),
+		Object: &github.GitObject{
+			SHA: github.Ptr("tag123"),
+		},
+	}
+
+	mockTagObj := &github.Tag{
+		SHA:     github.Ptr("tag123"),
+		Tag:     github.Ptr("v1.0.0"),
+		Message: github.Ptr("Release v1.0.0"),
+		Object: &github.GitObject{
+			Type: github.Ptr("commit"),
+			SHA:  github.Ptr("abc123"),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		mockedClient   *http.Client
+		requestArgs    map[string]interface{}
+		expectError    bool
+		expectedTag    *github.Tag
+		expectedErrMsg string
+	}{
+		{
+			name: "successful tag retrieval",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatch(
+					mock.GetReposGitRefByOwnerByRepoByRef,
+					mockTagRef,
+				),
+				mock.WithRequestMatch(
+					mock.GetReposGitTagsByOwnerByRepoByTagSha,
+					mockTagObj,
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+				"tag":   "v1.0.0",
+			},
+			expectError: false,
+			expectedTag: mockTagObj,
+		},
+		{
+			name: "tag reference not found",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.GetReposGitRefByOwnerByRepoByRef,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"message": "Reference does not exist"}`))
+					}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+				"tag":   "v1.0.0",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to get tag reference",
+		},
+		{
+			name: "tag object not found",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatch(
+					mock.GetReposGitRefByOwnerByRepoByRef,
+					mockTagRef,
+				),
+				mock.WithRequestMatchHandler(
+					mock.GetReposGitTagsByOwnerByRepoByTagSha,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"message": "Tag object does not exist"}`))
+					}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+				"tag":   "v1.0.0",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to get tag object",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup client with mock
+			client := github.NewClient(tc.mockedClient)
+			_, handler := GetTag(stubGetClientFn(client), translations.NullTranslationHelper)
+
+			// Create call request
+			request := createMCPRequest(tc.requestArgs)
+
+			// Call handler
+			result, err := handler(context.Background(), request)
+
+			// Verify results
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Parse the result and get the text content if no error
+			textContent := getTextResult(t, result)
+
+			// Parse and verify the result
+			var returnedTag github.Tag
+			err = json.Unmarshal([]byte(textContent.Text), &returnedTag)
+			require.NoError(t, err)
+
+			assert.Equal(t, *tc.expectedTag.SHA, *returnedTag.SHA)
+			assert.Equal(t, *tc.expectedTag.Tag, *returnedTag.Tag)
+			assert.Equal(t, *tc.expectedTag.Message, *returnedTag.Message)
+			assert.Equal(t, *tc.expectedTag.Object.Type, *returnedTag.Object.Type)
+			assert.Equal(t, *tc.expectedTag.Object.SHA, *returnedTag.Object.SHA)
+		})
+	}
+}

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -1545,7 +1545,7 @@ func Test_ListTags(t *testing.T) {
 		{
 			Name: github.Ptr("v1.0.0"),
 			Commit: &github.Commit{
-				SHA: github.Ptr("abc123"),
+				SHA: github.Ptr("v1.0.0-tag-sha"),
 				URL: github.Ptr("https://api.github.com/repos/owner/repo/commits/abc123"),
 			},
 			ZipballURL: github.Ptr("https://github.com/owner/repo/zipball/v1.0.0"),
@@ -1554,7 +1554,7 @@ func Test_ListTags(t *testing.T) {
 		{
 			Name: github.Ptr("v0.9.0"),
 			Commit: &github.Commit{
-				SHA: github.Ptr("def456"),
+				SHA: github.Ptr("v0.9.0-tag-sha"),
 				URL: github.Ptr("https://api.github.com/repos/owner/repo/commits/def456"),
 			},
 			ZipballURL: github.Ptr("https://github.com/owner/repo/zipball/v0.9.0"),
@@ -1573,9 +1573,14 @@ func Test_ListTags(t *testing.T) {
 		{
 			name: "successful tags list",
 			mockedClient: mock.NewMockedHTTPClient(
-				mock.WithRequestMatch(
+				mock.WithRequestMatchHandler(
 					mock.GetReposTagsByOwnerByRepo,
-					mockTags,
+					expectPath(
+						t,
+						"/repos/owner/repo/tags",
+					).andThen(
+						mockResponse(t, http.StatusOK, mockTags),
+					),
 				),
 			),
 			requestArgs: map[string]interface{}{
@@ -1659,12 +1664,12 @@ func Test_GetTag(t *testing.T) {
 	mockTagRef := &github.Reference{
 		Ref: github.Ptr("refs/tags/v1.0.0"),
 		Object: &github.GitObject{
-			SHA: github.Ptr("tag123"),
+			SHA: github.Ptr("v1.0.0-tag-sha"),
 		},
 	}
 
 	mockTagObj := &github.Tag{
-		SHA:     github.Ptr("tag123"),
+		SHA:     github.Ptr("v1.0.0-tag-sha"),
 		Tag:     github.Ptr("v1.0.0"),
 		Message: github.Ptr("Release v1.0.0"),
 		Object: &github.GitObject{
@@ -1684,13 +1689,23 @@ func Test_GetTag(t *testing.T) {
 		{
 			name: "successful tag retrieval",
 			mockedClient: mock.NewMockedHTTPClient(
-				mock.WithRequestMatch(
+				mock.WithRequestMatchHandler(
 					mock.GetReposGitRefByOwnerByRepoByRef,
-					mockTagRef,
+					expectPath(
+						t,
+						"/repos/owner/repo/git/ref/tags/v1.0.0",
+					).andThen(
+						mockResponse(t, http.StatusOK, mockTagRef),
+					),
 				),
-				mock.WithRequestMatch(
+				mock.WithRequestMatchHandler(
 					mock.GetReposGitTagsByOwnerByRepoByTagSha,
-					mockTagObj,
+					expectPath(
+						t,
+						"/repos/owner/repo/git/tags/v1.0.0-tag-sha",
+					).andThen(
+						mockResponse(t, http.StatusOK, mockTagObj),
+					),
 				),
 			),
 			requestArgs: map[string]interface{}{

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -27,6 +27,8 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 			toolsets.NewServerTool(SearchCode(getClient, t)),
 			toolsets.NewServerTool(GetCommit(getClient, t)),
 			toolsets.NewServerTool(ListBranches(getClient, t)),
+			toolsets.NewServerTool(ListTags(getClient, t)),
+			toolsets.NewServerTool(GetTag(getClient, t)),
 		).
 		AddWriteTools(
 			toolsets.NewServerTool(CreateOrUpdateFile(getClient, t)),


### PR DESCRIPTION
 Add git tag functionality, including:
    - List repository tags
    - Get tag details
    - Support for tag-based content access
    
This enables basic read-only tag management through the MCP server API.


Closes:  https://github.com/github/github-mcp-server/issues/344
![Screenshot From 2025-04-24 20-11-21](https://github.com/user-attachments/assets/5a9c305e-4308-47e1-8d1f-979d2958adc0)
![Screenshot From 2025-04-24 19-59-40](https://github.com/user-attachments/assets/52c2b3ed-93dd-4abc-9f81-a4f24aa1a62a)

![image](https://github.com/user-attachments/assets/1515083c-9529-4b98-99c0-7cc587986a61)
