### PR TITLE
Separate org and user search

### DIFF
--- a/pkg/github/__toolsnaps__/search_users.snap
+++ b/pkg/github/__toolsnaps__/search_users.snap
@@ -3,7 +3,7 @@
     "title": "Search users",
     "readOnlyHint": true
   },
-  "description": "Search for GitHub users",
+  "description": "Search for GitHub users exclusively",
   "inputSchema": {
     "properties": {
       "order": {
@@ -25,8 +25,8 @@
         "minimum": 1,
         "type": "number"
       },
-      "q": {
-        "description": "Search query using GitHub users search syntax",
+      "query": {
+        "description": "Search query using GitHub users search syntax scoped to type:user",
         "type": "string"
       },
       "sort": {
@@ -40,7 +40,7 @@
       }
     },
     "required": [
-      "q"
+      "query"
     ],
     "type": "object"
   },

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -328,12 +328,12 @@ func Test_SearchUsers(t *testing.T) {
 
 	assert.Equal(t, "search_users", tool.Name)
 	assert.NotEmpty(t, tool.Description)
-	assert.Contains(t, tool.InputSchema.Properties, "q")
+	assert.Contains(t, tool.InputSchema.Properties, "query")
 	assert.Contains(t, tool.InputSchema.Properties, "sort")
 	assert.Contains(t, tool.InputSchema.Properties, "order")
 	assert.Contains(t, tool.InputSchema.Properties, "perPage")
 	assert.Contains(t, tool.InputSchema.Properties, "page")
-	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"q"})
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"query"})
 
 	// Setup mock search results
 	mockSearchResult := &github.UsersSearchResult{
@@ -381,7 +381,7 @@ func Test_SearchUsers(t *testing.T) {
 				),
 			),
 			requestArgs: map[string]interface{}{
-				"q":       "location:finland language:go",
+				"query":   "location:finland language:go",
 				"sort":    "followers",
 				"order":   "desc",
 				"page":    float64(1),
@@ -405,7 +405,7 @@ func Test_SearchUsers(t *testing.T) {
 				),
 			),
 			requestArgs: map[string]interface{}{
-				"q": "location:finland language:go",
+				"query": "location:finland language:go",
 			},
 			expectError:    false,
 			expectedResult: mockSearchResult,
@@ -422,7 +422,7 @@ func Test_SearchUsers(t *testing.T) {
 				),
 			),
 			requestArgs: map[string]interface{}{
-				"q": "invalid:query",
+				"query": "invalid:query",
 			},
 			expectError:    true,
 			expectedErrMsg: "failed to search users",
