### PR TITLE
`get_file_content` Match Paths in Git Tree if Full Path Unknown

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -602,7 +602,11 @@ func GetFileContents(getClient GetClientFn, getRawClient raw.GetRawClientFn, t t
 				if err != nil {
 					return mcp.NewToolResultError(fmt.Sprintf("failed to marshal matching files: %s", err)), nil
 				}
-				return mcp.NewToolResultText(fmt.Sprintf("Path did not point to a file or directory, but resolved ref to %s with possible path matches: %s", ref, matchingFilesJSON)), nil
+				resolvedRefs, err := json.Marshal(rawOpts)
+				if err != nil {
+					return mcp.NewToolResultError(fmt.Sprintf("failed to marshal resolved refs: %s", err)), nil
+				}
+				return mcp.NewToolResultText(fmt.Sprintf("Path did not point to a file or directory, but resolved git ref to %s with possible path matches: %s", resolvedRefs, matchingFilesJSON)), nil
 			}
 
 			return mcp.NewToolResultError("Failed to get file contents. The path does not point to a file or directory, or the file does not exist in the repository."), nil

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1344,17 +1344,19 @@ func resolveGitReference(ctx context.Context, githubClient *github.Client, owner
 
 	// 2. If neither provided, use the default branch as ref
 	if ref == "" {
-		repoInfo, _, err := githubClient.Repositories.Get(ctx, owner, repo)
+		repoInfo, resp, err := githubClient.Repositories.Get(ctx, owner, repo)
 		if err != nil {
+			_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get repository info", resp, err)
 			return nil, fmt.Errorf("failed to get repository info: %w", err)
 		}
 		ref = fmt.Sprintf("refs/heads/%s", repoInfo.GetDefaultBranch())
 	}
 
 	// 3. Get the SHA from the ref
-	reference, _, err := githubClient.Git.GetRef(ctx, owner, repo, ref)
+	reference, resp, err := githubClient.Git.GetRef(ctx, owner, repo, ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get reference for default branch: %w", err)
+		_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get reference", resp, err)
+		return nil, fmt.Errorf("failed to get reference: %w", err)
 	}
 	sha = reference.GetObject().GetSHA()
 

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1290,6 +1290,10 @@ func GetTag(getClient GetClientFn, t translations.TranslationHelperFunc) (tool m
 
 // filterPaths filters the entries in a GitHub tree to find paths that
 // match the given suffix.
+// maxResults limits the number of results returned to first maxResults entries,
+// a maxResults of -1 means no limit.
+// It returns a slice of strings containing the matching paths.
+// Directories are returned with a trailing slash.
 func filterPaths(entries []*github.TreeEntry, path string, maxResults int) []string {
 	path = strings.TrimSuffix(path, "/") // Normalize path to avoid double slashes
 

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2137,6 +2137,39 @@ func Test_filterPaths(t *testing.T) {
 			maxResults: -1,
 			expected:   []string{"name/"},
 		},
+		{
+			name: "max results limit 2",
+			tree: []*github.TreeEntry{
+				{Path: github.Ptr("folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("nested/folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("nested/nested/folder"), Type: github.Ptr("tree")},
+			},
+			path:       "folder/",
+			maxResults: 2,
+			expected:   []string{"folder/", "nested/folder/"},
+		},
+		{
+			name: "max results limit 1",
+			tree: []*github.TreeEntry{
+				{Path: github.Ptr("folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("nested/folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("nested/nested/folder"), Type: github.Ptr("tree")},
+			},
+			path:       "folder/",
+			maxResults: 1,
+			expected:   []string{"folder/"},
+		},
+		{
+			name: "max results limit 0",
+			tree: []*github.TreeEntry{
+				{Path: github.Ptr("folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("nested/folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("nested/nested/folder"), Type: github.Ptr("tree")},
+			},
+			path:       "folder/",
+			maxResults: 0,
+			expected:   []string{},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2117,6 +2117,26 @@ func Test_filterPaths(t *testing.T) {
 			maxResults: -1,
 			expected:   []string{"folder/", "nested/folder/"},
 		},
+		{
+			name: "dir and file match",
+			tree: []*github.TreeEntry{
+				{Path: github.Ptr("name"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("name"), Type: github.Ptr("blob")},
+			},
+			path:       "name", // No trailing slash can match both files and directories
+			maxResults: -1,
+			expected:   []string{"name/", "name"},
+		},
+		{
+			name: "dir only match",
+			tree: []*github.TreeEntry{
+				{Path: github.Ptr("name"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("name"), Type: github.Ptr("blob")},
+			},
+			path:       "name/", // Trialing slash ensures only directories are matched
+			maxResults: -1,
+			expected:   []string{"name/"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2085,8 +2085,49 @@ func Test_GetTag(t *testing.T) {
 	}
 }
 
-func Test_ResolveGitReference(t *testing.T) {
+func Test_filterPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		tree       []*github.TreeEntry
+		path       string
+		maxResults int
+		expected   []string
+	}{
+		{
+			name: "file name",
+			tree: []*github.TreeEntry{
+				{Path: github.Ptr("folder/foo.txt"), Type: github.Ptr("blob")},
+				{Path: github.Ptr("bar.txt"), Type: github.Ptr("blob")},
+				{Path: github.Ptr("nested/folder/foo.txt"), Type: github.Ptr("blob")},
+				{Path: github.Ptr("nested/folder/baz.txt"), Type: github.Ptr("blob")},
+			},
+			path:       "foo.txt",
+			maxResults: -1,
+			expected:   []string{"folder/foo.txt", "nested/folder/foo.txt"},
+		},
+		{
+			name: "dir name",
+			tree: []*github.TreeEntry{
+				{Path: github.Ptr("folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("bar.txt"), Type: github.Ptr("blob")},
+				{Path: github.Ptr("nested/folder"), Type: github.Ptr("tree")},
+				{Path: github.Ptr("nested/folder/baz.txt"), Type: github.Ptr("blob")},
+			},
+			path:       "folder/",
+			maxResults: -1,
+			expected:   []string{"folder/", "nested/folder/"},
+		},
+	}
 
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterPaths(tc.tree, tc.path, tc.maxResults)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_resolveGitReference(t *testing.T) {
 	ctx := context.Background()
 	owner := "owner"
 	repo := "repo"


### PR DESCRIPTION
Adds additional steps to the end of `get_file_content` so that if the provided path wasn't found, then we check the Git Tree for possible matching paths. A path matches if it ends with the provided path.

### Changes

- Added additional processing to the end of `get_file_content` so that if previous attempts to get the file/dir fail, then:
    - Get the recursive Git Tree containing tree and blob paths
    - Filters the tree for entries matching the input `path` arg. New func `filterTree`.
    - If any matches, returns a tool result containing the resolved ref & sha and matching paths. Else resume and return tool error result as normal.
- Refactored logic for resolving input `ref` and `sha` into a function `resolveGitReference`.  This still handles refs of the form `refs/tags/{tag}`, `refs/heads/{branch}`, `refs/pull/{pr_number}/head` and finds their **commit** SHA.
- Unit tests for new functions `filterTree`, `resolveGitReference`.
- Update unit tests for `GetFileContent` to include mocking github client for resolving the git refs.


### Examples

<details><summary>File (Unknown Path) from Branch with 2 Matches</summary>

```
get file "server.go" from github/github-mcp-server
```


<img width="707" alt="image" src="https://github.com/user-attachments/assets/af07908b-ec12-41ea-a15c-a4577d1e82ee" />

</details> 

<details><summary>File (Unknown Path) from Last Release</summary>

```
get file "server.go" from github/github-mcp-server from the last release
```

<img width="703" alt="image" src="https://github.com/user-attachments/assets/c0c512f9-26fc-4e09-a809-d3554a2dc996" />

</details> 

<details><summary>File from Pull Request</summary>

```
get repositories.go from PR #605 in github/github-mcp-server
```

<img width="699" alt="image" src="https://github.com/user-attachments/assets/2019de74-1f61-44eb-9fe9-46a4f2fcc620" />

</details> 


<details><summary>File from Branch</summary>

```
get repositories.go from the lulu/get-file branch of github/github-mcp-server
```

<img width="704" alt="image" src="https://github.com/user-attachments/assets/2ea039fb-2cd2-4180-856d-b7d781aa3bf1" />

</details>



### TODO

- [x] Ensure `ref` is not empty when we call `client.Git.GetTree`
- [x] Ensure `/` are handled properly by `filterPaths`. Have unit tests.
- [x] Properly formatted errors
