### PR TITLE
feat: add pagination support to get_pull_request_files tool

### DIFF
--- a/pkg/github/__toolsnaps__/get_pull_request_files.snap
+++ b/pkg/github/__toolsnaps__/get_pull_request_files.snap
@@ -10,6 +10,17 @@
         "description": "Repository owner",
         "type": "string"
       },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
       "pullNumber": {
         "description": "Pull request number",
         "type": "number"

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -532,6 +532,7 @@ func GetPullRequestFiles(getClient GetClientFn, t translations.TranslationHelper
 				mcp.Required(),
 				mcp.Description("Pull request number"),
 			),
+			WithPagination(),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			owner, err := RequiredParam[string](request, "owner")
@@ -546,12 +547,19 @@ func GetPullRequestFiles(getClient GetClientFn, t translations.TranslationHelper
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
+			pagination, err := OptionalPaginationParams(request)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
 
 			client, err := getClient(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
-			opts := &github.ListOptions{}
+			opts := &github.ListOptions{
+				PerPage: pagination.perPage,
+				Page:    pagination.page,
+			}
 			files, resp, err := client.PullRequests.ListFiles(ctx, owner, repo, pullNumber, opts)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get pull request files: %w", err)

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -568,6 +568,8 @@ func Test_GetPullRequestFiles(t *testing.T) {
 	assert.Contains(t, tool.InputSchema.Properties, "owner")
 	assert.Contains(t, tool.InputSchema.Properties, "repo")
 	assert.Contains(t, tool.InputSchema.Properties, "pullNumber")
+	assert.Contains(t, tool.InputSchema.Properties, "page")
+	assert.Contains(t, tool.InputSchema.Properties, "perPage")
 	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo", "pullNumber"})
 
 	// Setup mock PR files for success case
@@ -610,6 +612,24 @@ func Test_GetPullRequestFiles(t *testing.T) {
 				"owner":      "owner",
 				"repo":       "repo",
 				"pullNumber": float64(42),
+			},
+			expectError:   false,
+			expectedFiles: mockFiles,
+		},
+		{
+			name: "successful files fetch with pagination",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatch(
+					mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
+					mockFiles,
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(42),
+				"page":       float64(2),
+				"perPage":    float64(10),
 			},
 			expectError:   false,
 			expectedFiles: mockFiles,


### PR DESCRIPTION
# Add pagination support to `get_pull_request_files` tool

## Fixes #527

## Problem
The `get_pull_request_files` tool currently retrieves only the first 30 files with diffs of any PR that contains more than 30 files. This is a limitation because large PRs with many files cannot be fully analyzed.

## Solution
Added pagination support to the `get_pull_request_files` tool by:
- Adding `WithPagination()` to the tool definition
- Using `OptionalPaginationParams(request)` to handle `page` and `perPage` parameters
- Passing pagination parameters to the GitHub API `ListFiles` call
- Following the same pattern used by other paginated tools in the codebase

## Changes Made

### 1. Core Implementation (`pkg/github/pullrequests.go`)
```go
// Added WithPagination() to tool definition
WithPagination(),

// Added pagination parameter handling
pagination, err := OptionalPaginationParams(request)
if err != nil {
    return mcp.NewToolResultError(err.Error()), nil
}

// Updated GitHub API call to use pagination
opts := &github.ListOptions{
    PerPage: pagination.perPage,
    Page:    pagination.page,
}
```

### 2. Test Updates (`pkg/github/pullrequests_test.go`)
- Added verification that pagination parameters (`page`, `perPage`) are present in tool schema
- Added test case for successful files fetch with pagination parameters
- Updated tool schema snapshot to reflect new parameters

### 3. Schema Snapshot (`pkg/github/__toolsnaps__/get_pull_request_files.snap`)
- Automatically updated to include new pagination parameters
- Ensures schema changes are tracked and validated

## Testing Done

### 1. Unit Tests
```bash
# All tests pass
go test ./pkg/github -v
```

**Test Results:**
- ✅ `Test_GetPullRequestFiles` - All test cases pass including new pagination test
- ✅ Schema verification - Confirms `page` and `perPage` parameters are present
- ✅ Pagination functionality - Verifies tool works with pagination parameters

### 2. Integration Testing
```bash
# Verified tool schema includes pagination parameters
GITHUB_PERSONAL_ACCESS_TOKEN=xxx ./mcpcurl --stdio-server-cmd="./github-mcp-server stdio --toolsets pull_requests" schema
```

**Schema Verification:**
```json
{
  "name": "get_pull_request_files",
  "inputSchema": {
    "properties": {
      "owner": {"description": "Repository owner", "type": "string"},
      "page": {"description": "Page number for pagination (min 1)", "minimum": 1, "type": "number"},
      "perPage": {"description": "Results per page for pagination (min 1, max 100)", "maximum": 100, "minimum": 1, "type": "number"},
      "pullNumber": {"description": "Pull request number", "type": "number"},
      "repo": {"description": "Repository name", "type": "string"}
    },
    "required": ["owner", "repo", "pullNumber"]
  }
}
```

### 3. GitHub API Verification
```bash
# Verified GitHub API supports pagination for PR files
curl -H "Authorization: token xxx" "https://api.github.com/repos/github/github-mcp-server/pulls/521/files?per_page=2&page=1"
```

**API Response:** Successfully returned paginated results with 2 files per page.

### 4. Build Verification
```bash
# Server builds successfully with changes
go build -o github-mcp-server cmd/github-mcp-server/main.go
```

## Usage Examples

### Default behavior (no pagination parameters):
```json
{
  "owner": "github",
  "repo": "github-mcp-server", 
  "pullNumber": 123
}
```

### With pagination:
```json
{
  "owner": "github",
  "repo": "github-mcp-server",
  "pullNumber": 123,
  "page": 2,
  "perPage": 10
}
```

## Backward Compatibility
- ✅ **Fully backward compatible** - Existing calls without pagination parameters work exactly as before
- ✅ **Optional parameters** - `page` and `perPage` are optional with sensible defaults
- ✅ **Same response format** - Returns the same JSON structure as before

## Impact
- **Large PRs**: Can now analyze PRs with more than 30 files
- **Performance**: Users can control the number of files retrieved per request
- **Flexibility**: Supports both default behavior and custom pagination

## Files Changed
- `pkg/github/pullrequests.go` - Core implementation
- `pkg/github/pullrequests_test.go` - Test updates
- `pkg/github/__toolsnaps__/get_pull_request_files.snap` - Schema snapshot