### PR TITLE
fix: use ENTRYPOINT and CMD for proper argument handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,7 @@ FROM gcr.io/distroless/base-debian12
 WORKDIR /server
 # Copy the binary from the build stage
 COPY --from=build /bin/github-mcp-server .
-# Command to run the server
-CMD ["./github-mcp-server", "stdio"]
+# Set the entrypoint to the server binary
+ENTRYPOINT ["./github-mcp-server"]
+# Default command arguments
+CMD ["stdio"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ WORKDIR /server
 # Copy the binary from the build stage
 COPY --from=build /bin/github-mcp-server .
 # Set the entrypoint to the server binary
-ENTRYPOINT ["./github-mcp-server"]
-# Default command arguments
+ENTRYPOINT ["/server/github-mcp-server"]
+# Default arguments for ENTRYPOINT
 CMD ["stdio"]


### PR DESCRIPTION
## Problem

The current Dockerfile uses `CMD ["./github-mcp-server", "stdio"]` which causes issues when container orchestration tools try to append additional arguments. This results in the entire CMD being replaced rather than arguments being appended.

## Root Cause

When using only `CMD`, container runtimes replace the entire command when additional arguments are provided. This breaks argument passing in tools like ToolHive, Kubernetes, and other container orchestrators.

## Solution

Implement Docker best practices by using:
- `ENTRYPOINT` for the executable that should always run
- `CMD` for default arguments that can be overridden/appended to

## Changes

**Before:**
```dockerfile
CMD ["./github-mcp-server", "stdio"]
```

**After:**
```dockerfile
ENTRYPOINT ["./github-mcp-server"]
CMD ["stdio"]
```

## Benefits

1. **Proper argument handling**: Additional arguments are appended to the default `stdio` argument instead of replacing the entire command
2. **Container orchestration compatibility**: Works correctly with Kubernetes, Docker Compose, and other tools
3. **Backward compatibility**: Default behavior remains the same when no arguments are provided
4. **Docker best practices**: Follows recommended patterns for containerized applications

## Testing

This change maintains backward compatibility:
- `docker run github-mcp-server` → runs `./github-mcp-server stdio` (same as before)
- `docker run github-mcp-server --toolsets all` → runs `./github-mcp-server --toolsets all` (new capability)

## Related Issues

This fixes argument passing issues reported in container orchestration tools where additional arguments couldn't be properly passed to the MCP server.