### PR TITLE
Support assigning copilot to issues

### DIFF
--- a/internal/githubv4mock/objects_are_equal_values.go
+++ b/internal/githubv4mock/objects_are_equal_values.go
@@ -1,6 +1,8 @@
 // The contents of this file are taken from https://github.com/stretchr/testify/blob/016e2e9c269209287f33ec203f340a9a723fe22c/assert/assertions.go#L166
 // because I do not want to take a dependency on the entire testify module just to use this equality check.
 //
+// There is a modification in objectsAreEqual to check that typed nils are equal, even if their types are different.
+//
 // The original license, copied from https://github.com/stretchr/testify/blob/016e2e9c269209287f33ec203f340a9a723fe22c/LICENSE
 //
 // MIT License
@@ -69,8 +71,10 @@ func objectsAreEqualValues(expected, actual any) bool {
 //
 // This function does no assertion of any kind.
 func objectsAreEqual(expected, actual any) bool {
-	if expected == nil || actual == nil {
-		return expected == actual
+	// There is a modification in objectsAreEqual to check that typed nils are equal, even if their types are different.
+	// This is required because when a nil is provided as a variable, the type is not known.
+	if isNil(expected) && isNil(actual) {
+		return true
 	}
 
 	exp, ok := expected.([]byte)
@@ -93,4 +97,17 @@ func objectsAreEqual(expected, actual any) bool {
 // float32, float64, complex64, complex128
 func isNumericType(t reflect.Type) bool {
 	return t.Kind() >= reflect.Int && t.Kind() <= reflect.Complex128
+}
+
+func isNil(i any) bool {
+	if i == nil {
+		return true
+	}
+	v := reflect.ValueOf(i)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/internal/githubv4mock/objects_are_equal_values_test.go
+++ b/internal/githubv4mock/objects_are_equal_values_test.go
@@ -1,5 +1,7 @@
 // The contents of this file are taken from https://github.com/stretchr/testify/blob/016e2e9c269209287f33ec203f340a9a723fe22c/assert/assertions_test.go#L140-L174
 //
+// There is a modification to test objectsAreEqualValues to check that typed nils are equal, even if their types are different.
+
 // The original license, copied from https://github.com/stretchr/testify/blob/016e2e9c269209287f33ec203f340a9a723fe22c/LICENSE
 //
 // MIT License
@@ -55,6 +57,8 @@ func TestObjectsAreEqualValues(t *testing.T) {
 		{3.14, complex128(1e+100 + 1e+100i), false},
 		{complex128(1e+10 + 1e+10i), complex64(1e+10 + 1e+10i), true},
 		{complex64(1e+10 + 1e+10i), complex128(1e+10 + 1e+10i), true},
+		{(*string)(nil), nil, true},         // typed nil vs untyped nil
+		{(*string)(nil), (*int)(nil), true}, // different typed nils
 	}
 
 	for _, c := range cases {

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -51,6 +51,7 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 			toolsets.NewServerTool(CreateIssue(getClient, t)),
 			toolsets.NewServerTool(AddIssueComment(getClient, t)),
 			toolsets.NewServerTool(UpdateIssue(getClient, t)),
+			toolsets.NewServerTool(AssignCopilotToIssue(getGQLClient, t)),
 		)
 	users := toolsets.NewToolset("users", "GitHub User related tools").
 		AddReadTools(


### PR DESCRIPTION
## Description

Closes: #398 

This adds a new tool `assign_copilot_to_issue`, which...assigns copilot to an issue.

```
➜  github-mcp-server git:(398-add-a-tool-to-assign-copilot-to-issues) GOMAXPROCS=1 GITHUB_MCP_SERVER_E2E_HOST=https://github.com GITHUB_MCP_SERVER_E2E_TOKEN=$(gh auth token) go test -v -count=1 --run TestAssignCopilotToIssue --tags e2e ./e2e

=== RUN   TestAssignCopilotToIssue
=== PAUSE TestAssignCopilotToIssue
=== CONT  TestAssignCopilotToIssue
    e2e_test.go:79: Building Docker image for e2e tests...
    e2e_test.go:162: Starting Stdio MCP client...
    e2e_test.go:959: Getting current user...
    e2e_test.go:988: Creating repository williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756871756...
    e2e_test.go:1011: Creating issue in williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756871756...
    e2e_test.go:1025: Assigning copilot to issue in williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756871756...
    e2e_test.go:997: Deleting repository williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756871756...
--- PASS: TestAssignCopilotToIssue (5.23s)
PASS
ok      github.com/github/github-mcp-server/e2e 5.472s
```

Since the coding agent is in public preview, it can require configuring manually. Thus, the e2e test will skip if it gets an error that copilot could not be found as a reviewer.

```
➜  github-mcp-server git:(398-add-a-tool-to-assign-copilot-to-issues) GOMAXPROCS=1 GITHUB_MCP_SERVER_E2E_HOST=https://github.com GITHUB_MCP_SERVER_E2E_TOKEN=$(gh auth token) go test -v -count=1 --run TestAssignCopilotToIssue --tags e2e ./e2e

=== RUN   TestAssignCopilotToIssue
=== PAUSE TestAssignCopilotToIssue
=== CONT  TestAssignCopilotToIssue
    e2e_test.go:79: Building Docker image for e2e tests...
    e2e_test.go:162: Starting Stdio MCP client...
    e2e_test.go:959: Getting current user...
    e2e_test.go:988: Creating repository williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756857173...
    e2e_test.go:1011: Creating issue in williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756857173...
    e2e_test.go:1025: Assigning copilot to issue in williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756857173...
    e2e_test.go:1034: skipping because copilot wasn't available as an assignee on this issue, it's likely that the owner doesn't have copilot enabled in their setttings <---------
    e2e_test.go:997: Deleting repository williammartin/github-mcp-server-e2e-TestAssignCopilotToIssue-1747756857173...
--- SKIP: TestAssignCopilotToIssue (5.93s)
PASS
ok      github.com/github/github-mcp-server/e2e 6.156s
```