### PR TITLE
chore: separate toolset creation from init and use typed error

### DIFF
--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -113,26 +113,22 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 	}
 
 	// Create default toolsets
-	toolsets, err := github.InitToolsets(
-		enabledToolsets,
-		cfg.ReadOnly,
-		getClient,
-		getGQLClient,
-		cfg.Translator,
-	)
+	tsg := github.DefaultToolsetGroup(cfg.ReadOnly, getClient, getGQLClient, cfg.Translator)
+	err = tsg.EnableToolsets(enabledToolsets)
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize toolsets: %w", err)
+		return nil, fmt.Errorf("failed to enable toolsets: %w", err)
 	}
 
 	context := github.InitContextToolset(getClient, cfg.Translator)
 	github.RegisterResources(ghServer, getClient, cfg.Translator)
 
 	// Register the tools with the server
-	toolsets.RegisterTools(ghServer)
+	tsg.RegisterTools(ghServer)
 	context.RegisterTools(ghServer)
 
 	if cfg.DynamicToolsets {
-		dynamic := github.InitDynamicToolset(ghServer, toolsets, cfg.Translator)
+		dynamic := github.InitDynamicToolset(ghServer, tsg, cfg.Translator)
 		dynamic.RegisterTools(ghServer)
 	}
 

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -15,8 +15,7 @@ type GetGQLClientFn func(context.Context) (*githubv4.Client, error)
 
 var DefaultTools = []string{"all"}
 
-func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn, getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) (*toolsets.ToolsetGroup, error) {
-	// Create a new toolset group
+func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetGQLClientFn, t translations.TranslationHelperFunc) *toolsets.ToolsetGroup {
 	tsg := toolsets.NewToolsetGroup(readOnly)
 
 	// Define all available features with their default state (disabled)
@@ -116,13 +115,8 @@ func InitToolsets(passedToolsets []string, readOnly bool, getClient GetClientFn,
 	tsg.AddToolset(secretProtection)
 	tsg.AddToolset(notifications)
 	tsg.AddToolset(experiments)
-	// Enable the requested features
 
-	if err := tsg.EnableToolsets(passedToolsets); err != nil {
-		return nil, err
-	}
-
-	return tsg, nil
+	return tsg
 }
 
 func InitContextToolset(getClient GetClientFn, t translations.TranslationHelperFunc) *toolsets.Toolset {

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -1,6 +1,7 @@
 package toolsets
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -151,6 +152,9 @@ func TestEnableToolsets(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error when enabling list with non-existent toolset")
 	}
+	if !errors.Is(err, NewToolsetDoesNotExistError("non-existent")) {
+		t.Errorf("Expected ToolsetDoesNotExistError when enabling non-existent toolset, got: %v", err)
+	}
 
 	// Test with empty list
 	err = tsg.EnableToolsets([]string{})
@@ -207,7 +211,7 @@ func TestEnableEverything(t *testing.T) {
 func TestIsEnabledWithEverythingOn(t *testing.T) {
 	tsg := NewToolsetGroup(false)
 
-	// Enable "everything"
+	// Enable "all"
 	err := tsg.EnableToolsets([]string{"all"})
 	if err != nil {
 		t.Errorf("Expected no error when enabling 'all', got: %v", err)
@@ -220,5 +224,29 @@ func TestIsEnabledWithEverythingOn(t *testing.T) {
 
 	if !tsg.IsEnabled("another-toolset") {
 		t.Error("Expected IsEnabled to return true for any toolset when everythingOn is true")
+	}
+}
+
+func TestToolsetGroup_GetToolset(t *testing.T) {
+	tsg := NewToolsetGroup(false)
+	toolset := NewToolset("my-toolset", "desc")
+	tsg.AddToolset(toolset)
+
+	// Should find the toolset
+	got, err := tsg.GetToolset("my-toolset")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != toolset {
+		t.Errorf("expected to get the same toolset instance")
+	}
+
+	// Should not find a non-existent toolset
+	_, err = tsg.GetToolset("does-not-exist")
+	if err == nil {
+		t.Error("expected error for missing toolset, got nil")
+	}
+	if !errors.Is(err, NewToolsetDoesNotExistError("does-not-exist")) {
+		t.Errorf("expected error to be ToolsetDoesNotExistError, got %v", err)
 	}
 }


### PR DESCRIPTION
This PR makes it easier to identify the error when a toolset does not exist, and also separates toolset creation from initialization, so it's possible to compose toolsets in more ways.