### PR TITLE
Add support for Repository Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The following sets of tools are available (all are on by default):
 | ----------------------- | ------------------------------------------------------------- |
 | `repos`                 | Repository-related tools (file operations, branches, commits) |
 | `issues`                | Issue-related tools (create, read, update, comment)           |
-| `discussions`           | GitHub Discussions tools (list, get, comments)                |
+| `discussions`           | GitHub Discussions tools (list, get, comments, categories)    |
 | `users`                 | Anything relating to GitHub Users                             |
 | `pull_requests`         | Pull request operations (create, merge, review)               |
 | `code_security`         | Code scanning alerts and security features                    |
@@ -582,7 +582,6 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `secret_type`: The secret types to be filtered for in a comma-separated list (string, optional)
   - `resolution`: The resolution status (string, optional)
 
-<<<<<<< HEAD
 ### Notifications
 
 - **list_notifications** – List notifications for a GitHub user
@@ -616,21 +615,17 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `repo`: The name of the repository (string, required)
   - `action`: Action to perform: `ignore`, `watch`, or `delete` (string, required)
 
-=======
->>>>>>> 8d6b84c (doc: add support for GitHub discussions, with an example.)
 ### Discussions
  
-> [!NOTE]  
-> As there is no support for discussions in the native GitHub go library, this toolset is deliberately limited to a few basic functions. The plan is to first implement native support in the GitHub go library, then use it for a better and consistent support in the MCP server.
-
 - **list_discussions** - List discussions for a repository
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
-  - `state`: State filter (open, closed, all) (string, optional)
-  - `labels`: Filter by label names (string[], optional)
+  - `categoryId`: Filter by category ID (string, optional)
   - `since`: Filter by date (ISO 8601 timestamp) (string, optional)
-  - `page`: Page number (number, optional)
-  - `perPage`: Results per page (number, optional)
+  - `first`: Pagination - Number of records to retrieve (number, optional)
+  - `after`: Pagination - Cursor to start with (string, optional)
+  - `sort`: Sort by ('CREATED_AT', 'UPDATED_AT') (string, optional)
+  - `direction`: Sort direction ('ASC', 'DESC') (string, optional)
 
 - **get_discussion** - Get a specific discussion by ID
   - `owner`: Repository owner (string, required)
@@ -641,6 +636,10 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
   - `discussion_id`: Discussion ID (number, required)
+
+- **list_discussion_categories** - List discussion categories for a repository, with their IDs and names
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The following sets of tools are available (all are on by default):
 | ----------------------- | ------------------------------------------------------------- |
 | `repos`                 | Repository-related tools (file operations, branches, commits) |
 | `issues`                | Issue-related tools (create, read, update, comment)           |
+| `discussions`           | GitHub Discussions tools (list, get, comments)                |
 | `users`                 | Anything relating to GitHub Users                             |
 | `pull_requests`         | Pull request operations (create, merge, review)               |
 | `code_security`         | Code scanning alerts and security features                    |
@@ -581,6 +582,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `secret_type`: The secret types to be filtered for in a comma-separated list (string, optional)
   - `resolution`: The resolution status (string, optional)
 
+<<<<<<< HEAD
 ### Notifications
 
 - **list_notifications** – List notifications for a GitHub user
@@ -613,6 +615,32 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
   - `owner`: The account owner of the repository (string, required)
   - `repo`: The name of the repository (string, required)
   - `action`: Action to perform: `ignore`, `watch`, or `delete` (string, required)
+
+=======
+>>>>>>> 8d6b84c (doc: add support for GitHub discussions, with an example.)
+### Discussions
+ 
+> [!NOTE]  
+> As there is no support for discussions in the native GitHub go library, this toolset is deliberately limited to a few basic functions. The plan is to first implement native support in the GitHub go library, then use it for a better and consistent support in the MCP server.
+
+- **list_discussions** - List discussions for a repository
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `state`: State filter (open, closed, all) (string, optional)
+  - `labels`: Filter by label names (string[], optional)
+  - `since`: Filter by date (ISO 8601 timestamp) (string, optional)
+  - `page`: Page number (number, optional)
+  - `perPage`: Results per page (number, optional)
+
+- **get_discussion** - Get a specific discussion by ID
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `discussion_id`: Discussion ID (number, required)
+
+- **get_discussion_comments** - Get comments from a discussion
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `discussion_id`: Discussion ID (number, required)
 
 ## Resources
 

