### PR TITLE
fix: get_discussion graphQL invalid field

### DIFF
--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -195,7 +195,6 @@ func GetDiscussion(getGQLClient GetGQLClientFn, t translations.TranslationHelper
 					Discussion struct {
 						Number    githubv4.Int
 						Body      githubv4.String
-						State     githubv4.String
 						CreatedAt githubv4.DateTime
 						URL       githubv4.String `graphql:"url"`
 						Category  struct {
@@ -213,16 +212,13 @@ func GetDiscussion(getGQLClient GetGQLClientFn, t translations.TranslationHelper
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			d := q.Repository.Discussion
-			discussion := &github.Issue{
+			discussion := &github.Discussion{
 				Number:    github.Ptr(int(d.Number)),
 				Body:      github.Ptr(string(d.Body)),
-				State:     github.Ptr(string(d.State)),
 				HTMLURL:   github.Ptr(string(d.URL)),
 				CreatedAt: &github.Timestamp{Time: d.CreatedAt.Time},
-				Labels: []*github.Label{
-					{
-						Name: github.Ptr(fmt.Sprintf("category:%s", string(d.Category.Name))),
-					},
+				DiscussionCategory: &github.DiscussionCategory{
+					Name: github.Ptr(string(d.Category.Name)),
 				},
 			}
 			out, err := json.Marshal(discussion)

--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -62,7 +62,7 @@ func ListDiscussions(getGQLClient GetGQLClientFn, t translations.TranslationHelp
 			}
 
 			// Now execute the discussions query
-			var discussions []*github.Issue
+			var discussions []*github.Discussion
 			if categoryID != nil {
 				// Query with category filter (server-side filtering)
 				var query struct {
@@ -89,17 +89,15 @@ func ListDiscussions(getGQLClient GetGQLClientFn, t translations.TranslationHelp
 					return mcp.NewToolResultError(err.Error()), nil
 				}
 
-				// Map nodes to GitHub Issue objects
+				// Map nodes to GitHub Discussion objects
 				for _, n := range query.Repository.Discussions.Nodes {
-					di := &github.Issue{
+					di := &github.Discussion{
 						Number:    github.Ptr(int(n.Number)),
 						Title:     github.Ptr(string(n.Title)),
 						HTMLURL:   github.Ptr(string(n.URL)),
 						CreatedAt: &github.Timestamp{Time: n.CreatedAt.Time},
-						Labels: []*github.Label{
-							{
-								Name: github.Ptr(fmt.Sprintf("category:%s", string(n.Category.Name))),
-							},
+						DiscussionCategory: &github.DiscussionCategory{
+							Name: github.Ptr(string(n.Category.Name)),
 						},
 					}
 					discussions = append(discussions, di)
@@ -129,17 +127,15 @@ func ListDiscussions(getGQLClient GetGQLClientFn, t translations.TranslationHelp
 					return mcp.NewToolResultError(err.Error()), nil
 				}
 
-				// Map nodes to GitHub Issue objects
+				// Map nodes to GitHub Discussion objects
 				for _, n := range query.Repository.Discussions.Nodes {
-					di := &github.Issue{
+					di := &github.Discussion{
 						Number:    github.Ptr(int(n.Number)),
 						Title:     github.Ptr(string(n.Title)),
 						HTMLURL:   github.Ptr(string(n.URL)),
 						CreatedAt: &github.Timestamp{Time: n.CreatedAt.Time},
-						Labels: []*github.Label{
-							{
-								Name: github.Ptr(fmt.Sprintf("category:%s", string(n.Category.Name))),
-							},
+						DiscussionCategory: &github.DiscussionCategory{
+							Name: github.Ptr(string(n.Category.Name)),
 						},
 					}
 					discussions = append(discussions, di)

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -168,17 +167,17 @@ func Test_ListDiscussions(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			var returnedDiscussions []*github.Issue
+			var returnedDiscussions []*github.Discussion
 			err = json.Unmarshal([]byte(text), &returnedDiscussions)
 			require.NoError(t, err)
 
 			assert.Len(t, returnedDiscussions, tc.expectedCount, "Expected %d discussions, got %d", tc.expectedCount, len(returnedDiscussions))
 
-			// Verify that all returned discussions have a category label if filtered
+			// Verify that all returned discussions have a category if filtered
 			if _, hasCategory := tc.reqParams["category"]; hasCategory {
 				for _, discussion := range returnedDiscussions {
-					require.NotEmpty(t, discussion.Labels, "Discussion should have category label")
-					assert.True(t, strings.HasPrefix(*discussion.Labels[0].Name, "category:"), "Discussion should have category label prefix")
+					require.NotNil(t, discussion.DiscussionCategory, "Discussion should have category")
+					assert.NotEmpty(t, *discussion.DiscussionCategory.Name, "Discussion should have category name")
 				}
 			}
 		})

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -200,7 +200,6 @@ func Test_GetDiscussion(t *testing.T) {
 			Discussion struct {
 				Number    githubv4.Int
 				Body      githubv4.String
-				State     githubv4.String
 				CreatedAt githubv4.DateTime
 				URL       githubv4.String `graphql:"url"`
 				Category  struct {
@@ -218,7 +217,7 @@ func Test_GetDiscussion(t *testing.T) {
 		name        string
 		response    githubv4mock.GQLResponse
 		expectError bool
-		expected    *github.Issue
+		expected    *github.Discussion
 		errContains string
 	}{
 		{
@@ -227,23 +226,19 @@ func Test_GetDiscussion(t *testing.T) {
 				"repository": map[string]any{"discussion": map[string]any{
 					"number":    1,
 					"body":      "This is a test discussion",
-					"state":     "open",
 					"url":       "https://github.com/owner/repo/discussions/1",
 					"createdAt": "2025-04-25T12:00:00Z",
 					"category":  map[string]any{"name": "General"},
 				}},
 			}),
 			expectError: false,
-			expected: &github.Issue{
+			expected: &github.Discussion{
 				HTMLURL:   github.Ptr("https://github.com/owner/repo/discussions/1"),
 				Number:    github.Ptr(1),
 				Body:      github.Ptr("This is a test discussion"),
-				State:     github.Ptr("open"),
 				CreatedAt: &github.Timestamp{Time: time.Date(2025, 4, 25, 12, 0, 0, 0, time.UTC)},
-				Labels: []*github.Label{
-					{
-						Name: github.Ptr("category:General"),
-					},
+				DiscussionCategory: &github.DiscussionCategory{
+					Name: github.Ptr("General"),
 				},
 			},
 		},
@@ -272,15 +267,13 @@ func Test_GetDiscussion(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			var out github.Issue
+			var out github.Discussion
 			require.NoError(t, json.Unmarshal([]byte(text), &out))
 			assert.Equal(t, *tc.expected.HTMLURL, *out.HTMLURL)
 			assert.Equal(t, *tc.expected.Number, *out.Number)
 			assert.Equal(t, *tc.expected.Body, *out.Body)
-			assert.Equal(t, *tc.expected.State, *out.State)
 			// Check category label
-			require.Len(t, out.Labels, 1)
-			assert.Equal(t, *tc.expected.Labels[0].Name, *out.Labels[0].Name)
+			assert.Equal(t, *tc.expected.DiscussionCategory.Name, *out.DiscussionCategory.Name)
 		})
 	}
 }


### PR DESCRIPTION
Fixes bug in `get_discussion` which caused tool error and returned:
> Field 'state' doesn't exist on type 'Discussion'

- Removed "state" field from query and response
- Used `github.Discussion` object instead of `github.Issue`
- Corrected "labels" to "category" in response
- Tool arguments and descriptions unchanged.

<details><summary>Before with bug</summary>

<img width="716" alt="image" src="https://github.com/user-attachments/assets/81cd55b5-85cf-4e71-85d4-600f3dfc52e0" />

</details> 

### Now fixed:
<img width="712" alt="image" src="https://github.com/user-attachments/assets/aa12afbb-f6ec-4903-af90-eb39f0bfdb43" />

