### PR TITLE
Tommy/(Bug-fix): adjust tool description to account for author in prompt

### DIFF
--- a/pkg/github/__toolsnaps__/list_pull_requests.snap
+++ b/pkg/github/__toolsnaps__/list_pull_requests.snap
@@ -3,7 +3,7 @@
     "title": "List pull requests",
     "readOnlyHint": true
   },
-  "description": "List pull requests in a GitHub repository.",
+  "description": "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.",
   "inputSchema": {
     "properties": {
       "base": {

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -361,10 +361,6 @@ func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFun
 				mcp.Description("Sort direction"),
 				mcp.Enum("asc", "desc"),
 			),
-			mcp.WithString("author", 
-				mcp.Description("Filter by author username."),
-			),
-			
 			WithPagination(),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -393,9 +389,6 @@ func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFun
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			direction, err := OptionalParam[string](request, "direction")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -330,7 +330,7 @@ func UpdatePullRequest(getClient GetClientFn, t translations.TranslationHelperFu
 // ListPullRequests creates a tool to list and filter repository pull requests.
 func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.Tool, server.ToolHandlerFunc) {
 	return mcp.NewTool("list_pull_requests",
-			mcp.WithDescription(t("TOOL_LIST_PULL_REQUESTS_DESCRIPTION", "List pull requests in a GitHub repository.")),
+			mcp.WithDescription(t("TOOL_LIST_PULL_REQUESTS_DESCRIPTION", "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool, use the search_pull_requests tool instead.")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_LIST_PULL_REQUESTS_USER_TITLE", "List pull requests"),
 				ReadOnlyHint: ToBoolPtr(true),
@@ -361,6 +361,10 @@ func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFun
 				mcp.Description("Sort direction"),
 				mcp.Enum("asc", "desc"),
 			),
+			mcp.WithString("author", 
+				mcp.Description("Filter by author username."),
+			),
+			
 			WithPagination(),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -392,11 +396,13 @@ func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFun
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
 			pagination, err := OptionalPaginationParams(request)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-
 			opts := &github.PullRequestListOptions{
 				State:     state,
 				Head:      head,

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -330,7 +330,7 @@ func UpdatePullRequest(getClient GetClientFn, t translations.TranslationHelperFu
 // ListPullRequests creates a tool to list and filter repository pull requests.
 func ListPullRequests(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.Tool, server.ToolHandlerFunc) {
 	return mcp.NewTool("list_pull_requests",
-			mcp.WithDescription(t("TOOL_LIST_PULL_REQUESTS_DESCRIPTION", "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool, use the search_pull_requests tool instead.")),
+			mcp.WithDescription(t("TOOL_LIST_PULL_REQUESTS_DESCRIPTION", "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_LIST_PULL_REQUESTS_USER_TITLE", "List pull requests"),
 				ReadOnlyHint: ToBoolPtr(true),


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->
### Overview
This PR fixes a buggy behaviour which occurs when the user uses the Github MCP to query PRs by author (e.g. by asking "show me my last 10 PRs in repo xyz") and the MCP uses the `list_pull_requests` tool, which does not support author-specific queries due to constraints in the Github API (see official API [docs](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests)). 

To fix this issue, this PR changes the `list_pull_requests` tool description to ensure that the `search_pull_requests` tool is selected when the user requests PRs by author.

### Testing
This solution seems to work as expected across all models. The only caveat is that o4-mini sometimes doesn't seem to always use the `get_me` tool to get the user information before using the `search_pull_requests` tool (it does sometimes, as shown in the last screenshot). This behaviour should be investigated further but I don't believe it's specific to this PR.

**Demo - Claude 4**
<img width="386" height="1045" alt="Screenshot 2025-07-10 at 17 14 46" src="https://github.com/user-attachments/assets/5311794a-b3a3-4330-a715-24abb4617a5a" />

**Demo - ChatGTP 4.1**
<img width="386" height="1045" alt="Screenshot 2025-07-10 at 17 42 09" src="https://github.com/user-attachments/assets/6da9bb00-d94b-486c-b704-d408eaea7f67" />

**Demo - ChatGPT 4.0**
<img width="386" height="1045" alt="Screenshot 2025-07-10 at 17 43 03" src="https://github.com/user-attachments/assets/38400abe-750b-4056-a0fb-2212f0dc8eee" />

**Demo - ChatGPT o4-mini (without get-me)**
<img width="386" height="1045" alt="Screenshot 2025-07-10 at 17 54 01" src="https://github.com/user-attachments/assets/e3eb81bd-eaa1-4a67-801f-d4fc691e05f2" />

**Demo - ChatGPT o4-mini (with get-me)**
<img width="3024" height="1890" alt="Screenshot 2025-07-10 at 17 42 38" src="https://github.com/user-attachments/assets/a04b6a2a-b18f-4146-a34e-22e4511da65a" />