--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -1,0 +1,340 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/google/go-github/v69/github"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/shurcooL/githubv4"
+)
+
+func ListDiscussions(getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("list_discussions",
+			mcp.WithDescription(t("TOOL_LIST_DISCUSSIONS_DESCRIPTION", "List discussions for a repository")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_LIST_DISCUSSIONS_USER_TITLE", "List discussions"),
+				ReadOnlyHint: toBoolPtr(true),
+			}),
+			mcp.WithString("owner",
+				mcp.Required(),
+				mcp.Description("Repository owner"),
+			),
+			mcp.WithString("repo",
+				mcp.Required(),
+				mcp.Description("Repository name"),
+			),
+			mcp.WithString("categoryId",
+				mcp.Description("Category ID filter"),
+			),
+			mcp.WithString("since",
+				mcp.Description("Filter by date (ISO 8601 timestamp)"),
+			),
+			mcp.WithString("sort",
+				mcp.Description("Sort field"),
+				mcp.DefaultString("CREATED_AT"),
+				mcp.Enum("CREATED_AT", "UPDATED_AT"),
+			),
+			mcp.WithString("direction",
+				mcp.Description("Sort direction"),
+				mcp.DefaultString("DESC"),
+				mcp.Enum("ASC", "DESC"),
+			),
+			mcp.WithNumber("first",
+				mcp.Description("Number of discussions to return per page (min 1, max 100)"),
+				mcp.Min(1),
+				mcp.Max(100),
+			),
+			mcp.WithString("after",
+				mcp.Description("Cursor for pagination, use the 'after' field from the previous response"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			// Decode params
+			var params struct {
+				Owner      string
+				Repo       string
+				CategoryId string
+				Since      string
+				Sort       string
+				Direction  string
+				First      int32
+				After      string
+			}
+			if err := mapstructure.Decode(request.Params.Arguments, &params); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			// Get GraphQL client
+			client, err := getGQLClient(ctx)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil
+			}
+			// Prepare GraphQL query
+			var q struct {
+				Repository struct {
+					Discussions struct {
+						Nodes []struct {
+							Number    githubv4.Int
+							Title     githubv4.String
+							CreatedAt githubv4.DateTime
+							Category  struct {
+								Name githubv4.String
+							} `graphql:"category"`
+							URL githubv4.String `graphql:"url"`
+						}
+					} `graphql:"discussions(categoryId: $categoryId, orderBy: {field: $sort, direction: $direction}, first: $first, after: $after)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}
+			// Build query variables
+			vars := map[string]interface{}{
+				"owner":      githubv4.String(params.Owner),
+				"repo":       githubv4.String(params.Repo),
+				"categoryId": githubv4.ID(params.CategoryId),
+				"sort":       githubv4.DiscussionOrderField(params.Sort),
+				"direction":  githubv4.OrderDirection(params.Direction),
+				"first":      githubv4.Int(params.First),
+				"after":      githubv4.String(params.After),
+			}
+			// Execute query
+			if err := client.Query(ctx, &q, vars); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			// Map nodes to GitHub Issue objects - there is no discussion type in the GitHub API, so we use Issue to benefit from existing code
+			var discussions []*github.Issue
+			for _, n := range q.Repository.Discussions.Nodes {
+				di := &github.Issue{
+					Number:    github.Ptr(int(n.Number)),
+					Title:     github.Ptr(string(n.Title)),
+					HTMLURL:   github.Ptr(string(n.URL)),
+					CreatedAt: &github.Timestamp{Time: n.CreatedAt.Time},
+				}
+				discussions = append(discussions, di)
+			}
+
+			// Post filtering discussions based on 'since' parameter
+			if params.Since != "" {
+				sinceTime, err := time.Parse(time.RFC3339, params.Since)
+				if err != nil {
+					return mcp.NewToolResultError(fmt.Sprintf("invalid 'since' timestamp: %v", err)), nil
+				}
+				var filteredDiscussions []*github.Issue
+				for _, d := range discussions {
+					if d.CreatedAt.Time.After(sinceTime) {
+						filteredDiscussions = append(filteredDiscussions, d)
+					}
+				}
+				discussions = filteredDiscussions
+			}
+
+			// Marshal and return
+			out, err := json.Marshal(discussions)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal discussions: %w", err)
+			}
+			return mcp.NewToolResultText(string(out)), nil
+		}
+}
+
+func GetDiscussion(getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("get_discussion",
+			mcp.WithDescription(t("TOOL_GET_DISCUSSION_DESCRIPTION", "Get a specific discussion by ID")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_GET_DISCUSSION_USER_TITLE", "Get discussion"),
+				ReadOnlyHint: toBoolPtr(true),
+			}),
+			mcp.WithString("owner",
+				mcp.Required(),
+				mcp.Description("Repository owner"),
+			),
+			mcp.WithString("repo",
+				mcp.Required(),
+				mcp.Description("Repository name"),
+			),
+			mcp.WithNumber("discussion_id",
+				mcp.Required(),
+				mcp.Description("Discussion ID"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			owner, err := requiredParam[string](request, "owner")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			repo, err := requiredParam[string](request, "repo")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			discussionID, err := RequiredInt(request, "discussion_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			client, err := getGQLClient(ctx)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil
+			}
+
+			var q struct {
+				Repository struct {
+					Discussion struct {
+						Number    githubv4.Int
+						Body      githubv4.String
+						State     githubv4.String
+						CreatedAt githubv4.DateTime
+						URL       githubv4.String `graphql:"url"`
+					} `graphql:"discussion(number: $discussionID)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}
+			vars := map[string]interface{}{
+				"owner":        githubv4.String(owner),
+				"repo":         githubv4.String(repo),
+				"discussionID": githubv4.Int(discussionID),
+			}
+			if err := client.Query(ctx, &q, vars); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			d := q.Repository.Discussion
+			discussion := &github.Issue{
+				Number:    github.Ptr(int(d.Number)),
+				Body:      github.Ptr(string(d.Body)),
+				State:     github.Ptr(string(d.State)),
+				HTMLURL:   github.Ptr(string(d.URL)),
+				CreatedAt: &github.Timestamp{Time: d.CreatedAt.Time},
+			}
+			out, err := json.Marshal(discussion)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal discussion: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(out)), nil
+		}
+}
+
+func GetDiscussionComments(getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("get_discussion_comments",
+			mcp.WithDescription(t("TOOL_GET_DISCUSSION_COMMENTS_DESCRIPTION", "Get comments from a discussion")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_GET_DISCUSSION_COMMENTS_USER_TITLE", "Get discussion comments"),
+				ReadOnlyHint: toBoolPtr(true),
+			}),
+			mcp.WithString("owner", mcp.Required(), mcp.Description("Repository owner")),
+			mcp.WithString("repo", mcp.Required(), mcp.Description("Repository name")),
+			mcp.WithNumber("discussion_id", mcp.Required(), mcp.Description("Discussion ID")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			owner, err := requiredParam[string](request, "owner")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			repo, err := requiredParam[string](request, "repo")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			discussionID, err := RequiredInt(request, "discussion_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			client, err := getGQLClient(ctx)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil
+			}
+
+			var q struct {
+				Repository struct {
+					Discussion struct {
+						Comments struct {
+							Nodes []struct {
+								Body githubv4.String
+							}
+						} `graphql:"comments(first:100)"`
+					} `graphql:"discussion(number: $discussionID)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}
+			vars := map[string]interface{}{
+				"owner":        githubv4.String(owner),
+				"repo":         githubv4.String(repo),
+				"discussionID": githubv4.Int(discussionID),
+			}
+			if err := client.Query(ctx, &q, vars); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			var comments []*github.IssueComment
+			for _, c := range q.Repository.Discussion.Comments.Nodes {
+				comments = append(comments, &github.IssueComment{Body: github.Ptr(string(c.Body))})
+			}
+
+			out, err := json.Marshal(comments)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal comments: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(out)), nil
+		}
+}
+
+func ListDiscussionCategories(getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("list_discussion_categories",
+			mcp.WithDescription(t("TOOL_LIST_DISCUSSION_CATEGORIES_DESCRIPTION", "List discussion categorie with their id and name, for a repository")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        t("TOOL_LIST_DISCUSSION_CATEGORIES_USER_TITLE", "List discussion categories"),
+				ReadOnlyHint: toBoolPtr(true),
+			}),
+			mcp.WithString("owner",
+				mcp.Required(),
+				mcp.Description("Repository owner"),
+			),
+			mcp.WithString("repo",
+				mcp.Required(),
+				mcp.Description("Repository name"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			owner, err := requiredParam[string](request, "owner")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			repo, err := requiredParam[string](request, "repo")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			client, err := getGQLClient(ctx)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil
+			}
+			var q struct {
+				Repository struct {
+					DiscussionCategories struct {
+						Nodes []struct {
+							ID   githubv4.ID
+							Name githubv4.String
+						}
+					} `graphql:"discussionCategories(first: 30)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}
+			vars := map[string]interface{}{
+				"owner": githubv4.String(owner),
+				"repo":  githubv4.String(repo),
+			}
+			if err := client.Query(ctx, &q, vars); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			var categories []map[string]string
+			for _, c := range q.Repository.DiscussionCategories.Nodes {
+				categories = append(categories, map[string]string{
+					"id":   fmt.Sprint(c.ID),
+					"name": string(c.Name),
+				})
+			}
+			out, err := json.Marshal(categories)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal discussion categories: %w", err)
+			}
+			return mcp.NewToolResultText(string(out)), nil
+		}
+}

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -1,0 +1,392 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/google/go-github/v69/github"
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	discussionsAll = []map[string]any{
+		{"number": 1, "title": "Discussion 1 title", "createdAt": "2023-01-01T00:00:00Z", "category": map[string]any{"name": "news"}, "url": "https://github.com/owner/repo/discussions/1"},
+		{"number": 2, "title": "Discussion 2 title", "createdAt": "2023-02-01T00:00:00Z", "category": map[string]any{"name": "updates"}, "url": "https://github.com/owner/repo/discussions/2"},
+		{"number": 3, "title": "Discussion 3 title", "createdAt": "2023-03-01T00:00:00Z", "category": map[string]any{"name": "questions"}, "url": "https://github.com/owner/repo/discussions/3"},
+	}
+	mockResponseListAll = githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"discussions": map[string]any{"nodes": discussionsAll},
+		},
+	})
+	mockResponseCategory = githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"discussions": map[string]any{"nodes": discussionsAll[:1]}, // Only return the first discussion for category test
+		},
+	})
+	mockErrorRepoNotFound = githubv4mock.ErrorResponse("repository not found")
+)
+
+func Test_ListDiscussions(t *testing.T) {
+	// Verify tool definition and schema
+	toolDef, _ := ListDiscussions(nil, translations.NullTranslationHelper)
+	assert.Equal(t, "list_discussions", toolDef.Name)
+	assert.NotEmpty(t, toolDef.Description)
+	assert.Contains(t, toolDef.InputSchema.Properties, "owner")
+	assert.Contains(t, toolDef.InputSchema.Properties, "repo")
+	assert.ElementsMatch(t, toolDef.InputSchema.Required, []string{"owner", "repo"})
+
+	// GraphQL query struct
+	var q struct {
+		Repository struct {
+			Discussions struct {
+				Nodes []struct {
+					Number    githubv4.Int
+					Title     githubv4.String
+					CreatedAt githubv4.DateTime
+					Category  struct {
+						Name githubv4.String
+					} `graphql:"category"`
+					URL githubv4.String `graphql:"url"`
+				}
+			} `graphql:"discussions(categoryId: $categoryId, orderBy: {field: $sort, direction: $direction}, first: $first, after: $after)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+
+	varsListAll := map[string]interface{}{
+		"owner":      githubv4.String("owner"),
+		"repo":       githubv4.String("repo"),
+		"categoryId": githubv4.ID(""),
+		"sort":       githubv4.DiscussionOrderField(""),
+		"direction":  githubv4.OrderDirection(""),
+		"first":      githubv4.Int(0),
+		"after":      githubv4.String(""),
+	}
+
+	varsListInvalid := map[string]interface{}{
+		"owner":      githubv4.String("invalid"),
+		"repo":       githubv4.String("repo"),
+		"categoryId": githubv4.ID(""),
+		"sort":       githubv4.DiscussionOrderField(""),
+		"direction":  githubv4.OrderDirection(""),
+		"first":      githubv4.Int(0),
+		"after":      githubv4.String(""),
+	}
+
+	varsListWithCategory := map[string]interface{}{
+		"owner":      githubv4.String("owner"),
+		"repo":       githubv4.String("repo"),
+		"categoryId": githubv4.ID("12345"),
+		"sort":       githubv4.DiscussionOrderField(""),
+		"direction":  githubv4.OrderDirection(""),
+		"first":      githubv4.Int(0),
+		"after":      githubv4.String(""),
+	}
+
+	tests := []struct {
+		name        string
+		vars        map[string]interface{}
+		reqParams   map[string]interface{}
+		response    githubv4mock.GQLResponse
+		expectError bool
+		expectedIds []int64
+		errContains string
+	}{
+		{
+			name: "list all discussions",
+			vars: varsListAll,
+			reqParams: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+			},
+			response:    mockResponseListAll,
+			expectError: false,
+			expectedIds: []int64{1, 2, 3},
+		},
+		{
+			name: "invalid owner or repo",
+			vars: varsListInvalid,
+			reqParams: map[string]interface{}{
+				"owner": "invalid",
+				"repo":  "repo",
+			},
+			response:    mockErrorRepoNotFound,
+			expectError: true,
+			errContains: "repository not found",
+		},
+		{
+			name: "list discussions with category",
+			vars: varsListWithCategory,
+			reqParams: map[string]interface{}{
+				"owner":      "owner",
+				"repo":       "repo",
+				"categoryId": "12345",
+			},
+			response:    mockResponseCategory,
+			expectError: false,
+			expectedIds: []int64{1},
+		},
+		{
+			name: "list discussions with since date",
+			vars: varsListAll,
+			reqParams: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+				"since": "2023-01-10T00:00:00Z",
+			},
+			response:    mockResponseListAll,
+			expectError: false,
+			expectedIds: []int64{2, 3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := githubv4mock.NewQueryMatcher(q, tc.vars, tc.response)
+			httpClient := githubv4mock.NewMockedHTTPClient(matcher)
+			gqlClient := githubv4.NewClient(httpClient)
+			_, handler := ListDiscussions(stubGetGQLClientFn(gqlClient), translations.NullTranslationHelper)
+
+			req := createMCPRequest(tc.reqParams)
+			res, err := handler(context.Background(), req)
+			text := getTextResult(t, res).Text
+
+			if tc.expectError {
+				require.True(t, res.IsError)
+				assert.Contains(t, text, tc.errContains)
+				return
+			}
+			require.NoError(t, err)
+
+			var returnedDiscussions []*github.Issue
+			err = json.Unmarshal([]byte(text), &returnedDiscussions)
+			require.NoError(t, err)
+
+			assert.Len(t, returnedDiscussions, len(tc.expectedIds), "Expected %d discussions, got %d", len(tc.expectedIds), len(returnedDiscussions))
+
+			// If no discussions are expected, skip further checks
+			if len(tc.expectedIds) == 0 {
+				return
+			}
+
+			// Create a map of expected IDs for easier checking
+			expectedIDMap := make(map[int64]bool)
+			for _, id := range tc.expectedIds {
+				expectedIDMap[id] = true
+			}
+
+			for _, discussion := range returnedDiscussions {
+				// Check if the discussion Number is in the expected list
+				assert.True(t, expectedIDMap[int64(*discussion.Number)], "Unexpected discussion Number: %d", *discussion.Number)
+			}
+		})
+	}
+}
+
+func Test_GetDiscussion(t *testing.T) {
+	// Verify tool definition and schema
+	toolDef, _ := GetDiscussion(nil, translations.NullTranslationHelper)
+	assert.Equal(t, "get_discussion", toolDef.Name)
+	assert.NotEmpty(t, toolDef.Description)
+	assert.Contains(t, toolDef.InputSchema.Properties, "owner")
+	assert.Contains(t, toolDef.InputSchema.Properties, "repo")
+	assert.Contains(t, toolDef.InputSchema.Properties, "discussion_id")
+	assert.ElementsMatch(t, toolDef.InputSchema.Required, []string{"owner", "repo", "discussion_id"})
+
+	var q struct {
+		Repository struct {
+			Discussion struct {
+				Number    githubv4.Int
+				Body      githubv4.String
+				State     githubv4.String
+				CreatedAt githubv4.DateTime
+				URL       githubv4.String `graphql:"url"`
+			} `graphql:"discussion(number: $discussionID)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+	vars := map[string]interface{}{
+		"owner":        githubv4.String("owner"),
+		"repo":         githubv4.String("repo"),
+		"discussionID": githubv4.Int(1),
+	}
+	tests := []struct {
+		name        string
+		response    githubv4mock.GQLResponse
+		expectError bool
+		expected    *github.Issue
+		errContains string
+	}{
+		{
+			name: "successful retrieval",
+			response: githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{"discussion": map[string]any{
+					"number":    1,
+					"body":      "This is a test discussion",
+					"state":     "open",
+					"url":       "https://github.com/owner/repo/discussions/1",
+					"createdAt": "2025-04-25T12:00:00Z",
+				}},
+			}),
+			expectError: false,
+			expected: &github.Issue{
+				HTMLURL:   github.Ptr("https://github.com/owner/repo/discussions/1"),
+				Number:    github.Ptr(1),
+				Body:      github.Ptr("This is a test discussion"),
+				State:     github.Ptr("open"),
+				CreatedAt: &github.Timestamp{Time: time.Date(2025, 4, 25, 12, 0, 0, 0, time.UTC)},
+			},
+		},
+		{
+			name:        "discussion not found",
+			response:    githubv4mock.ErrorResponse("discussion not found"),
+			expectError: true,
+			errContains: "discussion not found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := githubv4mock.NewQueryMatcher(q, vars, tc.response)
+			httpClient := githubv4mock.NewMockedHTTPClient(matcher)
+			gqlClient := githubv4.NewClient(httpClient)
+			_, handler := GetDiscussion(stubGetGQLClientFn(gqlClient), translations.NullTranslationHelper)
+
+			req := createMCPRequest(map[string]interface{}{"owner": "owner", "repo": "repo", "discussion_id": float64(1)})
+			res, err := handler(context.Background(), req)
+			text := getTextResult(t, res).Text
+
+			if tc.expectError {
+				require.True(t, res.IsError)
+				assert.Contains(t, text, tc.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			var out github.Issue
+			require.NoError(t, json.Unmarshal([]byte(text), &out))
+			assert.Equal(t, *tc.expected.HTMLURL, *out.HTMLURL)
+			assert.Equal(t, *tc.expected.Number, *out.Number)
+			assert.Equal(t, *tc.expected.Body, *out.Body)
+			assert.Equal(t, *tc.expected.State, *out.State)
+		})
+	}
+}
+
+func Test_GetDiscussionComments(t *testing.T) {
+	// Verify tool definition and schema
+	toolDef, _ := GetDiscussionComments(nil, translations.NullTranslationHelper)
+	assert.Equal(t, "get_discussion_comments", toolDef.Name)
+	assert.NotEmpty(t, toolDef.Description)
+	assert.Contains(t, toolDef.InputSchema.Properties, "owner")
+	assert.Contains(t, toolDef.InputSchema.Properties, "repo")
+	assert.Contains(t, toolDef.InputSchema.Properties, "discussion_id")
+	assert.ElementsMatch(t, toolDef.InputSchema.Required, []string{"owner", "repo", "discussion_id"})
+
+	var q struct {
+		Repository struct {
+			Discussion struct {
+				Comments struct {
+					Nodes []struct {
+						Body githubv4.String
+					}
+				} `graphql:"comments(first:100)"`
+			} `graphql:"discussion(number: $discussionID)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+	vars := map[string]interface{}{
+		"owner":        githubv4.String("owner"),
+		"repo":         githubv4.String("repo"),
+		"discussionID": githubv4.Int(1),
+	}
+	mockResponse := githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"discussion": map[string]any{
+				"comments": map[string]any{
+					"nodes": []map[string]any{
+						{"body": "This is the first comment"},
+						{"body": "This is the second comment"},
+					},
+				},
+			},
+		},
+	})
+	matcher := githubv4mock.NewQueryMatcher(q, vars, mockResponse)
+	httpClient := githubv4mock.NewMockedHTTPClient(matcher)
+	gqlClient := githubv4.NewClient(httpClient)
+	_, handler := GetDiscussionComments(stubGetGQLClientFn(gqlClient), translations.NullTranslationHelper)
+
+	request := createMCPRequest(map[string]interface{}{
+		"owner":         "owner",
+		"repo":          "repo",
+		"discussion_id": float64(1),
+	})
+
+	result, err := handler(context.Background(), request)
+	require.NoError(t, err)
+
+	textContent := getTextResult(t, result)
+
+	var returnedComments []*github.IssueComment
+	err = json.Unmarshal([]byte(textContent.Text), &returnedComments)
+	require.NoError(t, err)
+	assert.Len(t, returnedComments, 2)
+	expectedBodies := []string{"This is the first comment", "This is the second comment"}
+	for i, comment := range returnedComments {
+		assert.Equal(t, expectedBodies[i], *comment.Body)
+	}
+}
+
+func Test_ListDiscussionCategories(t *testing.T) {
+	var q struct {
+		Repository struct {
+			DiscussionCategories struct {
+				Nodes []struct {
+					ID   githubv4.ID
+					Name githubv4.String
+				}
+			} `graphql:"discussionCategories(first: 30)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+	vars := map[string]interface{}{
+		"owner": githubv4.String("owner"),
+		"repo":  githubv4.String("repo"),
+	}
+	mockResp := githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"discussionCategories": map[string]any{
+				"nodes": []map[string]any{
+					{"id": "123", "name": "CategoryOne"},
+					{"id": "456", "name": "CategoryTwo"},
+				},
+			},
+		},
+	})
+	matcher := githubv4mock.NewQueryMatcher(q, vars, mockResp)
+	httpClient := githubv4mock.NewMockedHTTPClient(matcher)
+	gqlClient := githubv4.NewClient(httpClient)
+
+	tool, handler := ListDiscussionCategories(stubGetGQLClientFn(gqlClient), translations.NullTranslationHelper)
+	assert.Equal(t, "list_discussion_categories", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "repo")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo"})
+
+	request := createMCPRequest(map[string]interface{}{"owner": "owner", "repo": "repo"})
+	result, err := handler(context.Background(), request)
+	require.NoError(t, err)
+
+	text := getTextResult(t, result).Text
+	var categories []map[string]string
+	require.NoError(t, json.Unmarshal([]byte(text), &categories))
+	assert.Len(t, categories, 2)
+	assert.Equal(t, "123", categories[0]["id"])
+	assert.Equal(t, "CategoryOne", categories[0]["name"])
+	assert.Equal(t, "456", categories[1]["id"])
+	assert.Equal(t, "CategoryTwo", categories[1]["name"])
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -104,6 +104,14 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 			toolsets.NewServerTool(ManageRepositoryNotificationSubscription(getClient, t)),
 		)
 
