### PR TITLE
Add toolsnaps for every tool

### DIFF
--- a/internal/toolsnaps/toolsnaps.go
+++ b/internal/toolsnaps/toolsnaps.go
@@ -60,7 +60,7 @@ func Test(toolName string, tool any) error {
 	diff := toolNode.Diff(snapNode, jd.SET).Render()
 	if diff != "" {
 		// If there is a difference, we return an error with the diff
-		return fmt.Errorf("tool schema for %s has changed unexpectedly:\n%s", toolName, diff)
+		return fmt.Errorf("tool schema for %s has changed unexpectedly:\n%s\nrun with `UPDATE_TOOLSNAPS=true` if this is expected", toolName, diff)
 	}
 
 	return nil

--- a/internal/toolsnaps/toolsnaps_test.go
+++ b/internal/toolsnaps/toolsnaps_test.go
@@ -43,6 +43,9 @@ func TestSnapshotDoesNotExistNotInCI(t *testing.T) {
 
 func TestSnapshotDoesNotExistInCI(t *testing.T) {
 	withIsolatedWorkingDir(t)
+	// Ensure that UPDATE_TOOLSNAPS is not set for this test, which it might be if someone is running
+	// UPDATE_TOOLSNAPS=true go test ./...
+	t.Setenv("UPDATE_TOOLSNAPS", "false")
 
 	// Given we are running in CI
 	t.Setenv("GITHUB_ACTIONS", "true")
@@ -74,6 +77,9 @@ func TestSnapshotExistsMatch(t *testing.T) {
 
 func TestSnapshotExistsDiff(t *testing.T) {
 	withIsolatedWorkingDir(t)
+	// Ensure that UPDATE_TOOLSNAPS is not set for this test, which it might be if someone is running
+	// UPDATE_TOOLSNAPS=true go test ./...
+	t.Setenv("UPDATE_TOOLSNAPS", "false")
 
 	// Given a non-matching snapshot file exists
 	require.NoError(t, os.MkdirAll("__toolsnaps__", 0700))
@@ -109,6 +115,9 @@ func TestUpdateToolsnaps(t *testing.T) {
 
 func TestMalformedSnapshotJSON(t *testing.T) {
 	withIsolatedWorkingDir(t)
+	// Ensure that UPDATE_TOOLSNAPS is not set for this test, which it might be if someone is running
+	// UPDATE_TOOLSNAPS=true go test ./...
+	t.Setenv("UPDATE_TOOLSNAPS", "false")
 
 	// Given a malformed snapshot file exists
 	require.NoError(t, os.MkdirAll("__toolsnaps__", 0700))

--- a/pkg/github/__toolsnaps__/add_issue_comment.snap
+++ b/pkg/github/__toolsnaps__/add_issue_comment.snap
@@ -1,0 +1,35 @@
+{
+  "annotations": {
+    "title": "Add comment to issue",
+    "readOnlyHint": false
+  },
+  "description": "Add a comment to a specific issue in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "Comment content",
+        "type": "string"
+      },
+      "issue_number": {
+        "description": "Issue number to comment on",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "issue_number",
+      "body"
+    ],
+    "type": "object"
+  },
+  "name": "add_issue_comment"
+}

--- a/pkg/github/__toolsnaps__/add_pull_request_review_comment_to_pending_review.snap
+++ b/pkg/github/__toolsnaps__/add_pull_request_review_comment_to_pending_review.snap
@@ -1,0 +1,73 @@
+{
+  "annotations": {
+    "title": "Add comment to the requester's latest pending pull request review",
+    "readOnlyHint": false
+  },
+  "description": "Add a comment to the requester's latest pending pull request review, a pending review needs to already exist to call this (check with the user if not sure).",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "The text of the review comment",
+        "type": "string"
+      },
+      "line": {
+        "description": "The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "path": {
+        "description": "The relative path to the file that necessitates a comment",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "side": {
+        "description": "The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state",
+        "enum": [
+          "LEFT",
+          "RIGHT"
+        ],
+        "type": "string"
+      },
+      "startLine": {
+        "description": "For multi-line comments, the first line of the range that the comment applies to",
+        "type": "number"
+      },
+      "startSide": {
+        "description": "For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state",
+        "enum": [
+          "LEFT",
+          "RIGHT"
+        ],
+        "type": "string"
+      },
+      "subjectType": {
+        "description": "The level at which the comment is targeted",
+        "enum": [
+          "FILE",
+          "LINE"
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber",
+      "path",
+      "body",
+      "subjectType"
+    ],
+    "type": "object"
+  },
+  "name": "add_pull_request_review_comment_to_pending_review"
+}

--- a/pkg/github/__toolsnaps__/assign_copilot_to_issue.snap
+++ b/pkg/github/__toolsnaps__/assign_copilot_to_issue.snap
@@ -1,0 +1,31 @@
+{
+  "annotations": {
+    "title": "Assign Copilot to issue",
+    "readOnlyHint": false,
+    "idempotentHint": true
+  },
+  "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+  "inputSchema": {
+    "properties": {
+      "issueNumber": {
+        "description": "Issue number",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "issueNumber"
+    ],
+    "type": "object"
+  },
+  "name": "assign_copilot_to_issue"
+}

--- a/pkg/github/__toolsnaps__/create_and_submit_pull_request_review.snap
+++ b/pkg/github/__toolsnaps__/create_and_submit_pull_request_review.snap
@@ -1,0 +1,49 @@
+{
+  "annotations": {
+    "title": "Create and submit a pull request review without comments",
+    "readOnlyHint": false
+  },
+  "description": "Create and submit a review for a pull request without review comments.",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "Review comment text",
+        "type": "string"
+      },
+      "commitID": {
+        "description": "SHA of commit to review",
+        "type": "string"
+      },
+      "event": {
+        "description": "Review action to perform",
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber",
+      "body",
+      "event"
+    ],
+    "type": "object"
+  },
+  "name": "create_and_submit_pull_request_review"
+}

--- a/pkg/github/__toolsnaps__/create_branch.snap
+++ b/pkg/github/__toolsnaps__/create_branch.snap
@@ -1,0 +1,34 @@
+{
+  "annotations": {
+    "title": "Create branch",
+    "readOnlyHint": false
+  },
+  "description": "Create a new branch in a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "branch": {
+        "description": "Name for new branch",
+        "type": "string"
+      },
+      "from_branch": {
+        "description": "Source branch (defaults to repo default)",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "branch"
+    ],
+    "type": "object"
+  },
+  "name": "create_branch"
+}

--- a/pkg/github/__toolsnaps__/create_issue.snap
+++ b/pkg/github/__toolsnaps__/create_issue.snap
@@ -1,0 +1,52 @@
+{
+  "annotations": {
+    "title": "Open new issue",
+    "readOnlyHint": false
+  },
+  "description": "Create a new issue in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "assignees": {
+        "description": "Usernames to assign to this issue",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "body": {
+        "description": "Issue body content",
+        "type": "string"
+      },
+      "labels": {
+        "description": "Labels to apply to this issue",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "milestone": {
+        "description": "Milestone number",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "title": {
+        "description": "Issue title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "title"
+    ],
+    "type": "object"
+  },
+  "name": "create_issue"
+}

--- a/pkg/github/__toolsnaps__/create_or_update_file.snap
+++ b/pkg/github/__toolsnaps__/create_or_update_file.snap
@@ -1,0 +1,49 @@
+{
+  "annotations": {
+    "title": "Create or update file",
+    "readOnlyHint": false
+  },
+  "description": "Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update.",
+  "inputSchema": {
+    "properties": {
+      "branch": {
+        "description": "Branch to create/update the file in",
+        "type": "string"
+      },
+      "content": {
+        "description": "Content of the file",
+        "type": "string"
+      },
+      "message": {
+        "description": "Commit message",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner (username or organization)",
+        "type": "string"
+      },
+      "path": {
+        "description": "Path where to create/update the file",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "sha": {
+        "description": "SHA of file being replaced (for updates)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "path",
+      "content",
+      "message",
+      "branch"
+    ],
+    "type": "object"
+  },
+  "name": "create_or_update_file"
+}

--- a/pkg/github/__toolsnaps__/create_pending_pull_request_review.snap
+++ b/pkg/github/__toolsnaps__/create_pending_pull_request_review.snap
@@ -1,0 +1,34 @@
+{
+  "annotations": {
+    "title": "Create pending pull request review",
+    "readOnlyHint": false
+  },
+  "description": "Create a pending review for a pull request. Call this first before attempting to add comments to a pending review, and ultimately submitting it. A pending pull request review means a pull request review, it is pending because you create it first and submit it later, and the PR author will not see it until it is submitted.",
+  "inputSchema": {
+    "properties": {
+      "commitID": {
+        "description": "SHA of commit to review",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "create_pending_pull_request_review"
+}

--- a/pkg/github/__toolsnaps__/create_pull_request.snap
+++ b/pkg/github/__toolsnaps__/create_pull_request.snap
@@ -1,0 +1,52 @@
+{
+  "annotations": {
+    "title": "Open new pull request",
+    "readOnlyHint": false
+  },
+  "description": "Create a new pull request in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "base": {
+        "description": "Branch to merge into",
+        "type": "string"
+      },
+      "body": {
+        "description": "PR description",
+        "type": "string"
+      },
+      "draft": {
+        "description": "Create as draft PR",
+        "type": "boolean"
+      },
+      "head": {
+        "description": "Branch containing changes",
+        "type": "string"
+      },
+      "maintainer_can_modify": {
+        "description": "Allow maintainer edits",
+        "type": "boolean"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "title": {
+        "description": "PR title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "title",
+      "head",
+      "base"
+    ],
+    "type": "object"
+  },
+  "name": "create_pull_request"
+}

--- a/pkg/github/__toolsnaps__/create_repository.snap
+++ b/pkg/github/__toolsnaps__/create_repository.snap
@@ -1,0 +1,32 @@
+{
+  "annotations": {
+    "title": "Create repository",
+    "readOnlyHint": false
+  },
+  "description": "Create a new GitHub repository in your account",
+  "inputSchema": {
+    "properties": {
+      "autoInit": {
+        "description": "Initialize with README",
+        "type": "boolean"
+      },
+      "description": {
+        "description": "Repository description",
+        "type": "string"
+      },
+      "name": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "private": {
+        "description": "Whether repo should be private",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "type": "object"
+  },
+  "name": "create_repository"
+}

--- a/pkg/github/__toolsnaps__/delete_file.snap
+++ b/pkg/github/__toolsnaps__/delete_file.snap
@@ -1,0 +1,41 @@
+{
+  "annotations": {
+    "title": "Delete file",
+    "readOnlyHint": false,
+    "destructiveHint": true
+  },
+  "description": "Delete a file from a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "branch": {
+        "description": "Branch to delete the file from",
+        "type": "string"
+      },
+      "message": {
+        "description": "Commit message",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner (username or organization)",
+        "type": "string"
+      },
+      "path": {
+        "description": "Path to the file to delete",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "path",
+      "message",
+      "branch"
+    ],
+    "type": "object"
+  },
+  "name": "delete_file"
+}

--- a/pkg/github/__toolsnaps__/delete_pending_pull_request_review.snap
+++ b/pkg/github/__toolsnaps__/delete_pending_pull_request_review.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Delete the requester's latest pending pull request review",
+    "readOnlyHint": false
+  },
+  "description": "Delete the requester's latest pending pull request review. Use this after the user decides not to submit a pending review, if you don't know if they already created one then check first.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "delete_pending_pull_request_review"
+}

--- a/pkg/github/__toolsnaps__/dismiss_notification.snap
+++ b/pkg/github/__toolsnaps__/dismiss_notification.snap
@@ -1,0 +1,28 @@
+{
+  "annotations": {
+    "title": "Dismiss notification",
+    "readOnlyHint": false
+  },
+  "description": "Dismiss a notification by marking it as read or done",
+  "inputSchema": {
+    "properties": {
+      "state": {
+        "description": "The new state of the notification (read/done)",
+        "enum": [
+          "read",
+          "done"
+        ],
+        "type": "string"
+      },
+      "threadID": {
+        "description": "The ID of the notification thread",
+        "type": "string"
+      }
+    },
+    "required": [
+      "threadID"
+    ],
+    "type": "object"
+  },
+  "name": "dismiss_notification"
+}

--- a/pkg/github/__toolsnaps__/fork_repository.snap
+++ b/pkg/github/__toolsnaps__/fork_repository.snap
@@ -1,0 +1,29 @@
+{
+  "annotations": {
+    "title": "Fork repository",
+    "readOnlyHint": false
+  },
+  "description": "Fork a GitHub repository to your account or specified organization",
+  "inputSchema": {
+    "properties": {
+      "organization": {
+        "description": "Organization to fork to",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo"
+    ],
+    "type": "object"
+  },
+  "name": "fork_repository"
+}

--- a/pkg/github/__toolsnaps__/get_code_scanning_alert.snap
+++ b/pkg/github/__toolsnaps__/get_code_scanning_alert.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get code scanning alert",
+    "readOnlyHint": true
+  },
+  "description": "Get details of a specific code scanning alert in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "alertNumber": {
+        "description": "The number of the alert.",
+        "type": "number"
+      },
+      "owner": {
+        "description": "The owner of the repository.",
+        "type": "string"
+      },
+      "repo": {
+        "description": "The name of the repository.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "alertNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_code_scanning_alert"
+}

--- a/pkg/github/__toolsnaps__/get_commit.snap
+++ b/pkg/github/__toolsnaps__/get_commit.snap
@@ -1,0 +1,41 @@
+{
+  "annotations": {
+    "title": "Get commit details",
+    "readOnlyHint": true
+  },
+  "description": "Get details for a commit from a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "sha": {
+        "description": "Commit SHA, branch name, or tag name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "sha"
+    ],
+    "type": "object"
+  },
+  "name": "get_commit"
+}

--- a/pkg/github/__toolsnaps__/get_file_contents.snap
+++ b/pkg/github/__toolsnaps__/get_file_contents.snap
@@ -1,0 +1,34 @@
+{
+  "annotations": {
+    "title": "Get file or directory contents",
+    "readOnlyHint": true
+  },
+  "description": "Get the contents of a file or directory from a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "branch": {
+        "description": "Branch to get contents from",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner (username or organization)",
+        "type": "string"
+      },
+      "path": {
+        "description": "Path to file/directory (directories must end with a slash '/')",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "path"
+    ],
+    "type": "object"
+  },
+  "name": "get_file_contents"
+}

