### PR TITLE
simplify environment var with same format UPPERCASE and UNDERSCORE

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -92,6 +92,8 @@ func init() {
 func initConfig() {
 	// Initialize Viper configuration
 	viper.SetEnvPrefix("github")
+	// Replace hyphens with underscores in environment variable names
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 }


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:

This enhance that all argument can be treat as environment variable with standard format from viper https://github.com/spf13/viper/blob/master/viper.go#L1400-L1403

eg: given argument flag `dynamic-toolsets` can use as `GITHUB_DYNAMIC_TOOLSETS`
