### PR TITLE
collapse docs from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
 
 <details>
 
-<summary>User</summary>
+<summary>Context</summary>
 
 - **get_me** - Get details of the authenticated user
   - No parameters required
@@ -778,7 +778,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
 
 <details>
 
-<summary>User</summary>
+<summary>Users</summary>
 
 - **search_users** - Search for GitHub users
   - `q`: Search query (string, required)


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:

The readme is getting too big and confusing. This is the first of a few refactors to reduce the size of the root readme and to improve readability.

See [here](https://github.com/github/github-mcp-server/tree/tonytrg/collapsible-docs) for a rendered version.