--- a/pkg/github/__toolsnaps__/get_issue.snap
+++ b/pkg/github/__toolsnaps__/get_issue.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get issue details",
+    "readOnlyHint": true
+  },
+  "description": "Get details of a specific issue in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "issue_number": {
+        "description": "The number of the issue",
+        "type": "number"
+      },
+      "owner": {
+        "description": "The owner of the repository",
+        "type": "string"
+      },
+      "repo": {
+        "description": "The name of the repository",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "issue_number"
+    ],
+    "type": "object"
+  },
+  "name": "get_issue"
+}

--- a/pkg/github/__toolsnaps__/get_issue_comments.snap
+++ b/pkg/github/__toolsnaps__/get_issue_comments.snap
@@ -1,0 +1,38 @@
+{
+  "annotations": {
+    "title": "Get issue comments",
+    "readOnlyHint": true
+  },
+  "description": "Get comments for a specific issue in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "issue_number": {
+        "description": "Issue number",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number",
+        "type": "number"
+      },
+      "per_page": {
+        "description": "Number of records per page",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "issue_number"
+    ],
+    "type": "object"
+  },
+  "name": "get_issue_comments"
+}

--- a/pkg/github/__toolsnaps__/get_notification_details.snap
+++ b/pkg/github/__toolsnaps__/get_notification_details.snap
@@ -1,0 +1,20 @@
+{
+  "annotations": {
+    "title": "Get notification details",
+    "readOnlyHint": true
+  },
+  "description": "Get detailed information for a specific GitHub notification, always call this tool when the user asks for details about a specific notification, if you don't know the ID list notifications first.",
+  "inputSchema": {
+    "properties": {
+      "notificationID": {
+        "description": "The ID of the notification",
+        "type": "string"
+      }
+    },
+    "required": [
+      "notificationID"
+    ],
+    "type": "object"
+  },
+  "name": "get_notification_details"
+}

