### PR TITLE
fix: get_file_contents use "/" for root

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
 
 - **get_file_contents** - Get file or directory contents
   - `owner`: Repository owner (username or organization) (string, required)
-  - `path`: Path to file/directory (directories must end with a slash '/') (string, required)
+  - `path`: Path to file/directory. Directories, including root, must end with '/' (string, required)
   - `ref`: Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head` (string, optional)
   - `repo`: Repository name (string, required)
   - `sha`: Accepts optional commit SHA. If specified, it will be used instead of ref (string, optional)

--- a/pkg/github/__toolsnaps__/get_file_contents.snap
+++ b/pkg/github/__toolsnaps__/get_file_contents.snap
@@ -11,7 +11,7 @@
         "type": "string"
       },
       "path": {
-        "description": "Path to file/directory (directories must end with a slash '/')",
+        "description": "Path to file/directory. Directories, including root, must end with '/'",
         "type": "string"
       },
       "ref": {

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -464,7 +464,7 @@ func GetFileContents(getClient GetClientFn, getRawClient raw.GetRawClientFn, t t
 			),
 			mcp.WithString("path",
 				mcp.Required(),
-				mcp.Description("Path to file/directory (directories must end with a slash '/')"),
+				mcp.Description("Path to file/directory. Directories, including root, must end with '/'"),
 			),
 			mcp.WithString("ref",
 				mcp.Description("Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`"),


### PR DESCRIPTION
Problem: To get root directory, agent was calling `get_file_contents` with path `""` which is not allowed for a required param.

Fix: Updated `path` param description:
> Path to file/directory. Directories, including root, must end with '/'


<details><summary>Screenshot</summary>

Claude Sonnet 3.5
```
get the contents of the github/github-mcp-server repo
```

<img width="691" height="767" alt="image" src="https://github.com/user-attachments/assets/753c525e-3a59-4ca1-aacc-3a503d779838" />

</details> 


