### PR TITLE
Ensure toolsets are configurable via env var

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -45,7 +45,15 @@ var (
 				stdlog.Fatal("Failed to initialize logger:", err)
 			}
 
-			enabledToolsets := viper.GetStringSlice("toolsets")
+			// If you're wondering why we're not using viper.GetStringSlice("toolsets"),
+			// it's because viper doesn't handle comma-separated values correctly for env
+			// vars when using GetStringSlice.
+			// https://github.com/spf13/viper/issues/380
+			var enabledToolsets []string
+			err = viper.UnmarshalKey("toolsets", &enabledToolsets)
+			if err != nil {
+				stdlog.Fatal("Failed to unmarshal toolsets:", err)
+			}
 
 			logCommands := viper.GetBool("enable-command-logging")
 			cfg := runConfig{


### PR DESCRIPTION
## Description

Fixes https://github.com/github/github-mcp-server/issues/307

### Reviewer Notes

You can run the e2e tests and see a failure by adjusting `GITHUB_TOOLSETS` and running:

```
GITHUB_MCP_SERVER_E2E_TOKEN=foo go test -v -run  "TestToolsets" --tags e2e ./e2e
```