+	discussions := toolsets.NewToolset("discussions", "GitHub Discussions related tools").
+		AddReadTools(
+			toolsets.NewServerTool(ListDiscussions(getGQLClient, t)),
+			toolsets.NewServerTool(GetDiscussion(getGQLClient, t)),
+			toolsets.NewServerTool(GetDiscussionComments(getGQLClient, t)),
+			toolsets.NewServerTool(ListDiscussionCategories(getGQLClient, t)),
+		)
+
 	// Keep experiments alive so the system doesn't error out when it's always enabled
 	experiments := toolsets.NewToolset("experiments", "Experimental features that are not considered stable yet")
 
@@ -116,6 +124,8 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 	tsg.AddToolset(secretProtection)
 	tsg.AddToolset(notifications)
 	tsg.AddToolset(experiments)
+	tsg.AddToolset(discussions)
+
 	// Enable the requested features
 
 	if err := tsg.EnableToolsets(passedToolsets); err != nil {

--- a/script/get-discussions
+++ b/script/get-discussions
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# echo '{"jsonrpc":"2.0","id":3,"params":{"name":"list_discussions","arguments": {"owner": "github", "repo": "securitylab", "first": 10, "since": "2025-04-01T00:00:00Z"}},"method":"tools/call"}' | go run  cmd/github-mcp-server/main.go stdio  | jq .
+echo '{"jsonrpc":"2.0","id":3,"params":{"name":"list_discussions","arguments": {"owner": "github", "repo": "securitylab", "first": 10, "since": "2025-04-01T00:00:00Z", "sort": "CREATED_AT", "direction": "DESC"}},"method":"tools/call"}' | go run  cmd/github-mcp-server/main.go stdio  | jq .
+


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: #213 

This PR adds support for repository discussions, with the following tools:
- `list_discussions`
- `get_discussion`
- `get_comments`
- `list_discussion_categories`

As there is no support for discussions in the GitHub go library, these tools use the GitHub GraphQL API

### Alternatives

I considered using the REST API, but it's not officially supported yet and lacks some features such as category filtering and pagination, requiring post-treatments.

