### PR TITLE
feat: upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
           go mod verify
           go mod download
 
-          LINT_VERSION=1.64.8
+          LINT_VERSION=2.1.6
           curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
             tar xz --strip-components 1 --wildcards \*/golangci-lint
           mkdir -p bin && mv golangci-lint bin/
@@ -45,6 +45,6 @@ jobs:
           assert-nothing-changed go fmt ./...
           assert-nothing-changed go mod tidy
 
-          bin/golangci-lint run --out-format=colored-line-number --timeout=3m || STATUS=$?
+          bin/golangci-lint run --timeout=3m || STATUS=$?
 
           exit $STATUS

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+# https://golangci-lint.run/usage/configuration
+version: "2"
+
 run:
   timeout: 5m
   tests: true
@@ -8,13 +11,9 @@ linters:
     - govet
     - errcheck
     - staticcheck
-    - gofmt
-    - goimports
     - revive
     - ineffassign
-    - typecheck
     - unused
-    - gosimple
     - misspell
     - nakedret
     - bodyclose
@@ -22,7 +21,15 @@ linters:
     - makezero
     - gosec
 
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+    - golines
+
 output:
-  formats: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
+  formats:
+    text:
+      print-linter-name: true
+      print-issued-lines: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,13 +20,25 @@ linters:
     - gocritic
     - makezero
     - gosec
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - '-QF1008' # Allow embedded structs to be referenced by field
+        - '-ST1000' # Do not require package comments
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
 
 formatters:
   enable:
-    - gci
     - gofmt
     - goimports
-    - golines
 
 output:
   formats:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 These are one time installations required to be able to test your changes locally as part of the pull request (PR) submission process.
 
 1. install Go [through download](https://go.dev/doc/install) | [through Homebrew](https://formulae.brew.sh/formula/go)
-1. [install golangci-lint](https://golangci-lint.run/welcome/install/#local-installation)
+1. [install golangci-lint v2](https://golangci-lint.run/welcome/install/#local-installation)
 
 ## Submitting a pull request
 

--- a/cmd/mcpcurl/main.go
+++ b/cmd/mcpcurl/main.go
@@ -77,7 +77,7 @@ type (
 		Arguments map[string]interface{} `json:"arguments"`
 	}
 
-	// Define structure to match the response format
+	// Content matches the response format of a text content response
 	Content struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
@@ -284,10 +284,10 @@ func addCommandFromTool(toolsCmd *cobra.Command, tool *Tool, prettyPrint bool) {
 			cmd.Flags().Bool(name, false, description)
 		case "array":
 			if prop.Items != nil {
-				if prop.Items.Type == "string" {
+				switch prop.Items.Type {
+				case "string":
 					cmd.Flags().StringSlice(name, []string{}, description)
-				} else if prop.Items.Type == "object" {
-					// For complex objects in arrays, we'll use a JSON string that users can provide
+				case "object":
 					cmd.Flags().String(name+"-json", "", description+" (provide as JSON array)")
 				}
 			}
@@ -327,11 +327,12 @@ func buildArgumentsMap(cmd *cobra.Command, tool *Tool) (map[string]interface{}, 
 			}
 		case "array":
 			if prop.Items != nil {
-				if prop.Items.Type == "string" {
+				switch prop.Items.Type {
+				case "string":
 					if values, _ := cmd.Flags().GetStringSlice(name); len(values) > 0 {
 						arguments[name] = values
 					}
-				} else if prop.Items.Type == "object" {
+				case "object":
 					if jsonStr, _ := cmd.Flags().GetString(name + "-json"); jsonStr != "" {
 						var jsonArray []interface{}
 						if err := json.Unmarshal([]byte(jsonStr), &jsonArray); err != nil {

--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/translations"
 	gogithub "github.com/google/go-github/v69/github"
 	"github.com/mark3labs/mcp-go/mcp"
-
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sirupsen/logrus"
 )
@@ -170,7 +169,7 @@ func RunStdioServer(cfg StdioServerConfig) error {
 
 	logrusLogger := logrus.New()
 	if cfg.LogFilePath != "" {
-		file, err := os.OpenFile(cfg.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		file, err := os.OpenFile(cfg.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
 			return fmt.Errorf("failed to open log file: %w", err)
 		}

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -612,7 +612,7 @@ func CreateBranch(getClient GetClientFn, t translations.TranslationHelperFunc) (
 				if err != nil {
 					return nil, fmt.Errorf("failed to get repository: %w", err)
 				}
-				defer resp.Body.Close()
+				defer func() { _ = resp.Body.Close() }()
 
 				fromBranch = *repository.DefaultBranch
 			}
@@ -622,7 +622,7 @@ func CreateBranch(getClient GetClientFn, t translations.TranslationHelperFunc) (
 			if err != nil {
 				return nil, fmt.Errorf("failed to get reference: %w", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			// Create new branch
 			newRef := &github.Reference{
@@ -634,7 +634,7 @@ func CreateBranch(getClient GetClientFn, t translations.TranslationHelperFunc) (
 			if err != nil {
 				return nil, fmt.Errorf("failed to create branch: %w", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			r, err := json.Marshal(createdRef)
 			if err != nil {

--- a/pkg/translations/translations.go
+++ b/pkg/translations/translations.go
@@ -56,7 +56,7 @@ func TranslationHelper() (TranslationHelperFunc, func()) {
 		}
 }
 
-// dump translationKeyMap to a json file called github-mcp-server-config.json
+// DumpTranslationKeyMap writes the translation map to a json file called github-mcp-server-config.json
 func DumpTranslationKeyMap(translationKeyMap map[string]string) error {
 	file, err := os.Create("github-mcp-server-config.json")
 	if err != nil {


### PR DESCRIPTION
Use the latest version of `golangci-lint` and fix the CI workflow.

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: #378 