--- a/pkg/github/__toolsnaps__/get_pull_request.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get pull request details",
+    "readOnlyHint": true
+  },
+  "description": "Get details of a specific pull request in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_pull_request"
+}

--- a/pkg/github/__toolsnaps__/get_pull_request_comments.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request_comments.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get pull request comments",
+    "readOnlyHint": true
+  },
+  "description": "Get comments for a specific pull request.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_pull_request_comments"
+}

--- a/pkg/github/__toolsnaps__/get_pull_request_diff.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request_diff.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get pull request diff",
+    "readOnlyHint": true
+  },
+  "description": "Get the diff of a pull request.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_pull_request_diff"
+}

--- a/pkg/github/__toolsnaps__/get_pull_request_files.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request_files.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get pull request files",
+    "readOnlyHint": true
+  },
+  "description": "Get the files changed in a specific pull request.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_pull_request_files"
+}

--- a/pkg/github/__toolsnaps__/get_pull_request_reviews.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request_reviews.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get pull request reviews",
+    "readOnlyHint": true
+  },
+  "description": "Get reviews for a specific pull request.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_pull_request_reviews"
+}

--- a/pkg/github/__toolsnaps__/get_pull_request_status.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request_status.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get pull request status checks",
+    "readOnlyHint": true
+  },
+  "description": "Get the status of a specific pull request.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "get_pull_request_status"
+}

