### PR TITLE
Enable docker builds with shell using different dockerfile

### DIFF
--- a/Dockerfile-with-shell
+++ b/Dockerfile-with-shell
@@ -1,0 +1,29 @@
+FROM golang:1.24.4-alpine AS build
+ARG VERSION="dev"
+
+# Set the working directory
+WORKDIR /build
+
+# Install git
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add git
+
+# Build the server
+# go build automatically download required module dependencies to /go/pkg/mod
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=bind,target=. \
+    CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    -o /bin/github-mcp-server cmd/github-mcp-server/main.go
+
+# Make a stage to run the app
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+# Set the working directory
+WORKDIR /server
+# Copy the binary from the build stage
+COPY --from=build /bin/github-mcp-server .
+# Set the entrypoint to the server binary
+ENTRYPOINT ["/server/github-mcp-server"]
+# Default arguments for ENTRYPOINT
+CMD ["stdio"]


### PR DESCRIPTION
As a first step to enabling shell access in our Docker image for developers that wish to use an image with a distro, this adds `Dockerfile-with-shell` to the repository root and can be run like so:

```sh
docker build --file  Dockerfile-with-shell . --tag ghcr.io/github/github-mcp-server:sh 
docker run --rm -it --entrypoint /bin/sh ghcr.io/github/github-mcp-server:sh 
```

In future we could consider letting this be a later build stage in our main Dockerfile and for our releases use the specific distroless build stage, while enabling others to build with a distro by default which is more common.

Motivation: https://github.com/github/github-mcp-server/issues/574
Docker's custom override: https://github.com/dgageot/github-mcp-server/commit/2e73e0a0df60450a6977b57bc96435de7fd1154e
The Docker MCP Hub listing that points to unsanctioned (by GitHub) fork: https://hub.docker.com/r/mcp/github-mcp-server

CC @dgageot