### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __debug_bin*
 # Go
 vendor
 bin/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Just a small housekeeping improvement 🧹

This PR adds `.DS_Store` to the `.gitignore` file to prevent macOS system files from being accidentally committed and to avoid them showing up in `git status`