### PR TITLE
Add ability to request Copilot reviews via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,13 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `base`: New base branch name (string, optional)
   - `maintainer_can_modify`: Allow maintainer edits (boolean, optional)
 
+- **request_copilot_review** - Request a GitHub Copilot review for a pull request (experimental; subject to GitHub API support)
+
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `pull_number`: Pull request number (number, required)
+  - _Note: As of now, requesting a Copilot review programmatically is not supported by the GitHub API. This tool will return an error until GitHub exposes this functionality._
+
 ### Repositories
 
 - **create_or_update_file** - Create or update a single file in a repository

--- a/README.md
+++ b/README.md
@@ -462,8 +462,8 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
 
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
-  - `pull_number`: Pull request number (number, required)
-  - _Note: As of now, requesting a Copilot review programmatically is not supported by the GitHub API. This tool will return an error until GitHub exposes this functionality._
+  - `pullNumber`: Pull request number (number, required)
+  - _Note: Currently, this tool will only work for github.com
 
 ### Repositories
 

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
   - `pullNumber`: Pull request number (number, required)
-  - _Note: Currently, this tool will only work for github.com
+  - _Note_: Currently, this tool will only work for github.com
 
 ### Repositories
 

--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type expectations struct {
+	path        string
+	queryParams map[string]string
+	requestBody any
+}
+
+// expect is a helper function to create a partial mock that expects various
+// request behaviors, such as path, query parameters, and request body.
+func expect(t *testing.T, e expectations) *partialMock {
+	return &partialMock{
+		t:                   t,
+		expectedPath:        e.path,
+		expectedQueryParams: e.queryParams,
+		expectedRequestBody: e.requestBody,
+	}
+}
+
 // expectPath is a helper function to create a partial mock that expects a
 // request with the given path, with the ability to chain a response handler.
 func expectPath(t *testing.T, expectedPath string) *partialMock {

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1246,3 +1246,40 @@ func CreatePullRequest(getClient GetClientFn, t translations.TranslationHelperFu
 			return mcp.NewToolResultText(string(r)), nil
 		}
 }
+
+// RequestCopilotReview creates a tool to request a Copilot review for a pull request.
+func RequestCopilotReview(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("request_copilot_review",
+			mcp.WithDescription(t("TOOL_REQUEST_COPILOT_REVIEW_DESCRIPTION", "Request a GitHub Copilot review for a pull request. Note: This feature depends on GitHub API support and may not be available for all users.")),
+			mcp.WithString("owner",
+				mcp.Required(),
+				mcp.Description("Repository owner"),
+			),
+			mcp.WithString("repo",
+				mcp.Required(),
+				mcp.Description("Repository name"),
+			),
+			mcp.WithNumber("pull_number",
+				mcp.Required(),
+				mcp.Description("Pull request number"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			owner, err := requiredParam[string](request, "owner")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			repo, err := requiredParam[string](request, "repo")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			pullNumber, err := RequiredInt(request, "pull_number")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			// As of now, GitHub API does not support Copilot as a reviewer programmatically.
+			// This is a placeholder for future support.
+			return mcp.NewToolResultError(fmt.Sprintf("Requesting a Copilot review for PR #%d in %s/%s is not currently supported by the GitHub API. Please request a Copilot review via the GitHub UI.", pullNumber, owner, repo)), nil
+		}
+}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1252,7 +1252,7 @@ func CreatePullRequest(getClient GetClientFn, t translations.TranslationHelperFu
 // tool if the configured host does not support it.
 func RequestCopilotReview(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.Tool, server.ToolHandlerFunc) {
 	return mcp.NewTool("request_copilot_review",
-			mcp.WithDescription(t("TOOL_REQUEST_COPILOT_REVIEW_DESCRIPTION", "Request a GitHub Copilot review for a pull request. Note: This feature depends on GitHub API support and may not be available for all users.")),
+			mcp.WithDescription(t("TOOL_REQUEST_COPILOT_REVIEW_DESCRIPTION", "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_REQUEST_COPILOT_REVIEW_USER_TITLE", "Request Copilot review"),
 				ReadOnlyHint: toBoolPtr(false),

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -1916,3 +1916,27 @@ func Test_AddPullRequestReviewComment(t *testing.T) {
 		})
 	}
 }
+
+func Test_RequestCopilotReview(t *testing.T) {
+	mockClient := github.NewClient(nil)
+	tool, handler := RequestCopilotReview(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+
+	assert.Equal(t, "request_copilot_review", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "repo")
+	assert.Contains(t, tool.InputSchema.Properties, "pull_number")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo", "pull_number"})
+
+	request := createMCPRequest(map[string]interface{}{
+		"owner":       "owner",
+		"repo":        "repo",
+		"pull_number": float64(42),
+	})
+
+	result, err := handler(context.Background(), request)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	textContent := getTextResult(t, result)
+	assert.Contains(t, textContent.Text, "not currently supported by the GitHub API")
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -70,7 +70,6 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 			toolsets.NewServerTool(CreatePullRequest(getClient, t)),
 			toolsets.NewServerTool(UpdatePullRequest(getClient, t)),
 			toolsets.NewServerTool(AddPullRequestReviewComment(getClient, t)),
-
 			toolsets.NewServerTool(RequestCopilotReview(getClient, t)),
 		)
 	codeSecurity := toolsets.NewToolset("code_security", "Code security related tools, such as GitHub Code Scanning").

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -70,6 +70,8 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 			toolsets.NewServerTool(CreatePullRequest(getClient, t)),
 			toolsets.NewServerTool(UpdatePullRequest(getClient, t)),
 			toolsets.NewServerTool(AddPullRequestReviewComment(getClient, t)),
+
+			toolsets.NewServerTool(RequestCopilotReview(getClient, t)),
 		)
 	codeSecurity := toolsets.NewToolset("code_security", "Code security related tools, such as GitHub Code Scanning").
 		AddReadTools(


### PR DESCRIPTION
## Description

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: #374

This PR adds the `request_copilot_review` tool, which...requests reviews from copilot on PRs where possible. It is an MVP implementation that doesn't try to do anything particularly clever around only exposing the tool for hosts that support it, or playing nice with various error messages that might come back.