### PR TITLE
Update `create_or_update_file` SHA Arg Description

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -288,7 +288,7 @@ func CreateOrUpdateFile(getClient GetClientFn, t translations.TranslationHelperF
 				mcp.Description("Branch to create/update the file in"),
 			),
 			mcp.WithString("sha",
-				mcp.Description("SHA of file being replaced (for updates)"),
+				mcp.Description("Required if you are updating an existing file. The blob SHA of the file being replaced."),
 			),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
Clarifies that `sha` is required if updating an existing file.

Fixes agent trying to update a file without providing the blob SHA.

New description is also more aligned to the API docs for this parameter
https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents

Relates to https://github.com/github/github-mcp-server/pull/605 because we would like to allow the agent get thee blob SHA using `get_file_contents` tool