### PR TITLE
feat: add DeleteFile tool to delete files from GitHub repositories

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -560,6 +560,11 @@ func ForkRepository(getClient GetClientFn, t translations.TranslationHelperFunc)
 func DeleteFile(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("delete_file",
 			mcp.WithDescription(t("TOOL_DELETE_FILE_DESCRIPTION", "Delete a file from a GitHub repository")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:           t("TOOL_DELETE_FILE_USER_TITLE", "Delete file"),
+				ReadOnlyHint:    false,
+				DestructiveHint: true,
+			}),
 			mcp.WithString("owner",
 				mcp.Required(),
 				mcp.Description("Repository owner (username or organization)"),

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -557,6 +557,11 @@ func ForkRepository(getClient GetClientFn, t translations.TranslationHelperFunc)
 }
 
 // DeleteFile creates a tool to delete a file in a GitHub repository.
+// This tool uses a more roundabout way of deleting a file than just using the client.Repositories.DeleteFile.
+// This is because REST file deletion endpoint (and client.Repositories.DeleteFile) don't add commit signing to the deletion commit, 
+// unlike how the endpoint backing the create_or_update_files tool does. This appears to be a quirk of the API. 
+// The approach implemented here gets automatic commit signing when used with either the github-actions user or as an app, 
+// both of which suit an LLM well.
 func DeleteFile(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("delete_file",
 			mcp.WithDescription(t("TOOL_DELETE_FILE_DESCRIPTION", "Delete a file from a GitHub repository")),

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -287,7 +287,7 @@ func CreateOrUpdateFile(getClient GetClientFn, t translations.TranslationHelperF
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			// Convert content to base64
+			// json.Marshal encodes byte arrays with base64, which is required for the API.
 			contentBytes := []byte(content)
 
 			// Create the file options
@@ -666,7 +666,7 @@ func DeleteFile(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 
 			// Create a response similar to what the DeleteFile API would return
 			response := map[string]interface{}{
-				"commit": newCommit,
+				"commit":  newCommit,
 				"content": nil,
 			}
 

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -558,17 +558,17 @@ func ForkRepository(getClient GetClientFn, t translations.TranslationHelperFunc)
 
 // DeleteFile creates a tool to delete a file in a GitHub repository.
 // This tool uses a more roundabout way of deleting a file than just using the client.Repositories.DeleteFile.
-// This is because REST file deletion endpoint (and client.Repositories.DeleteFile) don't add commit signing to the deletion commit, 
-// unlike how the endpoint backing the create_or_update_files tool does. This appears to be a quirk of the API. 
-// The approach implemented here gets automatic commit signing when used with either the github-actions user or as an app, 
+// This is because REST file deletion endpoint (and client.Repositories.DeleteFile) don't add commit signing to the deletion commit,
+// unlike how the endpoint backing the create_or_update_files tool does. This appears to be a quirk of the API.
+// The approach implemented here gets automatic commit signing when used with either the github-actions user or as an app,
 // both of which suit an LLM well.
 func DeleteFile(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("delete_file",
 			mcp.WithDescription(t("TOOL_DELETE_FILE_DESCRIPTION", "Delete a file from a GitHub repository")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:           t("TOOL_DELETE_FILE_USER_TITLE", "Delete file"),
-				ReadOnlyHint:    false,
-				DestructiveHint: true,
+				ReadOnlyHint:    toBoolPtr(false),
+				DestructiveHint: toBoolPtr(true),
 			}),
 			mcp.WithString("owner",
 				mcp.Required(),

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -1570,12 +1570,12 @@ func Test_DeleteFile(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
-		mockedClient     *http.Client
-		requestArgs      map[string]interface{}
-		expectError      bool
+		name              string
+		mockedClient      *http.Client
+		requestArgs       map[string]interface{}
+		expectError       bool
 		expectedCommitSHA string
-		expectedErrMsg   string
+		expectedErrMsg    string
 	}{
 		{
 			name: "successful file deletion using Git Data API",
@@ -1597,10 +1597,10 @@ func Test_DeleteFile(t *testing.T) {
 						"base_tree": "def456",
 						"tree": []interface{}{
 							map[string]interface{}{
-								"path":    "docs/example.md",
-								"mode":    "100644",
-								"type":    "blob",
-								"sha":     nil,
+								"path": "docs/example.md",
+								"mode": "100644",
+								"type": "blob",
+								"sha":  nil,
 							},
 						},
 					}).andThen(
@@ -1641,7 +1641,7 @@ func Test_DeleteFile(t *testing.T) {
 				"message": "Delete example file",
 				"branch":  "main",
 			},
-			expectError:        false,
+			expectError:       false,
 			expectedCommitSHA: "jkl012",
 		},
 		{

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -36,6 +36,7 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 			toolsets.NewServerTool(ForkRepository(getClient, t)),
 			toolsets.NewServerTool(CreateBranch(getClient, t)),
 			toolsets.NewServerTool(PushFiles(getClient, t)),
+			toolsets.NewServerTool(DeleteFile(getClient, t)),
 		)
 	issues := toolsets.NewToolset("issues", "GitHub Issues related tools").
 		AddReadTools(


### PR DESCRIPTION
This adds a tool that matches the behavior of [this API endpoint](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#delete-a-file). This is needed since the `create_or_update_file` tool doesn't allow deletion.