### PR TITLE
Remove non-existent get_line_number_in_pull_request_file tool reference

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -7,12 +7,13 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/go-github/v69/github"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/shurcooL/githubv4"
+
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 // GetPullRequest creates a tool to get details of a specific pull request.
@@ -1050,7 +1051,7 @@ func CreatePendingPullRequestReview(getGQLClient GetGQLClientFn, t translations.
 // AddPullRequestReviewCommentToPendingReview creates a tool to add a comment to a pull request review.
 func AddPullRequestReviewCommentToPendingReview(getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (mcp.Tool, server.ToolHandlerFunc) {
 	return mcp.NewTool("add_pull_request_review_comment_to_pending_review",
-			mcp.WithDescription(t("TOOL_ADD_PULL_REQUEST_REVIEW_COMMENT_TO_PENDING_REVIEW_DESCRIPTION", "Add a comment to the requester's latest pending pull request review, a pending review needs to already exist to call this (check with the user if not sure). If you are using the LINE subjectType, use the get_line_number_in_pull_request_file tool to get an exact line number before commenting.")),
+			mcp.WithDescription(t("TOOL_ADD_PULL_REQUEST_REVIEW_COMMENT_TO_PENDING_REVIEW_DESCRIPTION", "Add a comment to the requester's latest pending pull request review, a pending review needs to already exist to call this (check with the user if not sure).")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_ADD_PULL_REQUEST_REVIEW_COMMENT_TO_PENDING_REVIEW_USER_TITLE", "Add comment to the requester's latest pending pull request review"),
 				ReadOnlyHint: toBoolPtr(false),


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: https://github.com/github/github-mcp-server/issues/435

The `add_pull_request_review_comment_to_pending_review` tool mention the `get_line_number_in_pull_request_file` tool to be used to get line number. But this tool does not exists.

https://github.com/github/github-mcp-server/blob/e9f748f246761fb0769e2a5611003939a6274872/pkg/github/pullrequests.go#L1053

![Image](https://github.com/user-attachments/assets/a0f7bfaa-17c0-49f1-b066-8d3d40d1eed1)