### PR TITLE
add "Usage with Claude Code" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ More about using MCP server tools in VS Code's [agent mode documentation](https:
 }
 ```
 
+### Usage with Claude Code
+
+```sh
+claude mcp add-json github '
+{
+  "command": "docker",
+  "args": [
+    "run",
+    "-i",
+    "--rm",
+    "-e",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+    "ghcr.io/github/github-mcp-server"
+  ],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+  }
+}
+'
+```
+
+
 ### Build from source
 
 If you don't have Docker, you can use `go build` to build the binary in the


### PR DESCRIPTION
There's no mention to Claude Code in README.md, but there should be.

The usage is described in https://docs.anthropic.com/en/docs/claude-code/tutorials#set-up-model-context-protocol-mcp