--- a/pkg/github/__toolsnaps__/get_tag.snap
+++ b/pkg/github/__toolsnaps__/get_tag.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Get tag details",
+    "readOnlyHint": true
+  },
+  "description": "Get details about a specific git tag in a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "tag": {
+        "description": "Tag name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "tag"
+    ],
+    "type": "object"
+  },
+  "name": "get_tag"
+}

--- a/pkg/github/__toolsnaps__/list_branches.snap
+++ b/pkg/github/__toolsnaps__/list_branches.snap
@@ -1,0 +1,36 @@
+{
+  "annotations": {
+    "title": "List branches",
+    "readOnlyHint": true
+  },
+  "description": "List branches in a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo"
+    ],
+    "type": "object"
+  },
+  "name": "list_branches"
+}

--- a/pkg/github/__toolsnaps__/list_code_scanning_alerts.snap
+++ b/pkg/github/__toolsnaps__/list_code_scanning_alerts.snap
@@ -1,0 +1,57 @@
+{
+  "annotations": {
+    "title": "List code scanning alerts",
+    "readOnlyHint": true
+  },
+  "description": "List code scanning alerts in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "The owner of the repository.",
+        "type": "string"
+      },
+      "ref": {
+        "description": "The Git reference for the results you want to list.",
+        "type": "string"
+      },
+      "repo": {
+        "description": "The name of the repository.",
+        "type": "string"
+      },
+      "severity": {
+        "description": "Filter code scanning alerts by severity",
+        "enum": [
+          "critical",
+          "high",
+          "medium",
+          "low",
+          "warning",
+          "note",
+          "error"
+        ],
+        "type": "string"
+      },
+      "state": {
+        "default": "open",
+        "description": "Filter code scanning alerts by state. Defaults to open",
+        "enum": [
+          "open",
+          "closed",
+          "dismissed",
+          "fixed"
+        ],
+        "type": "string"
+      },
+      "tool_name": {
+        "description": "The name of the tool used for code scanning.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo"
+    ],
+    "type": "object"
+  },
+  "name": "list_code_scanning_alerts"
+}

--- a/pkg/github/__toolsnaps__/list_commits.snap
+++ b/pkg/github/__toolsnaps__/list_commits.snap
@@ -1,0 +1,40 @@
+{
+  "annotations": {
+    "title": "List commits",
+    "readOnlyHint": true
+  },
+  "description": "Get list of commits of a branch in a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "sha": {
+        "description": "SHA or Branch name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo"
+    ],
+    "type": "object"
+  },
+  "name": "list_commits"
+}

