### PR TITLE
get_me return concise user response

### DIFF
--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -2,12 +2,35 @@ package github
 
 import (
 	"context"
+	"time"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
+
+// UserDetails contains additional fields about a GitHub user not already
+// present in MinimalUser. Used by get_me context tool but omitted from search_users.
+type UserDetails struct {
+	Name              string    `json:"name,omitempty"`
+	Company           string    `json:"company,omitempty"`
+	Blog              string    `json:"blog,omitempty"`
+	Location          string    `json:"location,omitempty"`
+	Email             string    `json:"email,omitempty"`
+	Hireable          bool      `json:"hireable,omitempty"`
+	Bio               string    `json:"bio,omitempty"`
+	TwitterUsername   string    `json:"twitter_username,omitempty"`
+	PublicRepos       int       `json:"public_repos"`
+	PublicGists       int       `json:"public_gists"`
+	Followers         int       `json:"followers"`
+	Following         int       `json:"following"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	PrivateGists      int       `json:"private_gists,omitempty"`
+	TotalPrivateRepos int64     `json:"total_private_repos,omitempty"`
+	OwnedPrivateRepos int64     `json:"owned_private_repos,omitempty"`
+}
 
 // GetMe creates a tool to get details of the authenticated user.
 func GetMe(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.Tool, server.ToolHandlerFunc) {
@@ -44,6 +67,25 @@ func GetMe(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.Too
 			ID:         user.GetID(),
 			ProfileURL: user.GetHTMLURL(),
 			AvatarURL:  user.GetAvatarURL(),
+			Details: &UserDetails{
+				Name:              user.GetName(),
+				Company:           user.GetCompany(),
+				Blog:              user.GetBlog(),
+				Location:          user.GetLocation(),
+				Email:             user.GetEmail(),
+				Hireable:          user.GetHireable(),
+				Bio:               user.GetBio(),
+				TwitterUsername:   user.GetTwitterUsername(),
+				PublicRepos:       user.GetPublicRepos(),
+				PublicGists:       user.GetPublicGists(),
+				Followers:         user.GetFollowers(),
+				Following:         user.GetFollowing(),
+				CreatedAt:         user.GetCreatedAt().Time,
+				UpdatedAt:         user.GetUpdatedAt().Time,
+				PrivateGists:      user.GetPrivateGists(),
+				TotalPrivateRepos: user.GetTotalPrivateRepos(),
+				OwnedPrivateRepos: user.GetOwnedPrivateRepos(),
+			},
 		}
 
 		return MarshalledTextResult(minimalUser), nil

--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -26,15 +26,17 @@ func Test_GetMe(t *testing.T) {
 
 	// Setup mock user response
 	mockUser := &github.User{
-		Login:     github.Ptr("testuser"),
-		Name:      github.Ptr("Test User"),
-		Email:     github.Ptr("test@example.com"),
-		Bio:       github.Ptr("GitHub user for testing"),
-		Company:   github.Ptr("Test Company"),
-		Location:  github.Ptr("Test Location"),
-		HTMLURL:   github.Ptr("https://github.com/testuser"),
-		CreatedAt: &github.Timestamp{Time: time.Now().Add(-365 * 24 * time.Hour)},
-		Type:      github.Ptr("User"),
+		Login:           github.Ptr("testuser"),
+		Name:            github.Ptr("Test User"),
+		Email:           github.Ptr("test@example.com"),
+		Bio:             github.Ptr("GitHub user for testing"),
+		Company:         github.Ptr("Test Company"),
+		Location:        github.Ptr("Test Location"),
+		HTMLURL:         github.Ptr("https://github.com/testuser"),
+		CreatedAt:       &github.Timestamp{Time: time.Now().Add(-365 * 24 * time.Hour)},
+		Type:            github.Ptr("User"),
+		Hireable:        github.Ptr(true),
+		TwitterUsername: github.Ptr("testuser_twitter"),
 		Plan: &github.Plan{
 			Name: github.Ptr("pro"),
 		},
@@ -124,6 +126,16 @@ func Test_GetMe(t *testing.T) {
 			// Verify minimal user details
 			assert.Equal(t, *tc.expectedUser.Login, returnedUser.Login)
 			assert.Equal(t, *tc.expectedUser.HTMLURL, returnedUser.ProfileURL)
+
+			// Verify user details
+			require.NotNil(t, returnedUser.Details)
+			assert.Equal(t, *tc.expectedUser.Name, returnedUser.Details.Name)
+			assert.Equal(t, *tc.expectedUser.Email, returnedUser.Details.Email)
+			assert.Equal(t, *tc.expectedUser.Bio, returnedUser.Details.Bio)
+			assert.Equal(t, *tc.expectedUser.Company, returnedUser.Details.Company)
+			assert.Equal(t, *tc.expectedUser.Location, returnedUser.Details.Location)
+			assert.Equal(t, *tc.expectedUser.Hireable, returnedUser.Details.Hireable)
+			assert.Equal(t, *tc.expectedUser.TwitterUsername, returnedUser.Details.TwitterUsername)
 		})
 	}
 }

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -155,11 +155,13 @@ func SearchCode(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 		}
 }
 
+// MinimalUser is the output type for user and organization search results.
 type MinimalUser struct {
-	Login      string `json:"login"`
-	ID         int64  `json:"id,omitempty"`
-	ProfileURL string `json:"profile_url,omitempty"`
-	AvatarURL  string `json:"avatar_url,omitempty"`
+	Login      string       `json:"login"`
+	ID         int64        `json:"id,omitempty"`
+	ProfileURL string       `json:"profile_url,omitempty"`
+	AvatarURL  string       `json:"avatar_url,omitempty"`
+	Details    *UserDetails `json:"details,omitempty"` // Optional field for additional user details
 }
 
 type MinimalSearchUsersResult struct {


### PR DESCRIPTION
Update get_me tool to return a marshalled `MinimalUser` instead of a full `User` object, and extend `MinimalUser` with an optional nested `UserDetails`.

- (Before) Full user response same as API: https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user
- (Now) Minimal user with nested details struct: https://github.com/github/github-mcp-server/blob/dd62f8d80be5d69adaa8f36adab0395a1e570273/pkg/github/search.go#L158-L165
    - Note, `search_users` tool is unchanged, it omits the nested details field

<details><summary><h3>Example</h3></summary>


<img width="395" alt="image" src="https://github.com/user-attachments/assets/ee52fbe0-f91a-4a0c-8c28-32514bfcafb8" />

```json
{
    "login": "LuluBeatson",
    "id": 59149422,
    "profile_url": "https://github.com/LuluBeatson",
    "avatar_url": "https://avatars.githubusercontent.com/u/59149422?v=4",
    "details": {
        "name": "Lulu",
        "blog": "lulubeatson.com",
        "location": "London, UK",
        "public_repos": 31,
        "public_gists": 1,
        "followers": 0,
        "following": 5,
        "created_at": "2019-12-22T21:15:47Z",
        "updated_at": "2025-06-05T06:41:06Z"
    }
}
```


</details> 
