### PR TITLE
fix: update `get_me` reason arg description

### DIFF
--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -21,7 +21,7 @@ func GetMe(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mc
 				ReadOnlyHint: toBoolPtr(true),
 			}),
 			mcp.WithString("reason",
-				mcp.Description("Optional: reason the session was created"),
+				mcp.Description("Optional: the reason for requesting the user information"),
 			),
 		),
 		func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
This fixes the description for the `reason` argument in the `get_me` tool.