--- a/pkg/github/__toolsnaps__/list_issues.snap
+++ b/pkg/github/__toolsnaps__/list_issues.snap
@@ -1,0 +1,73 @@
+{
+  "annotations": {
+    "title": "List issues",
+    "readOnlyHint": true
+  },
+  "description": "List issues in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "direction": {
+        "description": "Sort direction",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "labels": {
+        "description": "Filter by labels",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "since": {
+        "description": "Filter by date (ISO 8601 timestamp)",
+        "type": "string"
+      },
+      "sort": {
+        "description": "Sort order",
+        "enum": [
+          "created",
+          "updated",
+          "comments"
+        ],
+        "type": "string"
+      },
+      "state": {
+        "description": "Filter by state",
+        "enum": [
+          "open",
+          "closed",
+          "all"
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo"
+    ],
+    "type": "object"
+  },
+  "name": "list_issues"
+}

--- a/pkg/github/__toolsnaps__/list_notifications.snap
+++ b/pkg/github/__toolsnaps__/list_notifications.snap
@@ -1,0 +1,49 @@
+{
+  "annotations": {
+    "title": "List notifications",
+    "readOnlyHint": true
+  },
+  "description": "Lists all GitHub notifications for the authenticated user, including unread notifications, mentions, review requests, assignments, and updates on issues or pull requests. Use this tool whenever the user asks what to work on next, requests a summary of their GitHub activity, wants to see pending reviews, or needs to check for new updates or tasks. This tool is the primary way to discover actionable items, reminders, and outstanding work on GitHub. Always call this tool when asked what to work on next, what is pending, or what needs attention in GitHub.",
+  "inputSchema": {
+    "properties": {
+      "before": {
+        "description": "Only show notifications updated before the given time (ISO 8601 format)",
+        "type": "string"
+      },
+      "filter": {
+        "description": "Filter notifications to, use default unless specified. Read notifications are ones that have already been acknowledged by the user. Participating notifications are those that the user is directly involved in, such as issues or pull requests they have commented on or created.",
+        "enum": [
+          "default",
+          "include_read_notifications",
+          "only_participating"
+        ],
+        "type": "string"
+      },
+      "owner": {
+        "description": "Optional repository owner. If provided with repo, only notifications for this repository are listed.",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "Optional repository name. If provided with owner, only notifications for this repository are listed.",
+        "type": "string"
+      },
+      "since": {
+        "description": "Only show notifications updated after the given time (ISO 8601 format)",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "name": "list_notifications"
+}

--- a/pkg/github/__toolsnaps__/list_pull_requests.snap
+++ b/pkg/github/__toolsnaps__/list_pull_requests.snap
@@ -1,0 +1,71 @@
+{
+  "annotations": {
+    "title": "List pull requests",
+    "readOnlyHint": true
+  },
+  "description": "List pull requests in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "base": {
+        "description": "Filter by base branch",
+        "type": "string"
+      },
+      "direction": {
+        "description": "Sort direction",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "head": {
+        "description": "Filter by head user/org and branch",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "sort": {
+        "description": "Sort by",
+        "enum": [
+          "created",
+          "updated",
+          "popularity",
+          "long-running"
+        ],
+        "type": "string"
+      },
+      "state": {
+        "description": "Filter by state",
+        "enum": [
+          "open",
+          "closed",
+          "all"
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo"
+    ],
+    "type": "object"
+  },
+  "name": "list_pull_requests"
+}

--- a/pkg/github/__toolsnaps__/list_tags.snap
+++ b/pkg/github/__toolsnaps__/list_tags.snap
@@ -1,0 +1,36 @@
+{
+  "annotations": {
+    "title": "List tags",
+    "readOnlyHint": true
+  },
+  "description": "List git tags in a GitHub repository",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo"
+    ],
+    "type": "object"
+  },
+  "name": "list_tags"
+}

--- a/pkg/github/__toolsnaps__/manage_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_notification_subscription.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Manage notification subscription",
+    "readOnlyHint": false
+  },
+  "description": "Manage a notification subscription: ignore, watch, or delete a notification thread subscription.",
+  "inputSchema": {
+    "properties": {
+      "action": {
+        "description": "Action to perform: ignore, watch, or delete the notification subscription.",
+        "enum": [
+          "ignore",
+          "watch",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "notificationID": {
+        "description": "The ID of the notification thread.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "notificationID",
+      "action"
+    ],
+    "type": "object"
+  },
+  "name": "manage_notification_subscription"
+}

--- a/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
@@ -1,0 +1,35 @@
+{
+  "annotations": {
+    "title": "Manage repository notification subscription",
+    "readOnlyHint": false
+  },
+  "description": "Manage a repository notification subscription: ignore, watch, or delete repository notifications subscription for the provided repository.",
+  "inputSchema": {
+    "properties": {
+      "action": {
+        "description": "Action to perform: ignore, watch, or delete the repository notification subscription.",
+        "enum": [
+          "ignore",
+          "watch",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "owner": {
+        "description": "The account owner of the repository.",
+        "type": "string"
+      },
+      "repo": {
+        "description": "The name of the repository.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "action"
+    ],
+    "type": "object"
+  },
+  "name": "manage_repository_notification_subscription"
+}

--- a/pkg/github/__toolsnaps__/mark_all_notifications_read.snap
+++ b/pkg/github/__toolsnaps__/mark_all_notifications_read.snap
@@ -1,0 +1,25 @@
+{
+  "annotations": {
+    "title": "Mark all notifications as read",
+    "readOnlyHint": false
+  },
+  "description": "Mark all notifications as read",
+  "inputSchema": {
+    "properties": {
+      "lastReadAt": {
+        "description": "Describes the last point that notifications were checked (optional). Default: Now",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Optional repository owner. If provided with repo, only notifications for this repository are marked as read.",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Optional repository name. If provided with owner, only notifications for this repository are marked as read.",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "name": "mark_all_notifications_read"
+}

--- a/pkg/github/__toolsnaps__/merge_pull_request.snap
+++ b/pkg/github/__toolsnaps__/merge_pull_request.snap
@@ -1,0 +1,47 @@
+{
+  "annotations": {
+    "title": "Merge pull request",
+    "readOnlyHint": false
+  },
+  "description": "Merge a pull request in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "commit_message": {
+        "description": "Extra detail for merge commit",
+        "type": "string"
+      },
+      "commit_title": {
+        "description": "Title for merge commit",
+        "type": "string"
+      },
+      "merge_method": {
+        "description": "Merge method",
+        "enum": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "merge_pull_request"
+}

--- a/pkg/github/__toolsnaps__/push_files.snap
+++ b/pkg/github/__toolsnaps__/push_files.snap
@@ -1,0 +1,58 @@
+{
+  "annotations": {
+    "title": "Push files to repository",
+    "readOnlyHint": false
+  },
+  "description": "Push multiple files to a GitHub repository in a single commit",
+  "inputSchema": {
+    "properties": {
+      "branch": {
+        "description": "Branch to push to",
+        "type": "string"
+      },
+      "files": {
+        "description": "Array of file objects to push, each object with path (string) and content (string)",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "description": "file content",
+              "type": "string"
+            },
+            "path": {
+              "description": "path to the file",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "content"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "message": {
+        "description": "Commit message",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "branch",
+      "files",
+      "message"
+    ],
+    "type": "object"
+  },
+  "name": "push_files"
+}

--- a/pkg/github/__toolsnaps__/request_copilot_review.snap
+++ b/pkg/github/__toolsnaps__/request_copilot_review.snap
@@ -1,0 +1,30 @@
+{
+  "annotations": {
+    "title": "Request Copilot review",
+    "readOnlyHint": false
+  },
+  "description": "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "request_copilot_review"
+}

--- a/pkg/github/__toolsnaps__/search_code.snap
+++ b/pkg/github/__toolsnaps__/search_code.snap
@@ -1,0 +1,43 @@
+{
+  "annotations": {
+    "title": "Search code",
+    "readOnlyHint": true
+  },
+  "description": "Search for code across GitHub repositories",
+  "inputSchema": {
+    "properties": {
+      "order": {
+        "description": "Sort order",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "q": {
+        "description": "Search query using GitHub code search syntax",
+        "type": "string"
+      },
+      "sort": {
+        "description": "Sort field ('indexed' only)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "q"
+    ],
+    "type": "object"
+  },
+  "name": "search_code"
+}

--- a/pkg/github/__toolsnaps__/search_issues.snap
+++ b/pkg/github/__toolsnaps__/search_issues.snap
@@ -1,0 +1,56 @@
+{
+  "annotations": {
+    "title": "Search issues",
+    "readOnlyHint": true
+  },
+  "description": "Search for issues in GitHub repositories.",
+  "inputSchema": {
+    "properties": {
+      "order": {
+        "description": "Sort order",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "q": {
+        "description": "Search query using GitHub issues search syntax",
+        "type": "string"
+      },
+      "sort": {
+        "description": "Sort field by number of matches of categories, defaults to best match",
+        "enum": [
+          "comments",
+          "reactions",
+          "reactions-+1",
+          "reactions--1",
+          "reactions-smile",
+          "reactions-thinking_face",
+          "reactions-heart",
+          "reactions-tada",
+          "interactions",
+          "created",
+          "updated"
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "q"
+    ],
+    "type": "object"
+  },
+  "name": "search_issues"
+}

--- a/pkg/github/__toolsnaps__/search_repositories.snap
+++ b/pkg/github/__toolsnaps__/search_repositories.snap
@@ -1,0 +1,31 @@
+{
+  "annotations": {
+    "title": "Search repositories",
+    "readOnlyHint": true
+  },
+  "description": "Search for GitHub repositories",
+  "inputSchema": {
+    "properties": {
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "query": {
+        "description": "Search query",
+        "type": "string"
+      }
+    },
+    "required": [
+      "query"
+    ],
+    "type": "object"
+  },
+  "name": "search_repositories"
+}

--- a/pkg/github/__toolsnaps__/search_users.snap
+++ b/pkg/github/__toolsnaps__/search_users.snap
@@ -1,0 +1,48 @@
+{
+  "annotations": {
+    "title": "Search users",
+    "readOnlyHint": true
+  },
+  "description": "Search for GitHub users",
+  "inputSchema": {
+    "properties": {
+      "order": {
+        "description": "Sort order",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "q": {
+        "description": "Search query using GitHub users search syntax",
+        "type": "string"
+      },
+      "sort": {
+        "description": "Sort field by category",
+        "enum": [
+          "followers",
+          "repositories",
+          "joined"
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "q"
+    ],
+    "type": "object"
+  },
+  "name": "search_users"
+}

--- a/pkg/github/__toolsnaps__/submit_pending_pull_request_review.snap
+++ b/pkg/github/__toolsnaps__/submit_pending_pull_request_review.snap
@@ -1,0 +1,44 @@
+{
+  "annotations": {
+    "title": "Submit the requester's latest pending pull request review",
+    "readOnlyHint": false
+  },
+  "description": "Submit the requester's latest pending pull request review, normally this is a final step after creating a pending review, adding comments first, unless you know that the user already did the first two steps, you should check before calling this.",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "The text of the review comment",
+        "type": "string"
+      },
+      "event": {
+        "description": "The event to perform",
+        "enum": [
+          "APPROVE",
+          "REQUEST_CHANGES",
+          "COMMENT"
+        ],
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber",
+      "event"
+    ],
+    "type": "object"
+  },
+  "name": "submit_pending_pull_request_review"
+}

--- a/pkg/github/__toolsnaps__/update_issue.snap
+++ b/pkg/github/__toolsnaps__/update_issue.snap
@@ -1,0 +1,64 @@
+{
+  "annotations": {
+    "title": "Edit issue",
+    "readOnlyHint": false
+  },
+  "description": "Update an existing issue in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "assignees": {
+        "description": "New assignees",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "body": {
+        "description": "New description",
+        "type": "string"
+      },
+      "issue_number": {
+        "description": "Issue number to update",
+        "type": "number"
+      },
+      "labels": {
+        "description": "New labels",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "milestone": {
+        "description": "New milestone number",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "state": {
+        "description": "New state",
+        "enum": [
+          "open",
+          "closed"
+        ],
+        "type": "string"
+      },
+      "title": {
+        "description": "New title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "issue_number"
+    ],
+    "type": "object"
+  },
+  "name": "update_issue"
+}

--- a/pkg/github/__toolsnaps__/update_pull_request.snap
+++ b/pkg/github/__toolsnaps__/update_pull_request.snap
@@ -1,0 +1,54 @@
+{
+  "annotations": {
+    "title": "Edit pull request",
+    "readOnlyHint": false
+  },
+  "description": "Update an existing pull request in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "base": {
+        "description": "New base branch name",
+        "type": "string"
+      },
+      "body": {
+        "description": "New description",
+        "type": "string"
+      },
+      "maintainer_can_modify": {
+        "description": "Allow maintainer edits",
+        "type": "boolean"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number to update",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      },
+      "state": {
+        "description": "New state",
+        "enum": [
+          "open",
+          "closed"
+        ],
+        "type": "string"
+      },
+      "title": {
+        "description": "New title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "update_pull_request"
+}

--- a/pkg/github/__toolsnaps__/update_pull_request_branch.snap
+++ b/pkg/github/__toolsnaps__/update_pull_request_branch.snap
@@ -1,0 +1,34 @@
+{
+  "annotations": {
+    "title": "Update pull request branch",
+    "readOnlyHint": false
+  },
+  "description": "Update the branch of a pull request with the latest changes from the base branch.",
+  "inputSchema": {
+    "properties": {
+      "expectedHeadSha": {
+        "description": "The expected SHA of the pull request's HEAD ref",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber"
+    ],
+    "type": "object"
+  },
+  "name": "update_pull_request_branch"
+}

--- a/pkg/github/code_scanning_test.go
+++ b/pkg/github/code_scanning_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/github/github-mcp-server/internal/toolsnaps"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v72/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
@@ -17,6 +18,7 @@ func Test_GetCodeScanningAlert(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetCodeScanningAlert(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_code_scanning_alert", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -119,6 +121,7 @@ func Test_ListCodeScanningAlerts(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := ListCodeScanningAlerts(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "list_code_scanning_alerts", tool.Name)
 	assert.NotEmpty(t, tool.Description)

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v72/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
@@ -21,6 +22,7 @@ func Test_GetIssue(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetIssue(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_issue", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -117,6 +119,7 @@ func Test_AddIssueComment(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := AddIssueComment(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "add_issue_comment", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -230,6 +233,7 @@ func Test_SearchIssues(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := SearchIssues(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "search_issues", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -386,6 +390,7 @@ func Test_CreateIssue(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := CreateIssue(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "create_issue", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -560,6 +565,7 @@ func Test_ListIssues(t *testing.T) {
 	// Verify tool definition
 	mockClient := github.NewClient(nil)
 	tool, _ := ListIssues(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "list_issues", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -736,6 +742,7 @@ func Test_UpdateIssue(t *testing.T) {
 	// Verify tool definition
 	mockClient := github.NewClient(nil)
 	tool, _ := UpdateIssue(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "update_issue", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -993,6 +1000,7 @@ func Test_GetIssueComments(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetIssueComments(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_issue_comments", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1129,6 +1137,7 @@ func TestAssignCopilotToIssue(t *testing.T) {
 	// Verify tool definition
 	mockClient := githubv4.NewClient(nil)
 	tool, _ := AssignCopilotToIssue(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "assign_copilot_to_issue", tool.Name)
 	assert.NotEmpty(t, tool.Description)

--- a/pkg/github/notifications_test.go
+++ b/pkg/github/notifications_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/github/github-mcp-server/internal/toolsnaps"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v72/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
@@ -17,6 +18,8 @@ func Test_ListNotifications(t *testing.T) {
 	// Verify tool definition and schema
 	mockClient := github.NewClient(nil)
 	tool, _ := ListNotifications(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
 	assert.Equal(t, "list_notifications", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.Contains(t, tool.InputSchema.Properties, "filter")
@@ -147,6 +150,8 @@ func Test_ManageNotificationSubscription(t *testing.T) {
 	// Verify tool definition and schema
 	mockClient := github.NewClient(nil)
 	tool, _ := ManageNotificationSubscription(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
 	assert.Equal(t, "manage_notification_subscription", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.Contains(t, tool.InputSchema.Properties, "notificationID")
@@ -283,6 +288,8 @@ func Test_ManageRepositoryNotificationSubscription(t *testing.T) {
 	// Verify tool definition and schema
 	mockClient := github.NewClient(nil)
 	tool, _ := ManageRepositoryNotificationSubscription(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
 	assert.Equal(t, "manage_repository_notification_subscription", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.Contains(t, tool.InputSchema.Properties, "owner")
@@ -444,6 +451,8 @@ func Test_DismissNotification(t *testing.T) {
 	// Verify tool definition and schema
 	mockClient := github.NewClient(nil)
 	tool, _ := DismissNotification(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
 	assert.Equal(t, "dismiss_notification", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.Contains(t, tool.InputSchema.Properties, "threadID")
@@ -574,6 +583,8 @@ func Test_MarkAllNotificationsRead(t *testing.T) {
 	// Verify tool definition and schema
 	mockClient := github.NewClient(nil)
 	tool, _ := MarkAllNotificationsRead(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
 	assert.Equal(t, "mark_all_notifications_read", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.Contains(t, tool.InputSchema.Properties, "lastReadAt")
@@ -672,6 +683,8 @@ func Test_GetNotificationDetails(t *testing.T) {
 	// Verify tool definition and schema
 	mockClient := github.NewClient(nil)
 	tool, _ := GetNotificationDetails(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
 	assert.Equal(t, "get_notification_details", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.Contains(t, tool.InputSchema.Properties, "notificationID")

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v72/github"
 	"github.com/shurcooL/githubv4"
@@ -21,6 +22,7 @@ func Test_GetPullRequest(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetPullRequest(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_pull_request", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -133,6 +135,7 @@ func Test_UpdatePullRequest(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := UpdatePullRequest(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "update_pull_request", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -315,6 +318,7 @@ func Test_ListPullRequests(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := ListPullRequests(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "list_pull_requests", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -445,6 +449,7 @@ func Test_MergePullRequest(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := MergePullRequest(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "merge_pull_request", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -556,6 +561,7 @@ func Test_GetPullRequestFiles(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetPullRequestFiles(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_pull_request_files", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -672,6 +678,7 @@ func Test_GetPullRequestStatus(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetPullRequestStatus(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_pull_request_status", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -833,6 +840,7 @@ func Test_UpdatePullRequestBranch(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := UpdatePullRequestBranch(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "update_pull_request_branch", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -949,6 +957,7 @@ func Test_GetPullRequestComments(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetPullRequestComments(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_pull_request_comments", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1076,6 +1085,7 @@ func Test_GetPullRequestReviews(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetPullRequestReviews(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_pull_request_reviews", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1199,6 +1209,7 @@ func Test_CreatePullRequest(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := CreatePullRequest(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "create_pull_request", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1358,6 +1369,7 @@ func TestCreateAndSubmitPullRequestReview(t *testing.T) {
 	// Verify tool definition once
 	mockClient := githubv4.NewClient(nil)
 	tool, _ := CreateAndSubmitPullRequestReview(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "create_and_submit_pull_request_review", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1551,6 +1563,7 @@ func Test_RequestCopilotReview(t *testing.T) {
 
 	mockClient := github.NewClient(nil)
 	tool, _ := RequestCopilotReview(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "request_copilot_review", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1661,6 +1674,7 @@ func TestCreatePendingPullRequestReview(t *testing.T) {
 	// Verify tool definition once
 	mockClient := githubv4.NewClient(nil)
 	tool, _ := CreatePendingPullRequestReview(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "create_pending_pull_request_review", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1843,6 +1857,7 @@ func TestAddPullRequestReviewCommentToPendingReview(t *testing.T) {
 	// Verify tool definition once
 	mockClient := githubv4.NewClient(nil)
 	tool, _ := AddPullRequestReviewCommentToPendingReview(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "add_pull_request_review_comment_to_pending_review", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1955,6 +1970,7 @@ func TestSubmitPendingPullRequestReview(t *testing.T) {
 	// Verify tool definition once
 	mockClient := githubv4.NewClient(nil)
 	tool, _ := SubmitPendingPullRequestReview(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "submit_pending_pull_request_review", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -2052,6 +2068,7 @@ func TestDeletePendingPullRequestReview(t *testing.T) {
 	// Verify tool definition once
 	mockClient := githubv4.NewClient(nil)
 	tool, _ := DeletePendingPullRequestReview(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "delete_pending_pull_request_review", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -2143,6 +2160,7 @@ func TestGetPullRequestDiff(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetPullRequestDiff(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_pull_request_diff", tool.Name)
 	assert.NotEmpty(t, tool.Description)

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/github/github-mcp-server/internal/toolsnaps"
 	"github.com/github/github-mcp-server/pkg/raw"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v72/github"
@@ -23,6 +24,7 @@ func Test_GetFileContents(t *testing.T) {
 	mockClient := github.NewClient(nil)
 	mockRawClient := raw.NewClient(mockClient, &url.URL{Scheme: "https", Host: "raw.githubusercontent.com", Path: "/"})
 	tool, _ := GetFileContents(stubGetClientFn(mockClient), stubGetRawClientFn(mockRawClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_file_contents", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -219,6 +221,7 @@ func Test_ForkRepository(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := ForkRepository(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "fork_repository", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -317,6 +320,7 @@ func Test_CreateBranch(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := CreateBranch(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "create_branch", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -508,6 +512,7 @@ func Test_GetCommit(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetCommit(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_commit", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -633,6 +638,7 @@ func Test_ListCommits(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := ListCommits(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "list_commits", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -807,6 +813,7 @@ func Test_CreateOrUpdateFile(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := CreateOrUpdateFile(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "create_or_update_file", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -970,6 +977,7 @@ func Test_CreateRepository(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := CreateRepository(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "create_repository", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1116,6 +1124,7 @@ func Test_PushFiles(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := PushFiles(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "push_files", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1452,6 +1461,7 @@ func Test_ListBranches(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := ListBranches(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "list_branches", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1562,6 +1572,7 @@ func Test_DeleteFile(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := DeleteFile(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "delete_file", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1739,6 +1750,7 @@ func Test_ListTags(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := ListTags(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "list_tags", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -1859,6 +1871,7 @@ func Test_GetTag(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := GetTag(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "get_tag", tool.Name)
 	assert.NotEmpty(t, tool.Description)

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/github/github-mcp-server/internal/toolsnaps"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v72/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
@@ -17,6 +18,7 @@ func Test_SearchRepositories(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := SearchRepositories(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "search_repositories", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -164,6 +166,7 @@ func Test_SearchCode(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := SearchCode(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "search_code", tool.Name)
 	assert.NotEmpty(t, tool.Description)
@@ -315,6 +318,7 @@ func Test_SearchUsers(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
 	tool, _ := SearchUsers(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
 
 	assert.Equal(t, "search_users", tool.Name)
 	assert.NotEmpty(t, tool.Description)


### PR DESCRIPTION
## Description

Some time ago I introduced the idea of `toolsnaps` to highlight unintended changes to our tool schemas. I also imagined that it might have the benefit of quickly validating conformance if/when the project swaps to the official Go supported SDK. This PR backfills the toolsnaps to all tools.

Here's a reminder of what the error messages look like:

```
ok      github.com/github/github-mcp-server/internal/toolsnaps  (cached)
--- FAIL: Test_GetIssue (0.00s)
    issues_test.go:25:
                Error Trace:    /Users/williammartin/workspace/github-mcp-server/pkg/github/issues_test.go:25
                Error:          Received unexpected error:
                                tool schema for get_issue has changed unexpectedly:
                                @ ["annotations","title"]
                                - "Get issue details"
                                + "Get isse details"

                                run with `UPDATE_TOOLSNAPS=true` if this is expected
                Test:           Test_GetIssue
FAIL
```

### Future Thoughts

Like with the desire to produce README's automatically from tool schemas, it would be better if there were a single data structure representing our tools, and then we could iterate that rather than relying on remembering to add the toolsnap call in each test.