@@ -470,6 +470,130 @@ func Test_SearchUsers(t *testing.T) {
 				assert.Equal(t, *tc.expectedResult.Users[i].ID, user.ID)
 				assert.Equal(t, *tc.expectedResult.Users[i].HTMLURL, user.ProfileURL)
 				assert.Equal(t, *tc.expectedResult.Users[i].AvatarURL, user.AvatarURL)
+			}
+		})
+	}
+}
+
+func Test_SearchOrgs(t *testing.T) {
+	// Verify tool definition once
+	mockClient := github.NewClient(nil)
+	tool, _ := SearchOrgs(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+
+	assert.Equal(t, "search_orgs", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "query")
+	assert.Contains(t, tool.InputSchema.Properties, "sort")
+	assert.Contains(t, tool.InputSchema.Properties, "order")
+	assert.Contains(t, tool.InputSchema.Properties, "perPage")
+	assert.Contains(t, tool.InputSchema.Properties, "page")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"query"})
+
+	// Setup mock search results
+	mockSearchResult := &github.UsersSearchResult{
+		Total:             github.Ptr(int(2)),
+		IncompleteResults: github.Ptr(false),
+		Users: []*github.User{
+			{
+				Login:     github.Ptr("org-1"),
+				ID:        github.Ptr(int64(111)),
+				HTMLURL:   github.Ptr("https://github.com/org-1"),
+				AvatarURL: github.Ptr("https://avatars.githubusercontent.com/u/111?v=4"),
+			},
+			{
+				Login:     github.Ptr("org-2"),
+				ID:        github.Ptr(int64(222)),
+				HTMLURL:   github.Ptr("https://github.com/org-2"),
+				AvatarURL: github.Ptr("https://avatars.githubusercontent.com/u/222?v=4"),
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		mockedClient   *http.Client
+		requestArgs    map[string]interface{}
+		expectError    bool
+		expectedResult *github.UsersSearchResult
+		expectedErrMsg string
+	}{
+		{
+			name: "successful org search",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.GetSearchUsers,
+					expectQueryParams(t, map[string]string{
+						"q":        "type:org github",
+						"page":     "1",
+						"per_page": "30",
+					}).andThen(
+						mockResponse(t, http.StatusOK, mockSearchResult),
+					),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"query": "github",
+			},
+			expectError:    false,
+			expectedResult: mockSearchResult,
+		},
+		{
+			name: "org search fails",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.GetSearchUsers,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusBadRequest)
+						_, _ = w.Write([]byte(`{"message": "Validation Failed"}`))
+					}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"query": "invalid:query",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to search orgs",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup client with mock
+			client := github.NewClient(tc.mockedClient)
+			_, handler := SearchOrgs(stubGetClientFn(client), translations.NullTranslationHelper)
+
+			// Create call request
+			request := createMCPRequest(tc.requestArgs)
+
+			// Call handler
+			result, err := handler(context.Background(), request)
+
+			// Verify results
+			if tc.expectError {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				errorContent := getErrorResult(t, result)
+				assert.Contains(t, errorContent.Text, tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			textContent := getTextResult(t, result)
+
+			// Unmarshal and verify the result
+			var returnedResult MinimalSearchUsersResult
+			err = json.Unmarshal([]byte(textContent.Text), &returnedResult)
+			require.NoError(t, err)
+			assert.Equal(t, *tc.expectedResult.Total, returnedResult.TotalCount)
+			assert.Equal(t, *tc.expectedResult.IncompleteResults, returnedResult.IncompleteResults)
+			assert.Len(t, returnedResult.Items, len(tc.expectedResult.Users))
+			for i, org := range returnedResult.Items {
+				assert.Equal(t, *tc.expectedResult.Users[i].Login, org.Login)
+				assert.Equal(t, *tc.expectedResult.Users[i].ID, org.ID)
+				assert.Equal(t, *tc.expectedResult.Users[i].HTMLURL, org.ProfileURL)
+				assert.Equal(t, *tc.expectedResult.Users[i].AvatarURL, org.AvatarURL)
 			}
 		})
 	}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -64,6 +64,10 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 		AddReadTools(
 			toolsets.NewServerTool(SearchUsers(getClient, t)),
 		)
+	orgs := toolsets.NewToolset("orgs", "GitHub Organization related tools").
+		AddReadTools(
+			toolsets.NewServerTool(SearchOrgs(getClient, t)),
+		)
 	pullRequests := toolsets.NewToolset("pull_requests", "GitHub Pull Request related tools").
 		AddReadTools(
 			toolsets.NewServerTool(GetPullRequest(getClient, t)),
@@ -143,6 +147,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 	tsg.AddToolset(contextTools)
 	tsg.AddToolset(repos)
 	tsg.AddToolset(issues)
+	tsg.AddToolset(orgs)
 	tsg.AddToolset(users)
 	tsg.AddToolset(pullRequests)
 	tsg.AddToolset(actions)


### PR DESCRIPTION
In order to make separation of certain objects more clear we should separate them. This means orgs and users are not the same.

A follow-up will be to separate issue and PR search by also scoping the queries and producing separate functions. It is best for the LLM that it has clear boundaries, and concepts are consistent, rather than accepting the legacy API quirks.