### PR TITLE
Add ctx propagation to raw api request

### DIFF
--- a/pkg/raw/raw.go
+++ b/pkg/raw/raw.go
@@ -25,9 +25,13 @@ func NewClient(client *gogithub.Client, rawURL *url.URL) *Client {
 	return &Client{client: client, url: rawURL}
 }
 
-func (c *Client) newRequest(method string, urlStr string, body interface{}, opts ...gogithub.RequestOption) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, method string, urlStr string, body interface{}, opts ...gogithub.RequestOption) (*http.Request, error) {
 	req, err := c.client.NewRequest(method, urlStr, body, opts...)
-	return req, err
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	return req, nil
 }
 
 func (c *Client) refURL(owner, repo, ref, path string) string {
@@ -60,7 +64,7 @@ type RawContentOpts struct {
 // GetRawContent fetches the raw content of a file from a GitHub repository.
 func (c *Client) GetRawContent(ctx context.Context, owner, repo, path string, opts *RawContentOpts) (*http.Response, error) {
 	url := c.URLFromOpts(opts, owner, repo, path)
-	req, err := c.newRequest("GET", url, nil)
+	req, err := c.newRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Update `newRequest` to accept a `context.Context` param and attach it to the generated `http.Request` using `withContext`.

This change ensures that trace contexts are correctly propagated, supporting distributed tracing in the remote MCP server.