### PR TITLE
docs: Add GitHub Copilot authentication requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The remote GitHub MCP Server is hosted by GitHub and provides the easiest method
 ## Prerequisites
 
 1. An MCP host that supports the latest MCP specification and remote servers, such as [VS Code](https://code.visualstudio.com/).
+2. **GitHub Copilot authentication**: The remote GitHub MCP Server is hosted at `api.githubcopilot.com` and requires GitHub Copilot authentication. Ensure you have a GitHub Copilot subscription and are properly authenticated.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The remote GitHub MCP Server is hosted by GitHub and provides the easiest method
 
 ## Prerequisites
 
-1. An MCP host that supports the latest MCP specification and remote servers, such as [VS Code](https://code.visualstudio.com/).
+1. An **MCP host** that supports the latest MCP specification and remote servers, such as [VS Code](https://code.visualstudio.com/).
 2. **GitHub Copilot authentication**: The remote GitHub MCP Server is hosted at `api.githubcopilot.com` and requires GitHub Copilot authentication. Ensure you have a GitHub Copilot subscription and are properly authenticated.
 
 ## Installation


### PR DESCRIPTION
## Summary

This PR addresses the confusion around GitHub Copilot authentication requirements when setting up the GitHub MCP Server.

## Changes

- Added a prerequisite note in the README explaining that GitHub Copilot authentication is required for the remote server
- Clarified that the remote server is hosted at `api.githubcopilot.com` and requires a Copilot subscription

## Problem

As mentioned in issue #555, users were experiencing confusion during setup because:
- The README didn't explicitly mention the GitHub Copilot authentication requirement
- Users had to figure this out through trial and error
- The only hint was the `api.githubcopilot.com` URL in the configuration

## Solution

Added clear documentation in the Prerequisites section to help users understand the authentication requirements upfront, preventing setup confusion.

Fixes #555