### PR TITLE
Support debugging e2e tests

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -1,25 +1,17 @@
 package main
 
 import (
-	"context"
+	"errors"
 	"fmt"
-	"io"
-	stdlog "log"
 	"os"
-	"os/signal"
-	"syscall"
 
+	"github.com/github/github-mcp-server/internal/ghmcp"
 	"github.com/github/github-mcp-server/pkg/github"
-	iolog "github.com/github/github-mcp-server/pkg/log"
-	"github.com/github/github-mcp-server/pkg/translations"
-	gogithub "github.com/google/go-github/v69/github"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+// These variables are set by the build process using ldflags.
 var version = "version"
 var commit = "commit"
 var date = "date"
@@ -36,13 +28,10 @@ var (
 		Use:   "stdio",
 		Short: "Start stdio server",
 		Long:  `Start a server that communicates via standard input/output streams using JSON-RPC messages.`,
-		Run: func(_ *cobra.Command, _ []string) {
-			logFile := viper.GetString("log-file")
-			readOnly := viper.GetBool("read-only")
-			exportTranslations := viper.GetBool("export-translations")
-			logger, err := initLogger(logFile)
-			if err != nil {
-				stdlog.Fatal("Failed to initialize logger:", err)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			token := viper.GetString("personal_access_token")
+			if token == "" {
+				return errors.New("GITHUB_PERSONAL_ACCESS_TOKEN not set")
 			}
 
 			// If you're wondering why we're not using viper.GetStringSlice("toolsets"),
@@ -50,22 +39,23 @@ var (
 			// vars when using GetStringSlice.
 			// https://github.com/spf13/viper/issues/380
 			var enabledToolsets []string
-			err = viper.UnmarshalKey("toolsets", &enabledToolsets)
-			if err != nil {
-				stdlog.Fatal("Failed to unmarshal toolsets:", err)
+			if err := viper.UnmarshalKey("toolsets", &enabledToolsets); err != nil {
+				return fmt.Errorf("failed to unmarshal toolsets: %w", err)
 			}
 
-			logCommands := viper.GetBool("enable-command-logging")
-			cfg := runConfig{
-				readOnly:           readOnly,
-				logger:             logger,
-				logCommands:        logCommands,
-				exportTranslations: exportTranslations,
-				enabledToolsets:    enabledToolsets,
+			stdioServerConfig := ghmcp.StdioServerConfig{
+				Version:              version,
+				Host:                 viper.GetString("host"),
+				Token:                token,
+				EnabledToolsets:      enabledToolsets,
+				DynamicToolsets:      viper.GetBool("dynamic_toolsets"),
+				ReadOnly:             viper.GetBool("read-only"),
+				ExportTranslations:   viper.GetBool("export-translations"),
+				EnableCommandLogging: viper.GetBool("enable-command-logging"),
+				LogFilePath:          viper.GetString("log-file"),
 			}
-			if err := runStdioServer(cfg); err != nil {
-				stdlog.Fatal("failed to run stdio server:", err)
-			}
+
+			return ghmcp.RunStdioServer(stdioServerConfig)
 		},
 	}
 )
@@ -103,143 +93,9 @@ func initConfig() {
 	viper.AutomaticEnv()
 }
 
-func initLogger(outPath string) (*log.Logger, error) {
-	if outPath == "" {
-		return log.New(), nil
-	}
-
-	file, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open log file: %w", err)
-	}
-
-	logger := log.New()
-	logger.SetLevel(log.DebugLevel)
-	logger.SetOutput(file)
-
-	return logger, nil
-}
-
-type runConfig struct {
-	readOnly           bool
-	logger             *log.Logger
-	logCommands        bool
-	exportTranslations bool
-	enabledToolsets    []string
-}
-
-func runStdioServer(cfg runConfig) error {
-	// Create app context
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	// Create GH client
-	token := viper.GetString("personal_access_token")
-	if token == "" {
-		cfg.logger.Fatal("GITHUB_PERSONAL_ACCESS_TOKEN not set")
-	}
-	ghClient := gogithub.NewClient(nil).WithAuthToken(token)
-	ghClient.UserAgent = fmt.Sprintf("github-mcp-server/%s", version)
-
-	host := viper.GetString("host")
-
-	if host != "" {
-		var err error
-		ghClient, err = ghClient.WithEnterpriseURLs(host, host)
-		if err != nil {
-			return fmt.Errorf("failed to create GitHub client with host: %w", err)
-		}
-	}
-
-	t, dumpTranslations := translations.TranslationHelper()
-
-	beforeInit := func(_ context.Context, _ any, message *mcp.InitializeRequest) {
-		ghClient.UserAgent = fmt.Sprintf("github-mcp-server/%s (%s/%s)", version, message.Params.ClientInfo.Name, message.Params.ClientInfo.Version)
-	}
-
-	getClient := func(_ context.Context) (*gogithub.Client, error) {
-		return ghClient, nil // closing over client
-	}
-
-	hooks := &server.Hooks{
-		OnBeforeInitialize: []server.OnBeforeInitializeFunc{beforeInit},
-	}
-	// Create server
-	ghServer := github.NewServer(version, server.WithHooks(hooks))
-
-	enabled := cfg.enabledToolsets
-	dynamic := viper.GetBool("dynamic_toolsets")
-	if dynamic {
-		// filter "all" from the enabled toolsets
-		enabled = make([]string, 0, len(cfg.enabledToolsets))
-		for _, toolset := range cfg.enabledToolsets {
-			if toolset != "all" {
-				enabled = append(enabled, toolset)
-			}
-		}
-	}
-
-	// Create default toolsets
-	toolsets, err := github.InitToolsets(enabled, cfg.readOnly, getClient, t)
-	context := github.InitContextToolset(getClient, t)
-
-	if err != nil {
-		stdlog.Fatal("Failed to initialize toolsets:", err)
-	}
-
-	// Register resources with the server
-	github.RegisterResources(ghServer, getClient, t)
-	// Register the tools with the server
-	toolsets.RegisterTools(ghServer)
-	context.RegisterTools(ghServer)
-
-	if dynamic {
-		dynamic := github.InitDynamicToolset(ghServer, toolsets, t)
-		dynamic.RegisterTools(ghServer)
-	}
-
-	stdioServer := server.NewStdioServer(ghServer)
-
-	stdLogger := stdlog.New(cfg.logger.Writer(), "stdioserver", 0)
-	stdioServer.SetErrorLogger(stdLogger)
-
-	if cfg.exportTranslations {
-		// Once server is initialized, all translations are loaded
-		dumpTranslations()
-	}
-
-	// Start listening for messages
-	errC := make(chan error, 1)
-	go func() {
-		in, out := io.Reader(os.Stdin), io.Writer(os.Stdout)
-
-		if cfg.logCommands {
-			loggedIO := iolog.NewIOLogger(in, out, cfg.logger)
-			in, out = loggedIO, loggedIO
-		}
-
-		errC <- stdioServer.Listen(ctx, in, out)
-	}()
-
-	// Output github-mcp-server string
-	_, _ = fmt.Fprintf(os.Stderr, "GitHub MCP Server running on stdio\n")
-
-	// Wait for shutdown signal
-	select {
-	case <-ctx.Done():
-		cfg.logger.Infof("shutting down server...")
-	case err := <-errC:
-		if err != nil {
-			return fmt.Errorf("error running server: %w", err)
-		}
-	}
-
-	return nil
-}
-
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -77,6 +77,12 @@ FAIL    github.com/github/github-mcp-server/e2e 1.433s
 FAIL
 ```
 
+## Debugging the Tests
+
+It is possible to provide `GITHUB_MCP_SERVER_E2E_DEBUG=true` to run the e2e tests with an in-process version of the MCP server. This has slightly reduced coverage as it doesn't integrate with Docker, or make use of the cobra/viper configuration parsing. However, it allows for placing breakpoints in the MCP Server internals, supporting much better debugging flows than the fully black-box tests.
+
+One might argue that the lack of visibility into failures for the black box tests also indicates a product need, but this solves for the immediate pain point felt as a maintainer.
+
 ## Limitations
 
 The current test suite is intentionally very limited in scope. This is because the maintenance costs on e2e tests tend to increase significantly over time. To read about some challenges with GitHub integration tests, see [go-github integration tests README](https://github.com/google/go-github/blob/5b75aa86dba5cf4af2923afa0938774f37fa0a67/test/README.md). We will expand this suite circumspectly!

--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -1,0 +1,216 @@
+package ghmcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/github/github-mcp-server/pkg/github"
+	mcplog "github.com/github/github-mcp-server/pkg/log"
+	"github.com/github/github-mcp-server/pkg/translations"
+	gogithub "github.com/google/go-github/v69/github"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/sirupsen/logrus"
+)
+
+type MCPServerConfig struct {
+	// Version of the server
+	Version string
+
+	// GitHub Host to target for API requests (e.g. github.com or github.enterprise.com)
+	Host string
+
+	// GitHub Token to authenticate with the GitHub API
+	Token string
+
+	// EnabledToolsets is a list of toolsets to enable
+	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#tool-configuration
+	EnabledToolsets []string
+
+	// Whether to enable dynamic toolsets
+	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#dynamic-tool-discovery
+	DynamicToolsets bool
+
+	// ReadOnly indicates if we should only offer read-only tools
+	ReadOnly bool
+
+	// Translator provides translated text for the server tooling
+	Translator translations.TranslationHelperFunc
+}
+
+func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
+	ghClient := gogithub.NewClient(nil).WithAuthToken(cfg.Token)
+	ghClient.UserAgent = fmt.Sprintf("github-mcp-server/%s", cfg.Version)
+
+	if cfg.Host != "" {
+		var err error
+		ghClient, err = ghClient.WithEnterpriseURLs(cfg.Host, cfg.Host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create GitHub client with host: %w", err)
+		}
+	}
+
+	// When a client send an initialize request, update the user agent to include the client info.
+	beforeInit := func(_ context.Context, _ any, message *mcp.InitializeRequest) {
+		ghClient.UserAgent = fmt.Sprintf(
+			"github-mcp-server/%s (%s/%s)",
+			cfg.Version,
+			message.Params.ClientInfo.Name,
+			message.Params.ClientInfo.Version,
+		)
+	}
+
+	hooks := &server.Hooks{
+		OnBeforeInitialize: []server.OnBeforeInitializeFunc{beforeInit},
+	}
+
+	ghServer := github.NewServer(cfg.Version, server.WithHooks(hooks))
+
+	enabledToolsets := cfg.EnabledToolsets
+	if cfg.DynamicToolsets {
+		// filter "all" from the enabled toolsets
+		enabledToolsets = make([]string, 0, len(cfg.EnabledToolsets))
+		for _, toolset := range cfg.EnabledToolsets {
+			if toolset != "all" {
+				enabledToolsets = append(enabledToolsets, toolset)
+			}
+		}
+	}
+
+	getClient := func(_ context.Context) (*gogithub.Client, error) {
+		return ghClient, nil // closing over client
+	}
+
+	// Create default toolsets
+	toolsets, err := github.InitToolsets(
+		enabledToolsets,
+		cfg.ReadOnly,
+		getClient,
+		cfg.Translator,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize toolsets: %w", err)
+	}
+
+	context := github.InitContextToolset(getClient, cfg.Translator)
+	github.RegisterResources(ghServer, getClient, cfg.Translator)
+
+	// Register the tools with the server
+	toolsets.RegisterTools(ghServer)
+	context.RegisterTools(ghServer)
+
+	if cfg.DynamicToolsets {
+		dynamic := github.InitDynamicToolset(ghServer, toolsets, cfg.Translator)
+		dynamic.RegisterTools(ghServer)
+	}
+
+	return ghServer, nil
+}
+
+type StdioServerConfig struct {
+	// Version of the server
+	Version string
+
+	// GitHub Host to target for API requests (e.g. github.com or github.enterprise.com)
+	Host string
+
+	// GitHub Token to authenticate with the GitHub API
+	Token string
+
+	// EnabledToolsets is a list of toolsets to enable
+	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#tool-configuration
+	EnabledToolsets []string
+
+	// Whether to enable dynamic toolsets
+	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#dynamic-tool-discovery
+	DynamicToolsets bool
+
+	// ReadOnly indicates if we should only register read-only tools
+	ReadOnly bool
+
+	// ExportTranslations indicates if we should export translations
+	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#i18n--overriding-descriptions
+	ExportTranslations bool
+
+	// EnableCommandLogging indicates if we should log commands
+	EnableCommandLogging bool
+
+	// Path to the log file if not stderr
+	LogFilePath string
+}
+
+// RunStdioServer is not concurrent safe.
+func RunStdioServer(cfg StdioServerConfig) error {
+	// Create app context
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	t, dumpTranslations := translations.TranslationHelper()
+
+	ghServer, err := NewMCPServer(MCPServerConfig{
+		Version:         cfg.Version,
+		Host:            cfg.Host,
+		Token:           cfg.Token,
+		EnabledToolsets: cfg.EnabledToolsets,
+		DynamicToolsets: cfg.DynamicToolsets,
+		ReadOnly:        cfg.ReadOnly,
+		Translator:      t,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create MCP server: %w", err)
+	}
+
+	stdioServer := server.NewStdioServer(ghServer)
+
+	logrusLogger := logrus.New()
+	if cfg.LogFilePath != "" {
+		file, err := os.OpenFile(cfg.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			return fmt.Errorf("failed to open log file: %w", err)
+		}
+
+		logrusLogger.SetLevel(logrus.DebugLevel)
+		logrusLogger.SetOutput(file)
+	}
+	stdLogger := log.New(logrusLogger.Writer(), "stdioserver", 0)
+	stdioServer.SetErrorLogger(stdLogger)
+
+	if cfg.ExportTranslations {
+		// Once server is initialized, all translations are loaded
+		dumpTranslations()
+	}
+
+	// Start listening for messages
+	errC := make(chan error, 1)
+	go func() {
+		in, out := io.Reader(os.Stdin), io.Writer(os.Stdout)
+
+		if cfg.EnableCommandLogging {
+			loggedIO := mcplog.NewIOLogger(in, out, logrusLogger)
+			in, out = loggedIO, loggedIO
+		}
+
+		errC <- stdioServer.Listen(ctx, in, out)
+	}()
+
+	// Output github-mcp-server string
+	_, _ = fmt.Fprintf(os.Stderr, "GitHub MCP Server running on stdio\n")
+
+	// Wait for shutdown signal
+	select {
+	case <-ctx.Done():
+		logrusLogger.Infof("shutting down server...")
+	case err := <-errC:
+		if err != nil {
+			return fmt.Errorf("error running server: %w", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

While working on other issues, I often found myself experiencing failures that were not easy to debug given the black box nature of the e2e tests. Now we can use `GITHUB_MCP_SERVER_E2E_DEBUG=true` to run an inprocess server version of the server, allowing for breakpointing. Open to renaming the env var to indicate exactly what it does, rather than debug. See image:

<img width="3321" alt="image" src="https://github.com/user-attachments/assets/656b8510-2701-477a-a26f-876382fe7afd" />


```
➜  github-mcp-server git:(wm/debug-e2e-tests) GOMAXPROCS=1 GITHUB_MCP_SERVER_E2E_TOKEN=$(gh auth token) go test -v -count=1 --tags e2e ./e2e

=== RUN   TestGetMe
=== PAUSE TestGetMe
=== RUN   TestToolsets
=== PAUSE TestToolsets
=== RUN   TestTags
=== PAUSE TestTags
=== CONT  TestGetMe
    e2e_test.go:49: Building Docker image for e2e tests...
    e2e_test.go:122: Starting Stdio MCP client...
--- PASS: TestGetMe (3.07s)
=== CONT  TestTags
    e2e_test.go:122: Starting Stdio MCP client...
    e2e_test.go:245: Getting current user...
    e2e_test.go:274: Creating repository williammartin/github-mcp-server-e2e-TestTags-1746619480361...
    e2e_test.go:291: Creating tag williammartin/github-mcp-server-e2e-TestTags-1746619480361:v0.0.1...
    e2e_test.go:321: Listing tags for williammartin/github-mcp-server-e2e-TestTags-1746619480361...
    e2e_test.go:354: Getting tag williammartin/github-mcp-server-e2e-TestTags-1746619480361:v0.0.1...
    e2e_test.go:283: Deleting repository williammartin/github-mcp-server-e2e-TestTags-1746619480361...
--- PASS: TestTags (3.51s)
=== CONT  TestToolsets
    e2e_test.go:122: Starting Stdio MCP client...
--- PASS: TestToolsets (0.19s)
PASS
ok      github.com/github/github-mcp-server/e2e 7.048s

➜  github-mcp-server git:(wm/debug-e2e-tests) GOMAXPROCS=1 GITHUB_MCP_SERVER_E2E_DEBUG=true GITHUB_MCP_SERVER_E2E_TOKEN=$(gh auth token) go test -v -count=1 --tags e2e ./e2e

=== RUN   TestGetMe
=== PAUSE TestGetMe
=== RUN   TestToolsets
=== PAUSE TestToolsets
=== RUN   TestTags
=== PAUSE TestTags
=== CONT  TestGetMe
    e2e_test.go:142: Starting In Process MCP client...
--- PASS: TestGetMe (0.46s)
=== CONT  TestTags
    e2e_test.go:142: Starting In Process MCP client...
    e2e_test.go:245: Getting current user...
    e2e_test.go:274: Creating repository williammartin/github-mcp-server-e2e-TestTags-1746619493471...
    e2e_test.go:291: Creating tag williammartin/github-mcp-server-e2e-TestTags-1746619493471:v0.0.1...
    e2e_test.go:321: Listing tags for williammartin/github-mcp-server-e2e-TestTags-1746619493471...
    e2e_test.go:354: Getting tag williammartin/github-mcp-server-e2e-TestTags-1746619493471:v0.0.1...
    e2e_test.go:283: Deleting repository williammartin/github-mcp-server-e2e-TestTags-1746619493471...
--- PASS: TestTags (3.04s)
=== CONT  TestToolsets
    e2e_test.go:142: Starting In Process MCP client...
--- PASS: TestToolsets (0.00s)
PASS
ok      github.com/github/github-mcp-server/e2e 3.738s
➜  github-mcp-server git:(wm/debug-e2e-tests)
```


Doing this also drove out some nice cleanups, separating config parsing, mcp server construction and stdio server execution. I have not written unit tests for these extracted functions as they were not previously tested and currently get most of their coverage from the e2e tests. I believe that later we may want to look into further testing of these to support further refactors, but that is out of scope for this PR.

