### PR TITLE
Add in an assign copilot prompt

### DIFF
--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -931,3 +931,42 @@ func parseISOTimestamp(timestamp string) (time.Time, error) {
 	// Return error with supported formats
 	return time.Time{}, fmt.Errorf("invalid ISO 8601 timestamp: %s (supported formats: YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DD)", timestamp)
 }
+
+func AssignCodingAgentPrompt(t translations.TranslationHelperFunc) (tool mcp.Prompt, handler server.PromptHandlerFunc) {
+	return mcp.NewPrompt("AssignCodingAgent",
+			mcp.WithPromptDescription(t("PROMPT_ASSIGN_CODING_AGENT_DESCRIPTION", "Assign GitHub Coding Agent to multiple tasks in a GitHub repository.")),
+			mcp.WithArgument("repo", mcp.ArgumentDescription("The repository to assign tasks in (owner/repo)."), mcp.RequiredArgument()),
+		), func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			repo := request.Params.Arguments["repo"]
+
+			messages := []mcp.PromptMessage{
+				{
+					Role:    "system",
+					Content: mcp.NewTextContent("You are a personal assistant for GitHub the Copilot GitHub Coding Agent. Your task is to help the user assign tasks to the Coding Agent based on their open GitHub issues. You can use `assign_copilot_to_issue` tool to assign the Coding Agent to issues that are suitable for autonomous work, and `search_issues` tool to find issues that match the user's criteria. You can also use `list_issues` to get a list of issues in the repository."),
+				},
+				{
+					Role:    "user",
+					Content: mcp.NewTextContent(fmt.Sprintf("Please go and get a list of the most recent 10 issues from the %s GitHub repository", repo)),
+				},
+				{
+					Role:    "assistant",
+					Content: mcp.NewTextContent(fmt.Sprintf("Sure! I will get a list of the 10 most recent issues for the repo %s.", repo)),
+				},
+				{
+					Role:    "user",
+					Content: mcp.NewTextContent("For each issue, please check if it is a clearly defined coding task with acceptance criteria and a low to medium complexity to identify issues that are suitable for an AI Coding Agent to work on. Then assign each of the identified issues to Copilot."),
+				},
+				{
+					Role:    "assistant",
+					Content: mcp.NewTextContent("Certainly! Let me carefully check which ones are clearly scoped issues that are good to assign to the coding agent, and I will summarise and assign them now."),
+				},
+				{
+					Role:    "user",
+					Content: mcp.NewTextContent("Great, if you are unsure if an issue is good to assign, ask me first, rather than assigning copilot. If you are certain the issue is clear and suitable you can assign it to Copilot without asking."),
+				},
+			}
+			return &mcp.GetPromptResult{
+				Messages: messages,
+			}, nil
+		}
+}

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -958,7 +958,7 @@ func AssignCodingAgentPrompt(t translations.TranslationHelperFunc) (tool mcp.Pro
 				},
 				{
 					Role:    "assistant",
-					Content: mcp.NewTextContent("Certainly! Let me carefully check which ones are clearly scoped issues that are good to assign to the coding agent, and I will summarise and assign them now."),
+					Content: mcp.NewTextContent("Certainly! Let me carefully check which ones are clearly scoped issues that are good to assign to the coding agent, and I will summarize and assign them now."),
 				},
 				{
 					Role:    "user",

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -59,7 +59,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 			toolsets.NewServerTool(AddIssueComment(getClient, t)),
 			toolsets.NewServerTool(UpdateIssue(getClient, t)),
 			toolsets.NewServerTool(AssignCopilotToIssue(getGQLClient, t)),
-		)
+		).AddPrompts(toolsets.NewServerPrompt(AssignCodingAgentPrompt(t)))
 	users := toolsets.NewToolset("users", "GitHub User related tools").
 		AddReadTools(
 			toolsets.NewServerTool(SearchUsers(getClient, t)),


### PR DESCRIPTION
This PR adds a prompt that assigns the Coding Agent to multiple tasks in a specified GitHub repository, validating first if they are clear enough to assign.

- Adds first Prompt to the codebase
- Adds Prompt support to toolsets. 

## Example

### Rendered prompt

```
--SYSTEM
You are a personal assistant for GitHub the Copilot GitHub Coding Agent. Your task is to help the user assign tasks to the Coding Agent based on their open GitHub issues. You can use assign_copilot_to_issue tool to assign the Coding Agent to issues that are suitable for autonomous work, and search_issues tool to find issues that match the user's criteria. You can also use list_issues to get a list of issues in the repository.

--USER
Please go and get a list of the most recent 10 issues from the SamMorrowDrums/pigs-facts GitHub repository

--ASSISTANT
Sure! I will get a list of the 10 most recent issues for the repo SamMorrowDrums/pigs-facts.

--USER
For each issue, please check if it is a clearly defined coding task with acceptance criteria and a low to medium complexity to identify issues that are suitable for an AI Coding Agent to work on. Then assign each of the identified issues to Copilot.

--ASSISTANT
Certainly! Let me carefully check which ones are clearly scoped issues that are good to assign to the coding agent, and I will assign them now.

--USER
Great, if you are unsure if an issue is good to assign, ask me first, rather than assigning copilot. If you are certain the issue is clear and suitable you can assign it to Copilot without asking.
```

After listing issues, it proceeds to do exactly as hoped

![image](https://github.com/user-attachments/assets/6e267b41-741d-4f2b-9584-ab78b1201b9b)

![image](https://github.com/user-attachments/assets/d455205d-982b-40b6-80ca-8202750c6ef1)
