### PR TITLE
Reorganize README, add dedicated install guides, include policies and governance info for the github server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,17 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+## What we're looking for
+
+We can't guarantee that every tool, feature, or pull request will be approved or merged. Our focus is on supporting high-quality, high-impact capabilities that advance agentic workflows and deliver clear value to developers.
+
+To increase the chances your request is accepted:
+* Include real use cases or examples that demonstrate practical value
+* If your request stalls, you can open a Discussion post and link to your issue or PR
+* We actively revisit requests that gain strong community engagement (👍s, comments, or evidence of real-world use)
+
+Thanks for contributing and for helping us build toolsets that are truly valuable!
+
 ## Prerequisites for running and testing code
 
 These are one time installations required to be able to test your changes locally as part of the pull request (PR) submission process.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 > ⚠️ **Public Preview Status:** The **remote** GitHub MCP Server is currently in Public Preview. During preview, access may be gated depending on authentication type and surface:
 > - OAuth: Subject to GitHub Copilot Editor Preview Policy until GA
 > - PAT: Controlled via your organization's PAT policies
-> - MCP Access in Copilot: Enables/disables access to all MCP servers in VS Code and Copilot Coding Agent, with other Copilot editors migrating to this policy in the coming months.
+> - MCP Servers in Copilot policy: Enables/disables access to all MCP servers in VS Code, with other Copilot editors migrating to this policy in the coming months.
 
 ### Configuration
 See [Remote Server Documentation](/docs/remote-server.md) on how to pass additional configuration settings to the remote GitHub MCP Server.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # GitHub MCP Server
 
-The GitHub MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction)
-server that provides seamless integration with GitHub APIs, enabling advanced
-automation and interaction capabilities for developers and tools.
+The GitHub MCP Server connects AI tools directly to GitHub's platform. This gives AI agents, assistants, and chatbots the ability to read repositories and code files, manage issues and PRs, analyze code, and automate workflows. All through natural language interactions.
 
 ### Use Cases
 
-- Automating GitHub workflows and processes.
-- Extracting and analyzing data from GitHub repositories.
-- Building AI powered tools and applications that interact with GitHub's ecosystem.
+- Repository Management: Browse and query code, search files, analyze commits, and understand project structure across any repository you have access to.
+- Issue & PR Automation: Create, update, and manage issues and pull requests. Let AI help triage bugs, review code changes, and maintain project boards.
+- CI/CD & Workflow Intelligence: Monitor GitHub Actions workflow runs, analyze build failures, manage releases, and get insights into your development pipeline.
+- Code Analysis: Examine security findings, review Dependabot alerts, understand code patterns, and get comprehensive insights into your codebase.
+- Team Collaboration: Access discussions, manage notifications, analyze team activity, and streamline processes for your team.
+
+Built for developers who want to connect their AI tools to GitHub context and capabilities, from simple natural language queries to complex multi-step agent workflows.
 
 ---
 
@@ -20,14 +22,12 @@ The remote GitHub MCP Server is hosted by GitHub and provides the easiest method
 
 ## Prerequisites
 
-1. An MCP host that supports the latest MCP specification and remote servers, such as [VS Code](https://code.visualstudio.com/).
+1. A compatible MCP host with remote server support (VS Code 1.101+, Claude Desktop, Cursor, Windsurf, etc.)
+2. Any applicable [policies enabled](https://github.com/github/github-mcp-server/blob/main/docs/policies-and-governance.md)
 
-## Installation
-
-### Usage with VS Code
+## Install in VS Code
 
 For quick installation, use one of the one-click install buttons above. Once you complete that flow, toggle Agent mode (located by the Copilot Chat text input) and the server will start. Make sure you're using [VS Code 1.101](https://code.visualstudio.com/updates/v1_101) or [later](https://code.visualstudio.com/updates) for remote MCP and OAuth support.
-
 
 Alternatively, to manually configure VS Code, choose the appropriate JSON block from the examples below and add it to your host configuration:
 
@@ -77,48 +77,18 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 </tr>
 </table>
 
-### Usage in other MCP Hosts
+## Install in other MCP hosts
+- **[GitHub Copilot in other IDEs](/docs/installation-guides/install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
+- **[Claude Applications](/docs/installation-guides/install-claude.md)** - Installation guide for Claude Web, Claude Desktop and Claude Code CLI
+- **[Cursor](/docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE
+- **[Windsurf](/docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
 
-For MCP Hosts that are [Remote MCP-compatible](docs/host-integration.md), choose the appropriate JSON block from the examples below and add it to your host configuration:
+> **Note:** Each MCP host application needs to configure a GitHub App or OAuth App to support remote access via OAuth. Any host application that supports remote MCP servers should support the remote GitHub server with PAT authentication. Configuration details and support levels vary by host. Make sure to refer to the host application's documentation for more info.
 
-<table>
-<tr><th>Using OAuth</th><th>Using a GitHub PAT</th></tr>
-<tr valign=top>
-<td>
-  
-```json
-{
-  "mcpServers": {
-    "github": {
-      "url": "https://api.githubcopilot.com/mcp/"
-    }
-  }
-}
-```
-
-</td>
-<td>
-
-```json
-{
-  "mcpServers": {
-    "github": {
-      "url": "https://api.githubcopilot.com/mcp/",
-      "authorization_token": "Bearer <your GitHub PAT>"
-    }
-  }
-}
-```
-
-</td>
-</tr>
-</table>
-
-> **Note:** The exact configuration format may vary by host. Refer to your host's documentation for the correct syntax and location for remote MCP server setup.
-
-### Configuration
-
-See [Remote Server Documentation](docs/remote-server.md) on how to pass additional configuration settings to the remote GitHub MCP Server.
+> ⚠️ **Public Preview Status:** The **remote** GitHub MCP Server is currently in Public Preview. During preview, access may be gated depending on authentication type and surface:
+> - OAuth: Subject to GitHub Copilot Editor Preview Policy until GA
+> - PAT: Controlled via your organization's PAT policies
+> - MCP Access in Copilot: Enables/disables access to all MCP servers in VS Code and Copilot Coding Agent, with other Copilot editors migrating to this policy in the coming months.
 
 ---
 
@@ -133,15 +103,71 @@ See [Remote Server Documentation](docs/remote-server.md) on how to pass addition
 3. Lastly you will need to [Create a GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new).
 The MCP server can use many of the GitHub APIs, so enable the permissions that you feel comfortable granting your AI tools (to learn more about access tokens, please check out the [documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)).
 
+<details><summary><b>Handling PATs Securely</b></summary>
+
+## Environment Variables (Recommended)
+To keep your GitHub PAT secure and reusable across different MCP hosts:
+
+1. **Store your PAT in environment variables**
+   ```bash
+   export GITHUB_PAT=your_token_here
+   ```
+   Or create a `.env` file:
+   ```env
+   GITHUB_PAT=your_token_here
+   ```
+
+2. **Protect your `.env` file**
+   ```bash
+   # Add to .gitignore to prevent accidental commits
+   echo ".env" >> .gitignore
+   ```
+
+3. **Reference the token in configurations**
+   ```bash
+   # CLI usage
+   claude mcp update github -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PAT
+   
+   # In config files (where supported)
+   "env": {
+     "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_PAT"
+   }
+   ```
+
+> **Note**: Environment variable support varies by host app and IDE. Some applications (like Windsurf) require hardcoded tokens in config files.
+
+## Token Security Best Practices
+
+- **Minimum scopes**: Only grant necessary permissions
+  - `repo` - Repository operations
+  - `read:packages` - Docker image access
+- **Separate tokens**: Use different PATs for different projects/environments
+- **Regular rotation**: Update tokens periodically
+- **Never commit**: Keep tokens out of version control
+- **File permissions**: Restrict access to config files containing tokens
+  ```bash
+  chmod 600 ~/.your-app/config.json
+  ```
+
+## Required Scopes
+For GitHub MCP Server functionality, your PAT needs:
+- `repo` - Full repository access
+- `read:org` - Organization membership (if accessing org repos)
+- `workflow` - GitHub Actions access (if using workflow tools)
+
+</details>
+
 ## Installation
 
-### Usage with VS Code
+### Install in GitHub Copilot on VS Code
 
-For quick installation, use one of the one-click install buttons. Once you complete that flow, toggle Agent mode (located by the Copilot Chat text input) and the server will start.
+For quick installation, use one of the one-click install buttons above. Once you complete that flow, toggle Agent mode (located by the Copilot Chat text input) and the server will start.
 
-### Usage in other MCP Hosts
+More about using MCP server tools in VS Code's [agent mode documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
 
-Add the following JSON block to your IDE MCP settings.
+Install in GitHub Copilot on other IDEs (JetBrains, Visual Studio, Eclipse, etc.)
+
+Add the following JSON block to your IDE's MCP settings.
 
 ```json
 {
@@ -174,8 +200,11 @@ Add the following JSON block to your IDE MCP settings.
 }
 ```
 
-Optionally, you can add a similar example (i.e. without the mcp key) to a file called `.vscode/mcp.json` in your workspace. This will allow you to share the configuration with others.
+Optionally, you can add a similar example (i.e. without the mcp key) to a file called `.vscode/mcp.json` in your workspace. This will allow you to share the configuration with other host applications that accept the same format.
 
+<details>
+<summary><b>Example JSON block without the MCP key included</b></summary>
+<br>
 
 ```json
 {
@@ -204,33 +233,21 @@ Optionally, you can add a similar example (i.e. without the mcp key) to a file c
     }
   }
 }
-
 ```
 
-More about using MCP server tools in VS Code's [agent mode documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+</details>
 
-### Usage with Claude Desktop
+### Install in Other Host Applications
 
-```json
-{
-  "mcpServers": {
-    "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
-      }
-    }
-  }
-}
-```
+For other MCP host applications, please refer to our installation guides:
+
+- **[Claude Code & Claude Desktop](docs/installation-guides/install-claude.md)** - Installation guide for Claude Code and Claude Desktop
+- **[Cursor](docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE  
+- **[Windsurf](docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
+
+For a complete overview of all installation options, see our **[Installation Guides Index](docs/installation-guides/installation-guides.md)**.
+
+> **Note:** Any host application that supports local MCP servers should be able to access the local GitHub MCP server. However, the specific configuration process, syntax and stability of the integration will vary by host application. While many may follow a similar format to the examples above, this is not guaranteed. Please refer to your host application's documentation for the correct MCP configuration syntax and setup process.
 
 ### Build from source
 
@@ -280,153 +297,6 @@ The following sets of tools are available (all are on by default):
 | `secret_protection` | Secret protection related tools, such as GitHub Secret Scanning |
 | `users` | GitHub User related tools |
 <!-- END AUTOMATED TOOLSETS -->
-
-#### Specifying Toolsets
-
-To specify toolsets you want available to the LLM, you can pass an allow-list in two ways:
-
-1. **Using Command Line Argument**:
-
-   ```bash
-   github-mcp-server --toolsets repos,issues,pull_requests,actions,code_security
-   ```
-
-2. **Using Environment Variable**:
-   ```bash
-   GITHUB_TOOLSETS="repos,issues,pull_requests,actions,code_security" ./github-mcp-server
-   ```
-
-The environment variable `GITHUB_TOOLSETS` takes precedence over the command line argument if both are provided.
-
-### Using Toolsets With Docker
-
-When using Docker, you can pass the toolsets as environment variables:
-
-```bash
-docker run -i --rm \
-  -e GITHUB_PERSONAL_ACCESS_TOKEN=<your-token> \
-  -e GITHUB_TOOLSETS="repos,issues,pull_requests,actions,code_security,experiments" \
-  ghcr.io/github/github-mcp-server
-```
-
-### The "all" Toolset
-
-The special toolset `all` can be provided to enable all available toolsets regardless of any other configuration:
-
-```bash
-./github-mcp-server --toolsets all
-```
-
-Or using the environment variable:
-
-```bash
-GITHUB_TOOLSETS="all" ./github-mcp-server
-```
-
-## Dynamic Tool Discovery
-
-**Note**: This feature is currently in beta and may not be available in all environments. Please test it out and let us know if you encounter any issues.
-
-Instead of starting with all tools enabled, you can turn on dynamic toolset discovery. Dynamic toolsets allow the MCP host to list and enable toolsets in response to a user prompt. This should help to avoid situations where the model gets confused by the sheer number of tools available.
-
-### Using Dynamic Tool Discovery
-
-When using the binary, you can pass the `--dynamic-toolsets` flag.
-
-```bash
-./github-mcp-server --dynamic-toolsets
-```
-
-When using Docker, you can pass the toolsets as environment variables:
-
-```bash
-docker run -i --rm \
-  -e GITHUB_PERSONAL_ACCESS_TOKEN=<your-token> \
-  -e GITHUB_DYNAMIC_TOOLSETS=1 \
-  ghcr.io/github/github-mcp-server
-```
-
-## Read-Only Mode
-
-To run the server in read-only mode, you can use the `--read-only` flag. This will only offer read-only tools, preventing any modifications to repositories, issues, pull requests, etc.
-
-```bash
-./github-mcp-server --read-only
-```
-
-When using Docker, you can pass the read-only mode as an environment variable:
-
-```bash
-docker run -i --rm \
-  -e GITHUB_PERSONAL_ACCESS_TOKEN=<your-token> \
-  -e GITHUB_READ_ONLY=1 \
-  ghcr.io/github/github-mcp-server
-```
-
-## GitHub Enterprise Server and Enterprise Cloud with data residency (ghe.com)
-
-The flag `--gh-host` and the environment variable `GITHUB_HOST` can be used to set
-the hostname for GitHub Enterprise Server or GitHub Enterprise Cloud with data residency.
-
-- For GitHub Enterprise Server, prefix the hostname with the `https://` URI scheme, as it otherwise defaults to `http://`, which GitHub Enterprise Server does not support.
-- For GitHub Enterprise Cloud with data residency, use `https://YOURSUBDOMAIN.ghe.com` as the hostname.
-``` json
-"github": {
-    "command": "docker",
-    "args": [
-    "run",
-    "-i",
-    "--rm",
-    "-e",
-    "GITHUB_PERSONAL_ACCESS_TOKEN",
-    "-e",
-    "GITHUB_HOST",
-    "ghcr.io/github/github-mcp-server"
-    ],
-    "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}",
-        "GITHUB_HOST": "https://<your GHES or ghe.com domain name>"
-    }
-}
-```
-
-## i18n / Overriding Descriptions
-
-The descriptions of the tools can be overridden by creating a
-`github-mcp-server-config.json` file in the same directory as the binary.
-
-The file should contain a JSON object with the tool names as keys and the new
-descriptions as values. For example:
-
-```json
-{
-  "TOOL_ADD_ISSUE_COMMENT_DESCRIPTION": "an alternative description",
-  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository"
-}
-```
-
-You can create an export of the current translations by running the binary with
-the `--export-translations` flag.
-
-This flag will preserve any translations/overrides you have made, while adding
-any new translations that have been added to the binary since the last time you
-exported.
-
-```sh
-./github-mcp-server --export-translations
-cat github-mcp-server-config.json
-```
-
-You can also use ENV vars to override the descriptions. The environment
-variable names are the same as the keys in the JSON file, prefixed with
-`GITHUB_MCP_` and all uppercase.
-
-For example, to override the `TOOL_ADD_ISSUE_COMMENT_DESCRIPTION` tool, you can
-set the following environment variable:
-
-```sh
-export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description"
-```
 
 ## Tools
 
@@ -996,6 +866,153 @@ export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description
     -   `base_ref`: Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch (string, optional)
 
 </details>
+
+#### Specifying Toolsets
+
+To specify toolsets you want available to the LLM, you can pass an allow-list in two ways:
+
+1. **Using Command Line Argument**:
+
+   ```bash
+   github-mcp-server --toolsets repos,issues,pull_requests,actions,code_security
+   ```
+
+2. **Using Environment Variable**:
+   ```bash
+   GITHUB_TOOLSETS="repos,issues,pull_requests,actions,code_security" ./github-mcp-server
+   ```
+
+The environment variable `GITHUB_TOOLSETS` takes precedence over the command line argument if both are provided.
+
+### Using Toolsets With Docker
+
+When using Docker, you can pass the toolsets as environment variables:
+
+```bash
+docker run -i --rm \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=<your-token> \
+  -e GITHUB_TOOLSETS="repos,issues,pull_requests,actions,code_security,experiments" \
+  ghcr.io/github/github-mcp-server
+```
+
+### The "all" Toolset
+
+The special toolset `all` can be provided to enable all available toolsets regardless of any other configuration:
+
+```bash
+./github-mcp-server --toolsets all
+```
+
+Or using the environment variable:
+
+```bash
+GITHUB_TOOLSETS="all" ./github-mcp-server
+```
+
+## Dynamic Tool Discovery
+
+**Note**: This feature is currently in beta and may not be available in all environments. Please test it out and let us know if you encounter any issues.
+
+Instead of starting with all tools enabled, you can turn on dynamic toolset discovery. Dynamic toolsets allow the MCP host to list and enable toolsets in response to a user prompt. This should help to avoid situations where the model gets confused by the sheer number of tools available.
+
+### Using Dynamic Tool Discovery
+
+When using the binary, you can pass the `--dynamic-toolsets` flag.
+
+```bash
+./github-mcp-server --dynamic-toolsets
+```
+
+When using Docker, you can pass the toolsets as environment variables:
+
+```bash
+docker run -i --rm \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=<your-token> \
+  -e GITHUB_DYNAMIC_TOOLSETS=1 \
+  ghcr.io/github/github-mcp-server
+```
+
+## Read-Only Mode
+
+To run the server in read-only mode, you can use the `--read-only` flag. This will only offer read-only tools, preventing any modifications to repositories, issues, pull requests, etc.
+
+```bash
+./github-mcp-server --read-only
+```
+
+When using Docker, you can pass the read-only mode as an environment variable:
+
+```bash
+docker run -i --rm \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=<your-token> \
+  -e GITHUB_READ_ONLY=1 \
+  ghcr.io/github/github-mcp-server
+```
+
+## GitHub Enterprise Server and Enterprise Cloud with data residency (ghe.com)
+
+The flag `--gh-host` and the environment variable `GITHUB_HOST` can be used to set
+the hostname for GitHub Enterprise Server or GitHub Enterprise Cloud with data residency.
+
+- For GitHub Enterprise Server, prefix the hostname with the `https://` URI scheme, as it otherwise defaults to `http://`, which GitHub Enterprise Server does not support.
+- For GitHub Enterprise Cloud with data residency, use `https://YOURSUBDOMAIN.ghe.com` as the hostname.
+``` json
+"github": {
+    "command": "docker",
+    "args": [
+    "run",
+    "-i",
+    "--rm",
+    "-e",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+    "-e",
+    "GITHUB_HOST",
+    "ghcr.io/github/github-mcp-server"
+    ],
+    "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}",
+        "GITHUB_HOST": "https://<your GHES or ghe.com domain name>"
+    }
+}
+```
+
+## i18n / Overriding Descriptions
+
+The descriptions of the tools can be overridden by creating a
+`github-mcp-server-config.json` file in the same directory as the binary.
+
+The file should contain a JSON object with the tool names as keys and the new
+descriptions as values. For example:
+
+```json
+{
+  "TOOL_ADD_ISSUE_COMMENT_DESCRIPTION": "an alternative description",
+  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository"
+}
+```
+
+You can create an export of the current translations by running the binary with
+the `--export-translations` flag.
+
+This flag will preserve any translations/overrides you have made, while adding
+any new translations that have been added to the binary since the last time you
+exported.
+
+```sh
+./github-mcp-server --export-translations
+cat github-mcp-server-config.json
+```
+
+You can also use ENV vars to override the descriptions. The environment
+variable names are the same as the keys in the JSON file, prefixed with
+`GITHUB_MCP_` and all uppercase.
+
+For example, to override the `TOOL_ADD_ISSUE_COMMENT_DESCRIPTION` tool, you can
+set the following environment variable:
+
+```sh
+export GITHUB_MCP_TOOL_ADD_ISSUE_COMMENT_DESCRIPTION="an alternative description"
+```
 
 ## Library Usage
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Built for developers who want to connect their AI tools to GitHub context and ca
 
 The remote GitHub MCP Server is hosted by GitHub and provides the easiest method for getting up and running. If your MCP host does not support remote MCP servers, don't worry! You can use the [local version of the GitHub MCP Server](https://github.com/github/github-mcp-server?tab=readme-ov-file#local-github-mcp-server) instead.
 
-## Prerequisites
+### Prerequisites
 
 1. A compatible MCP host with remote server support (VS Code 1.101+, Claude Desktop, Cursor, Windsurf, etc.)
 2. Any applicable [policies enabled](https://github.com/github/github-mcp-server/blob/main/docs/policies-and-governance.md)
 
-## Install in VS Code
+### Install in VS Code
 
 For quick installation, use one of the one-click install buttons above. Once you complete that flow, toggle Agent mode (located by the Copilot Chat text input) and the server will start. Make sure you're using [VS Code 1.101](https://code.visualstudio.com/updates/v1_101) or [later](https://code.visualstudio.com/updates) for remote MCP and OAuth support.
 
@@ -77,13 +77,16 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 </tr>
 </table>
 
-## Install in other MCP hosts
+### Install in other MCP hosts
 - **[GitHub Copilot in other IDEs](/docs/installation-guides/install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
 - **[Claude Applications](/docs/installation-guides/install-claude.md)** - Installation guide for Claude Web, Claude Desktop and Claude Code CLI
 - **[Cursor](/docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE
 - **[Windsurf](/docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
 
 > **Note:** Each MCP host application needs to configure a GitHub App or OAuth App to support remote access via OAuth. Any host application that supports remote MCP servers should support the remote GitHub server with PAT authentication. Configuration details and support levels vary by host. Make sure to refer to the host application's documentation for more info.
+
+### Configuration
+See [Remote Server Documentation](/docs/remote-server.md) on how to pass additional configuration settings to the remote GitHub MCP Server.
 
 > ⚠️ **Public Preview Status:** The **remote** GitHub MCP Server is currently in Public Preview. During preview, access may be gated depending on authentication type and surface:
 > - OAuth: Subject to GitHub Copilot Editor Preview Policy until GA
@@ -96,7 +99,7 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 
 [![Install with Docker in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=github&inputs=%5B%7B%22id%22%3A%22github_token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22GitHub%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22GITHUB_PERSONAL_ACCESS_TOKEN%22%2C%22ghcr.io%2Fgithub%2Fgithub-mcp-server%22%5D%2C%22env%22%3A%7B%22GITHUB_PERSONAL_ACCESS_TOKEN%22%3A%22%24%7Binput%3Agithub_token%7D%22%7D%7D) [![Install with Docker in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=github&inputs=%5B%7B%22id%22%3A%22github_token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22GitHub%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22GITHUB_PERSONAL_ACCESS_TOKEN%22%2C%22ghcr.io%2Fgithub%2Fgithub-mcp-server%22%5D%2C%22env%22%3A%7B%22GITHUB_PERSONAL_ACCESS_TOKEN%22%3A%22%24%7Binput%3Agithub_token%7D%22%7D%7D&quality=insiders)
 
-## Prerequisites
+### Prerequisites
 
 1. To run the server in a container, you will need to have [Docker](https://www.docker.com/) installed.
 2. Once Docker is installed, you will also need to ensure Docker is running. The image is public; if you get errors on pull, you may have an expired token and need to `docker logout ghcr.io`.
@@ -105,7 +108,7 @@ The MCP server can use many of the GitHub APIs, so enable the permissions that y
 
 <details><summary><b>Handling PATs Securely</b></summary>
 
-## Environment Variables (Recommended)
+### Environment Variables (Recommended)
 To keep your GitHub PAT secure and reusable across different MCP hosts:
 
 1. **Store your PAT in environment variables**
@@ -136,7 +139,7 @@ To keep your GitHub PAT secure and reusable across different MCP hosts:
 
 > **Note**: Environment variable support varies by host app and IDE. Some applications (like Windsurf) require hardcoded tokens in config files.
 
-## Token Security Best Practices
+### Token Security Best Practices
 
 - **Minimum scopes**: Only grant necessary permissions
   - `repo` - Repository operations
@@ -148,12 +151,6 @@ To keep your GitHub PAT secure and reusable across different MCP hosts:
   ```bash
   chmod 600 ~/.your-app/config.json
   ```
-
-## Required Scopes
-For GitHub MCP Server functionality, your PAT needs:
-- `repo` - Full repository access
-- `read:org` - Organization membership (if accessing org repos)
-- `workflow` - GitHub Actions access (if using workflow tools)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 
 > **Note:** Each MCP host application needs to configure a GitHub App or OAuth App to support remote access via OAuth. Any host application that supports remote MCP servers should support the remote GitHub server with PAT authentication. Configuration details and support levels vary by host. Make sure to refer to the host application's documentation for more info.
 
-### Configuration
-See [Remote Server Documentation](/docs/remote-server.md) on how to pass additional configuration settings to the remote GitHub MCP Server.
-
 > ⚠️ **Public Preview Status:** The **remote** GitHub MCP Server is currently in Public Preview. During preview, access may be gated depending on authentication type and surface:
 > - OAuth: Subject to GitHub Copilot Editor Preview Policy until GA
 > - PAT: Controlled via your organization's PAT policies
 > - MCP Access in Copilot: Enables/disables access to all MCP servers in VS Code and Copilot Coding Agent, with other Copilot editors migrating to this policy in the coming months.
+
+### Configuration
+See [Remote Server Documentation](/docs/remote-server.md) on how to pass additional configuration settings to the remote GitHub MCP Server.
 
 ---
 

--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -1,0 +1,95 @@
+# GitHub MCP Server Installation Guides
+
+This directory contains detailed installation instructions for the GitHub MCP Server across different host applications and IDEs. Choose the guide that matches your development environment.
+
+## Installation Guides by Host Application
+- **[GitHub Copilot in other IDEs](install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
+- **[Claude Applications](install-claude.md)** - Installation guide for Claude Web, Claude Desktop and Claude Code CLI
+- **[Cursor](install-cursor.md)** - Installation guide for Cursor IDE
+- **[Windsurf](install-windsurf.md)** - Installation guide for Windsurf IDE
+
+## Support by Host Application
+
+| Host Application | Local GitHub MCP Support | Remote GitHub MCP Support | Prerequisites | Difficulty |
+|-----------------|---------------|----------------|---------------|------------|
+| Copilot in VS Code | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: VS Code 1.101+ | Easy |
+| Copilot Coding Agent | ✅ | ✅ Full (on by default; no auth needed) | Any _paid_ copilot license | Default on |
+| Copilot in Visual Studio | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker or Go build, GitHub PAT<br>Remote: Visual Studio 17.14+ | Easy |
+| Copilot in JetBrains | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker or Go build, GitHub PAT<br>Remote: JetBrains Copilot Extension v1.5.35+ | Easy |
+| Claude Code | ✅ | ✅ PAT + ❌ No OAuth| GitHub MCP Server binary or remote URL, GitHub PAT | Easy |
+| Claude Desktop | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Moderate |
+| Cursor | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
+| Windsurf | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
+| Copilot in Xcode | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker or Go build, GitHub PAT<br>Remote: Copilot for Xcode latest version | Easy |
+| Copilot in Eclipse | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker or Go build, GitHub PAT<br>Remote: TBD | Easy |
+
+**Legend:**
+- ✅ = Fully supported
+- ❌ = Not yet supported
+
+**Note:** Remote MCP support requires host applications to register a GitHub App or OAuth app for OAuth flow support – even if the new OAuth spec is supported by that host app. Currently, only VS Code has full remote GitHub server support. 
+
+## Installation Methods
+
+The GitHub MCP Server can be installed using several methods. **Docker is the most popular and recommended approach** for most users, but alternatives are available depending on your needs:
+
+### 🐳 Docker (Most Common & Recommended)
+- **Pros**: No local build required, consistent environment, easy updates, works across all platforms
+- **Cons**: Requires Docker installed and running
+- **Best for**: Most users, especially those already using Docker or wanting the simplest setup
+- **Used by**: Claude Desktop, Copilot in VS Code, Cursor, Windsurf, etc.
+
+### 📦 Pre-built Binary (Lightweight Alternative)
+- **Pros**: No Docker required, direct execution via stdio, minimal setup
+- **Cons**: Need to manually download and manage updates, platform-specific binaries
+- **Best for**: Minimal environments, users who prefer not to use Docker
+- **Used by**: Claude Code CLI, lightweight setups
+
+### 🔨 Build from Source (Advanced Users)
+- **Pros**: Latest features, full customization, no external dependencies
+- **Cons**: Requires Go development environment, more complex setup
+- **Prerequisites**: [Go 1.24+](https://go.dev/doc/install)
+- **Build command**: `go build -o github-mcp-server cmd/github-mcp-server/main.go`
+- **Best for**: Developers who want the latest features or need custom modifications
+
+### Important Notes on the GitHub MCP Server
+
+- **Docker Image**: The official Docker image is now `ghcr.io/github/github-mcp-server`
+- **npm Package**: The npm package @modelcontextprotocol/server-github is no longer supported as of April 2025
+- **Remote Server**: The remote server URL is `https://api.githubcopilot.com/mcp/`
+
+## General Prerequisites
+
+All installations with Personal Access Tokens (PAT) require:
+- **GitHub Personal Access Token (PAT)**: [Create one here](https://github.com/settings/personal-access-tokens/new)
+
+Optional (depending on installation method):
+- **Docker** (for Docker-based installations): [Download Docker](https://www.docker.com/)
+- **Go 1.24+** (for building from source): [Install Go](https://go.dev/doc/install)
+
+## Security Best Practices
+
+Regardless of which installation method you choose, follow these security guidelines:
+
+1. **Secure Token Storage**: Never commit your GitHub PAT to version control
+2. **Limit Token Scope**: Only grant necessary permissions to your GitHub PAT
+3. **File Permissions**: Restrict access to configuration files containing tokens
+4. **Regular Rotation**: Periodically rotate your GitHub Personal Access Tokens
+5. **Environment Variables**: Use environment variables when supported by your host
+
+## Getting Help
+
+If you encounter issues:
+1. Check the troubleshooting section in your specific installation guide
+2. Verify your GitHub PAT has the required permissions
+3. Ensure Docker is running (for local installations)
+4. Review your host application's logs for error messages
+5. Consult the main [README.md](README.md) for additional configuration options
+
+## Configuration Options
+
+After installation, you may want to explore:
+- **Toolsets**: Enable/disable specific GitHub API capabilities
+- **Read-Only Mode**: Restrict to read-only operations
+- **Dynamic Tool Discovery**: Enable tools on-demand
+

--- a/docs/installation-guides/install-claude.md
+++ b/docs/installation-guides/install-claude.md
@@ -1,0 +1,204 @@
+# Install GitHub MCP Server in Claude Applications
+
+This guide covers installation of the GitHub MCP server for Claude Code CLI, Claude Desktop, and Claude Web applications.
+
+## Claude Web (claude.ai)
+
+Claude Web supports remote MCP servers through the Integrations built-in feature.
+
+### Prerequisites
+
+1. Claude Pro, Team, or Enterprise account (Integrations not available on free plan)
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new)
+
+### Installation
+
+**Note**: As of July 2025, the remote GitHub MCP Server has known compatibility issues with Claude Web. While Claude Web supports remote MCP servers from other providers (like Atlassian, Zapier, Notion), the GitHub MCP Server integration may not work reliably.
+
+For other remote MCP servers that do work with Claude Web:
+
+1. Go to [claude.ai](https://claude.ai) and log in
+2. Click your profile icon → **Settings**
+3. Navigate to **Integrations** section
+4. Click **+ Add integration** or **Add More**
+5. Enter the remote server URL
+6. Follow the OAuth authentication flow when prompted
+
+**Alternative**: Use Claude Desktop or Claude Code CLI for reliable GitHub MCP Server integration.
+
+---
+
+## Claude Code CLI
+
+Claude Code CLI provides command-line access to Claude with MCP server integration.
+
+### Prerequisites
+
+1. Claude Code CLI installed
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new)
+3. [Docker](https://www.docker.com/) installed and running
+
+### Installation
+
+Run the following command to add the GitHub MCP server using Docker:
+
+```bash
+claude mcp add github -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
+```
+
+Then set the environment variable:
+```bash
+claude mcp update github -e GITHUB_PERSONAL_ACCESS_TOKEN=your_github_pat
+```
+
+Or as a single command with the token inline:
+```bash
+claude mcp add-json github '{"command": "docker", "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"], "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "your_github_pat"}}'
+```
+
+**Important**: The npm package `@modelcontextprotocol/server-github` is no longer supported as of April 2025. Use the official Docker image `ghcr.io/github/github-mcp-server` instead.
+
+### Configuration Options
+
+- Use `-s user` to add the server to your user configuration (available across all projects)
+- Use `-s project` to add the server to project-specific configuration (shared via `.mcp.json`)
+- Default scope is `local` (available only to you in the current project)
+
+### Verification
+
+Run the following command to verify the installation:
+```bash
+claude mcp list
+```
+
+---
+
+## Claude Desktop
+
+Claude Desktop provides a graphical interface for interacting with the GitHub MCP Server.
+
+### Prerequisites
+
+1. Claude Desktop installed
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new)
+3. [Docker](https://www.docker.com/) installed and running
+
+### Configuration File Location
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json` (unofficial support)
+
+### Installation
+
+Add the following to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "your_github_pat"
+      }
+    }
+  }
+}
+```
+
+**Important**: The npm package `@modelcontextprotocol/server-github` is no longer supported as of April 2025. Use the official Docker image `ghcr.io/github/github-mcp-server` instead.
+
+### Using Environment Variables
+
+Claude Desktop supports environment variable references. You can use:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+Then set the environment variable in your system before starting Claude Desktop.
+
+### Installation Steps
+
+1. Open Claude Desktop
+2. Go to Settings (from the Claude menu) → Developer → Edit Config
+3. Add your chosen configuration
+4. Save the file
+5. Restart Claude Desktop
+
+### Verification
+
+After restarting, you should see:
+- An MCP icon in the Claude Desktop interface
+- The GitHub server listed as "running" in Developer settings
+
+---
+
+## Troubleshooting
+
+### Claude Web
+- Currently experiencing compatibility issues with the GitHub MCP Server
+- Try other remote MCP servers (Atlassian, Zapier, Notion) which work reliably
+- Use Claude Desktop or Claude Code CLI as alternatives for GitHub integration
+
+### Claude Code CLI
+- Verify the command syntax is correct (note the single quotes around the JSON)
+- Ensure Docker is running: `docker --version`
+- Use `/mcp` command within Claude Code to check server status
+
+### Claude Desktop
+- Check logs at:
+  - **macOS**: `~/Library/Logs/Claude/`
+  - **Windows**: `%APPDATA%\Claude\logs\`
+- Look for `mcp-server-github.log` for server-specific errors
+- Ensure configuration file is valid JSON
+- Try running the Docker command manually in terminal to diagnose issues
+
+### Common Issues
+- **Invalid JSON**: Validate your configuration at [jsonlint.com](https://jsonlint.com)
+- **PAT issues**: Ensure your GitHub PAT has required scopes
+- **Docker not found**: Install Docker Desktop and ensure it's running
+- **Docker image pull fails**: Try `docker logout ghcr.io` then retry
+
+---
+
+## Security Best Practices
+
+- **Protect configuration files**: Set appropriate file permissions
+- **Use environment variables** when possible instead of hardcoding tokens
+- **Limit PAT scope** to only necessary permissions
+- **Regularly rotate** your GitHub Personal Access Tokens
+- **Never commit** configuration files containing tokens to version control
+
+---
+
+## Additional Resources
+
+- [Model Context Protocol Documentation](https://modelcontextprotocol.io)
+- [Claude Code MCP Documentation](https://docs.anthropic.com/en/docs/claude-code/mcp)
+- [Claude Web Integrations Support](https://support.anthropic.com/en/articles/11175166-about-custom-integrations-using-remote-mcp)

--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -1,0 +1,123 @@
+# Install GitHub MCP Server in Cursor
+
+## Prerequisites
+1. Cursor IDE installed (latest version)
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new) with appropriate scopes
+3. For local installation: [Docker](https://www.docker.com/) installed and running
+
+## Remote Server Setup (Recommended)
+
+The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports both HTTP and SSE protocols. Cursor currently supports remote servers with PAT authentication.
+
+### SSE Configuration
+As of Cursor v0.48.0, Cursor supports SSE servers directly:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+**Note**: You may need to update to the latest version, if the current version doesn't support direct SSE
+
+## Local Server Setup
+
+### Docker Installation (Required)
+> **Important**: The npm package `@modelcontextprotocol/server-github` is no longer supported as of April 2025. Use the official Docker image `ghcr.io/github/github-mcp-server` instead.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+## Installation Steps
+
+### Via Cursor Settings UI
+1. Open Cursor
+2. Navigate to **Settings** → **Tools & Integrations** → **MCP**
+3. Click **"+ Add new global MCP server"**
+4. This opens `~/.cursor/mcp.json` in the editor
+5. Add your chosen configuration from above
+6. Save the file
+7. Restart Cursor
+
+### Manual Configuration
+1. Create or edit the configuration file:
+   - **Global (all projects)**: `~/.cursor/mcp.json`
+   - **Project-specific**: `.cursor/mcp.json` in project root
+2. Add your chosen configuration
+3. Save the file
+4. Restart Cursor completely
+
+### Token Security
+- Create PATs with minimum required scopes:
+  - `repo` - For repository operations
+  - `read:packages` - For Docker image pull (local setup)
+  - Additional scopes based on tools you need
+- Use separate PATs for different projects
+- Regularly rotate tokens
+- Never commit configuration files to version control
+
+## Configuration Details
+
+- **File paths**: 
+  - Global: `~/.cursor/mcp.json`
+  - Project: `.cursor/mcp.json`
+- **Scope**: Both global and project-specific configurations supported
+- **Format**: Must be valid JSON (use a linter to verify)
+
+## Verification
+
+After installation:
+1. Restart Cursor completely
+2. Open Settings → Tools & Integrations → MCP
+3. Look for green dot next to your server name
+4. In chat/composer, check "Available Tools"
+5. Test with: "List my GitHub repositories"
+
+## Troubleshooting
+
+### Remote Server Issues
+- **SSE not working**: Ensure you're using Cursor v0.48.0 or later
+- **Authentication failures**: Verify PAT has correct scopes
+- **Connection errors**: Check firewall/proxy settings
+
+### Local Server Issues
+- **Docker errors**: Ensure Docker Desktop is running
+- **Image pull failures**: Try `docker logout ghcr.io` then retry
+- **Docker not found**: Install Docker Desktop and ensure it's running
+
+### General Issues
+- **MCP not loading**: Restart Cursor completely after configuration
+- **Invalid JSON**: Validate that json format is correct
+- **Tools not appearing**: Check server shows green dot in MCP settings
+- **Check logs**: Look for MCP-related errors in Cursor logs
+
+## Important Notes
+
+- **Docker image**: `ghcr.io/github/github-mcp-server` (official and supported)
+- **npm package**: `@modelcontextprotocol/server-github` (deprecated as of April 2025 - no longer functional)
+- **Cursor specifics**: Supports both project and global configurations, uses `mcpServers` key

--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -7,7 +7,7 @@
 
 ## Remote Server Setup (Recommended)
 
-The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports both HTTP and SSE protocols. Cursor currently supports remote servers with PAT authentication.
+The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports Streamable HTTP protocol. Cursor currently supports remote servers with PAT authentication.
 
 ### Streamable HTTP Configuration
 As of Cursor v0.48.0, Cursor supports SSE servers directly:

--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -10,7 +10,7 @@
 The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports Streamable HTTP protocol. Cursor currently supports remote servers with PAT authentication.
 
 ### Streamable HTTP Configuration
-As of Cursor v0.48.0, Cursor supports SSE servers directly:
+As of Cursor v0.48.0, Cursor supports Streamable HTTP servers directly:
 
 ```json
 {

--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -9,7 +9,7 @@
 
 The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports both HTTP and SSE protocols. Cursor currently supports remote servers with PAT authentication.
 
-### SSE Configuration
+### Streamable HTTP Configuration
 As of Cursor v0.48.0, Cursor supports SSE servers directly:
 
 ```json

--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -101,7 +101,7 @@ After installation:
 ## Troubleshooting
 
 ### Remote Server Issues
-- **SSE not working**: Ensure you're using Cursor v0.48.0 or later
+- **Streamable HTTP not working**: Ensure you're using Cursor v0.48.0 or later
 - **Authentication failures**: Verify PAT has correct scopes
 - **Connection errors**: Check firewall/proxy settings
 

--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -25,7 +25,7 @@ As of Cursor v0.48.0, Cursor supports Streamable HTTP servers directly:
 }
 ```
 
-**Note**: You may need to update to the latest version, if the current version doesn't support direct SSE
+**Note**: You may need to update to the latest version, if the current version doesn't support direct Streamable HTTP
 
 ## Local Server Setup
 

--- a/docs/installation-guides/install-other-copilot-ides.md
+++ b/docs/installation-guides/install-other-copilot-ides.md
@@ -99,7 +99,7 @@ The remote GitHub MCP server is hosted by GitHub and provides automatic updates 
   }
 }
 ```
-4. Restart IDE and use Agent mode in Copilot Chat
+4. Press `Ctrl + S` or `Command + S` to save, or close the `mcp.json` file. The configuration should take effect immediately and restart all the MCP servers defined. You can restart the IDE if needed.
 
 ### Local Server
 

--- a/docs/installation-guides/install-other-copilot-ides.md
+++ b/docs/installation-guides/install-other-copilot-ides.md
@@ -186,7 +186,7 @@ For users who prefer to run the GitHub MCP server locally. Requires Docker insta
 
 ## Eclipse
 
-MCP support available with Eclipse 2024-09+ and latest GitHub Copilot extension.
+MCP support available with Eclipse 2024-03+ and latest version of the GitHub Copilot plugin.
 
 ### Remote Server (Recommended)
 
@@ -196,7 +196,7 @@ The remote GitHub MCP server is hosted by GitHub and provides automatic updates 
 
 #### Configuration Steps
 1. Install GitHub Copilot extension from Eclipse Marketplace
-2. Click **GitHub Copilot icon** → **Edit Preferences** → **MCP Servers**
+2. Click the **GitHub Copilot icon** → **Edit Preferences** → **MCP** (under **GitHub Copilot**)
 3. Add GitHub MCP server configuration:
 ```json
 {
@@ -212,7 +212,7 @@ The remote GitHub MCP server is hosted by GitHub and provides automatic updates 
   }
 }
 ```
-4. Restart Eclipse
+4. Click the "Apply and Close" button in the preference dialog and the configuration will take effect automatically.
 
 ### Local Server
 
@@ -237,7 +237,7 @@ For users who prefer to run the GitHub MCP server locally. Requires Docker insta
 }
 ```
 
-**Documentation:** [Eclipse Copilot Extension](https://marketplace.eclipse.org/content/github-copilot)
+**Documentation:** [Eclipse Copilot plugin](https://marketplace.eclipse.org/content/github-copilot)
 
 ---
 

--- a/docs/installation-guides/install-other-copilot-ides.md
+++ b/docs/installation-guides/install-other-copilot-ides.md
@@ -1,0 +1,265 @@
+# Install GitHub MCP Server in Copilot IDEs & GitHub.com
+
+Quick setup guide for the GitHub MCP server in GitHub Copilot across different IDEs. For VS Code instructions, refer to the [VS Code install guide in the README](/README.md#installation-in-vs-code)
+
+### Requirements:
+- **GitHub Copilot License**: Any Copilot plan (Free, Pro, Pro+, Business, Enterprise) for Copilot access
+- **GitHub Account**: Individual GitHub account (organization/enterprise membership optional) for GitHub MCP server access
+- **MCP Servers in Copilot Policy**: Organizations assigning Copilot seats must enable this policy for all MCP access in Copilot for VS Code and Copilot Coding Agent – all other Copilot IDEs will migrate to this policy in the coming months
+- **Editor Preview Policy**: Organizations assigning Copilot seats must enable this policy for OAuth access while the Remote GitHub MCP Server is in public preview
+
+> **Note:** All Copilot IDEs now support the remote GitHub MCP server. VS Code offers OAuth authentication, while Visual Studio, JetBrains IDEs, Xcode, and Eclipse currently use PAT authentication with OAuth support coming soon.
+
+## Visual Studio
+
+Requires Visual Studio 2022 version 17.14 or later.
+
+### Remote Server (Recommended)
+
+The remote GitHub MCP server is hosted by GitHub and provides automatic updates with no local setup required.
+
+#### Configuration
+1. Go to **Tools** → **Options** → **GitHub** → **Copilot** → **MCP Servers**
+2. Add this configuration:
+```json
+{
+  "servers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "authorization_token": "Bearer YOUR_GITHUB_PAT"
+    }
+  }
+}
+```
+3. Restart Visual Studio
+
+### Local Server
+
+For users who prefer to run the GitHub MCP server locally. Requires Docker installed and running.
+
+#### Configuration
+1. Create an `.mcp.json` file in your solution directory
+2. Add this configuration:
+```json
+{
+  "inputs": [
+    {
+      "id": "github_pat",
+      "description": "GitHub personal access token",
+      "type": "promptString",
+      "password": true
+    }
+  ],
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_pat}"
+      }
+    }
+  }
+}
+```
+3. Save the file and restart Visual Studio
+
+**Documentation:** [Visual Studio MCP Guide](https://learn.microsoft.com/en-us/visualstudio/ide/mcp-servers?view=vs-2022)
+
+---
+
+## JetBrains IDEs
+
+Agent mode and MCP support available in public preview across IntelliJ IDEA, PyCharm, WebStorm, and other JetBrains IDEs.
+
+### Remote Server (Recommended)
+
+The remote GitHub MCP server is hosted by GitHub and provides automatic updates with no local setup required.
+
+> **Note**: OAuth authentication for the remote GitHub server is not yet supported in JetBrains IDEs. You must use a Personal Access Token (PAT).
+
+#### Configuration Steps
+1. Install/update the GitHub Copilot plugin
+2. Click **GitHub Copilot icon** → **Edit Settings** → **MCP Servers** → **Edit in mcp.json**
+3. Add configuration:
+```json
+{
+  "servers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "requestInit": {
+        "headers": {
+          "Authorization": "Bearer YOUR_GITHUB_PAT"
+        }
+      }
+    }
+  }
+}
+```
+4. Restart IDE and use Agent mode in Copilot Chat
+
+### Local Server
+
+For users who prefer to run the GitHub MCP server locally. Requires Docker installed and running.
+
+#### Configuration
+```json
+{
+  "servers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", 
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+**Documentation:** [JetBrains Copilot Guide](https://plugins.jetbrains.com/plugin/17718-github-copilot)
+
+---
+
+## Xcode
+
+Agent mode and MCP support now available in public preview for Xcode.
+
+### Remote Server (Recommended)
+
+The remote GitHub MCP server is hosted by GitHub and provides automatic updates with no local setup required.
+
+> **Note**: OAuth authentication for the remote GitHub server is not yet supported in Xcode. You must use a Personal Access Token (PAT).
+
+#### Configuration Steps
+1. Install/update [GitHub Copilot for Xcode](https://github.com/github/CopilotForXcode)
+2. Open **GitHub Copilot for Xcode app** → **Agent Mode** → **🛠️ Tool Picker** → **Edit Config**
+3. Configure your MCP servers:
+```json
+{
+  "servers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "requestInit": {
+        "headers": {
+          "Authorization": "Bearer YOUR_GITHUB_PAT"
+        }
+      }
+    }
+  }
+}
+```
+
+### Local Server
+
+For users who prefer to run the GitHub MCP server locally. Requires Docker installed and running.
+
+#### Configuration
+```json
+{
+  "servers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", 
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+**Documentation:** [Xcode Copilot Guide](https://devblogs.microsoft.com/xcode/github-copilot-exploring-agent-mode-and-mcp-support-in-public-preview-for-xcode/)
+
+---
+
+## Eclipse
+
+MCP support available with Eclipse 2024-09+ and latest GitHub Copilot extension.
+
+### Remote Server (Recommended)
+
+The remote GitHub MCP server is hosted by GitHub and provides automatic updates with no local setup required.
+
+> **Note**: OAuth authentication for the remote GitHub server is not yet supported in Eclipse. You must use a Personal Access Token (PAT).
+
+#### Configuration Steps
+1. Install GitHub Copilot extension from Eclipse Marketplace
+2. Click **GitHub Copilot icon** → **Edit Preferences** → **MCP Servers**
+3. Add GitHub MCP server configuration:
+```json
+{
+  "servers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "requestInit": {
+        "headers": {
+          "Authorization": "Bearer YOUR_GITHUB_PAT"
+        }
+      }
+    }
+  }
+}
+```
+4. Restart Eclipse
+
+### Local Server
+
+For users who prefer to run the GitHub MCP server locally. Requires Docker installed and running.
+
+#### Configuration
+```json
+{
+  "servers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", 
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+**Documentation:** [Eclipse Copilot Extension](https://marketplace.eclipse.org/content/github-copilot)
+
+---
+
+## GitHub Personal Access Token
+
+For PAT authentication, see our [Personal Access Token documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for setup instructions.
+
+---
+
+## Usage
+
+After setup:
+1. Restart your IDE completely
+2. Open Agent mode in Copilot Chat
+3. Try: *"List recent issues in this repository"*
+4. Copilot can now access GitHub data and perform repository operations
+
+---
+
+## Troubleshooting
+
+- **Connection issues**: Verify GitHub PAT permissions and IDE version compatibility
+- **Authentication errors**: Check if your organization has enabled the MCP policy for Copilot
+- **Tools not appearing**: Restart IDE after configuration changes and check error logs
+- **Local server issues**: Ensure Docker is running for Docker-based setups

--- a/docs/installation-guides/install-other-copilot-ides.md
+++ b/docs/installation-guides/install-other-copilot-ides.md
@@ -83,7 +83,7 @@ The remote GitHub MCP server is hosted by GitHub and provides automatic updates 
 
 #### Configuration Steps
 1. Install/update the GitHub Copilot plugin
-2. Click **GitHub Copilot icon** → **Edit Settings** → **MCP Servers** → **Edit in mcp.json**
+2. Click **GitHub Copilot icon in the status bar** → **Edit Settings** → **Model Context Protocol** → **Configure**
 3. Add configuration:
 ```json
 {

--- a/docs/installation-guides/install-windsurf.md
+++ b/docs/installation-guides/install-windsurf.md
@@ -9,7 +9,7 @@
 
 The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports Streamable HTTP protocol. Windsurf currently supports PAT authentication only.
 
-### Direct SSE Configuration
+### Streamable HTTP Configuration
 Windsurf supports SSE servers with a `serverUrl` field:
 
 ```json

--- a/docs/installation-guides/install-windsurf.md
+++ b/docs/installation-guides/install-windsurf.md
@@ -86,7 +86,7 @@ After installation:
 ### Remote Server Issues
 - **Authentication failures**: Verify PAT has correct scopes and hasn't expired
 - **Connection errors**: Check firewall/proxy settings for HTTPS connections
-- **SSE not working**: Ensure you're using the correct `serverUrl` field format
+- **Streamable HTTP not working**: Ensure you're using the correct `serverUrl` field format
 
 ### Local Server Issues
 - **Docker errors**: Ensure Docker Desktop is running

--- a/docs/installation-guides/install-windsurf.md
+++ b/docs/installation-guides/install-windsurf.md
@@ -1,0 +1,107 @@
+# Install GitHub MCP Server in Windsurf
+
+## Prerequisites
+1. Windsurf IDE installed (latest version)
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new) with appropriate scopes
+3. For local installation: [Docker](https://www.docker.com/) installed and running
+
+## Remote Server Setup (Recommended)
+
+The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports both HTTP and SSE protocols. Windsurf currently supports PAT authentication only.
+
+### Direct SSE Configuration
+Windsurf supports SSE servers with a `serverUrl` field:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "serverUrl": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+## Local Server Setup
+
+### Docker Installation (Required)
+**Important**: The npm package `@modelcontextprotocol/server-github` is no longer supported as of April 2025. Use the official Docker image `ghcr.io/github/github-mcp-server` instead.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+## Installation Steps
+
+### Via Plugin Store
+1. Open Windsurf and navigate to Cascade
+2. Click the **Plugins** icon or **hammer icon** (🔨)
+3. Search for "GitHub MCP Server"
+4. Click **Install** and enter your PAT when prompted
+5. Click **Refresh** (🔄)
+
+### Manual Configuration
+1. Click the hammer icon (🔨) in Cascade
+2. Click **Configure** to open `~/.codeium/windsurf/mcp_config.json`
+3. Add your chosen configuration from above
+4. Save the file
+5. Click **Refresh** (🔄) in the MCP toolbar
+
+## Configuration Details
+
+- **File path**: `~/.codeium/windsurf/mcp_config.json`
+- **Scope**: Global configuration only (no per-project support)
+- **Format**: Must be valid JSON (use a linter to verify)
+
+## Verification
+
+After installation:
+1. Look for "1 available MCP server" in the MCP toolbar
+2. Click the hammer icon to see available GitHub tools
+3. Test with: "List my GitHub repositories"
+4. Check for green dot next to the server name
+
+## Troubleshooting
+
+### Remote Server Issues
+- **Authentication failures**: Verify PAT has correct scopes and hasn't expired
+- **Connection errors**: Check firewall/proxy settings for HTTPS connections
+- **SSE not working**: Ensure you're using the correct `serverUrl` field format
+
+### Local Server Issues
+- **Docker errors**: Ensure Docker Desktop is running
+- **Image pull failures**: Try `docker logout ghcr.io` then retry
+- **Docker not found**: Install Docker Desktop and ensure it's running
+
+### General Issues
+- **Invalid JSON**: Validate with [jsonlint.com](https://jsonlint.com)
+- **Tools not appearing**: Restart Windsurf completely
+- **Check logs**: `~/.codeium/windsurf/logs/`
+
+## Important Notes
+
+- **Official repository**: [github/github-mcp-server](https://github.com/github/github-mcp-server)
+- **Remote server URL**: `https://api.githubcopilot.com/mcp/`
+- **Docker image**: `ghcr.io/github/github-mcp-server` (official and supported)
+- **npm package**: `@modelcontextprotocol/server-github` (deprecated as of April 2025 - no longer functional)
+- **Windsurf limitations**: No environment variable interpolation, global config only

--- a/docs/installation-guides/install-windsurf.md
+++ b/docs/installation-guides/install-windsurf.md
@@ -10,7 +10,7 @@
 The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports Streamable HTTP protocol. Windsurf currently supports PAT authentication only.
 
 ### Streamable HTTP Configuration
-Windsurf supports SSE servers with a `serverUrl` field:
+Windsurf supports Streamable HTTP servers with a `serverUrl` field:
 
 ```json
 {

--- a/docs/installation-guides/install-windsurf.md
+++ b/docs/installation-guides/install-windsurf.md
@@ -7,7 +7,7 @@
 
 ## Remote Server Setup (Recommended)
 
-The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports both HTTP and SSE protocols. Windsurf currently supports PAT authentication only.
+The remote GitHub MCP server is hosted by GitHub at `https://api.githubcopilot.com/mcp/` and supports Streamable HTTP protocol. Windsurf currently supports PAT authentication only.
 
 ### Direct SSE Configuration
 Windsurf supports SSE servers with a `serverUrl` field:

--- a/docs/policies-and-governance.md
+++ b/docs/policies-and-governance.md
@@ -1,0 +1,216 @@
+# Policies & Governance for the GitHub MCP Server
+
+Organizations and enterprises have several existing control mechanisms for the GitHub MCP server on GitHub.com:
+- MCP servers in Copilot Policy
+- Copilot Editor Preview Policy (temporary)
+- OAuth App Access Policies
+- GitHub App Installation
+- Personal Access Token (PAT) policies
+- SSO Enforcement
+
+This document outlines how these policies apply to different deployment modes, authentication methods, and host applications – while providing guidance for managing GitHub MCP Server access across your organization.
+
+## How the GitHub MCP Server Works
+
+The GitHub MCP Server provides access to GitHub resources and capabilities through a standardized protocol, with flexible deployment and authentication options tailored to different use cases. It supports two deployment modes, both built on the same underlying codebase.
+
+### 1. Local GitHub MCP Server
+* **Runs:** Locally alongside your IDE or application
+* **Authentication & Controls:** Requires Personal Access Tokens (PATs). Users must generate and configure a PAT to connect. Managed via [PAT policies](https://docs.github.com/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization#restricting-access-by-personal-access-tokens).
+  * Can optionally use GitHub App installation tokens when embedded in a GitHub App-based tool (rare).
+ 
+**Supported SKUs:** Can be used with GitHub Enterprise Server (GHES) and GitHub Enterprise Cloud (GHEC).
+
+### 2. Remote GitHub MCP Server
+* **Runs:** As a hosted service accessed over the internet
+* **Authentication & Controls:** (determined by the chosen authentication method)
+  * **GitHub App Installation Tokens:** Uses a signed JWT to request installation access tokens (similar to the OAuth 2.0 client credentials flow) to operate as the application itself. Provides granular control via [installation](https://docs.github.com/apps/using-github-apps/installing-a-github-app-from-a-third-party#requirements-to-install-a-github-app), [permissions](https://docs.github.com/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app) and [repository access controls](https://docs.github.com/apps/using-github-apps/reviewing-and-modifying-installed-github-apps#modifying-repository-access).
+  * **OAuth Authorization Code Flow:** Uses the standard OAuth 2.0 Authorization Code flow. Controlled via [OAuth App access policies](https://docs.github.com/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions) for OAuth apps. For GitHub Apps that sign in ([are authorized by](https://docs.github.com/apps/using-github-apps/authorizing-github-apps)) a user, control access to your organization via [installation](https://docs.github.com/apps/using-github-apps/installing-a-github-app-from-a-third-party#requirements-to-install-a-github-app).
+  * **Personal Access Tokens (PATs):** Managed via [PAT policies](https://docs.github.com/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization#restricting-access-by-personal-access-tokens).
+  * **SSO enforcement:** Applies when using OAuth Apps, GitHub Apps, and PATs to access resources in organizations and enterprises with SSO enabled. Acts as an overlay control. Users must have a valid SSO session for your organization or enterprise when signing into the app or creating the token in order for the token to access your resources. Learn more in the [SSO documentation](https://docs.github.com/enterprise-cloud@latest/authentication/authenticating-with-single-sign-on/about-authentication-with-single-sign-on#about-oauth-apps-github-apps-and-sso).
+
+**Supported Platforms:** Currently available only on GitHub Enterprise Cloud (GHEC). Remote hosting for GHES is not supported at this time.
+
+> **Note:** This does not apply to the Local GitHub MCP Server, which uses PATs and does not rely on GitHub App installations.
+
+#### Enterprise Install Considerations
+
+- When using the Remote GitHub MCP Server, if authenticating with OAuth instead of PAT, each host application must have a registered GitHub App (or OAuth App) to authenticate on behalf of the user.
+- Enterprises may choose to install these apps in multiple organizations (e.g., per team or department) to scope access narrowly, or at the enterprise level to centralize access control across all child organizations. 
+- Enterprise installation is only supported for GitHub Apps. OAuth Apps can only be installed on a per organization basis in multi-org enterprises.
+
+### Security Principles for Both Modes
+* **Authentication:** Required for all operations, no anonymous access
+* **Authorization:** Access enforced by GitHub's native permission model. Users and apps cannot use an MCP server to access more resources than they could otherwise access normally via the API.
+* **Communication:** All data transmitted over HTTPS with optional SSE for real-time updates
+* **Rate Limiting:** Subject to GitHub API rate limits based on authentication method
+* **Token Storage:** Tokens should be stored securely using platform-appropriate credential storage
+* **Audit Trail:** All underlying API calls are logged in GitHub's audit log when available
+
+For integration architecture and implementation details, see the [Host Integration Guide](https://github.com/github/github-mcp-server/blob/main/docs/host-integration.md).
+
+## Where It's Used
+
+The GitHub MCP server can be accessed in various environments (referred to as "host" applications):
+* **First-party Hosts:** GitHub Copilot in VS Code, Visual Studio, JetBrains, Eclipse, and Xcode with integrated MCP support, as well as Copilot Coding Agent.
+* **Third-party Hosts:** Editors outside the GitHub ecosystem, such as Claude, Cursor, Windsurf, and Cline, that support connecting to MCP servers, as well as AI chat applications like Claude Desktop and other AI assistants that connect to MCP servers to fetch GitHub context or execute write actions.
+
+## What It Can Access
+
+The MCP server accesses GitHub resources based on the permissions granted through the chosen authentication method (PAT, OAuth, or GitHub App). These may include:
+* Repository contents (files, branches, commits)
+* Issues and pull requests
+* Organization and team metadata
+* User profile information
+* Actions workflow runs, logs, and statuses
+* Security and vulnerability alerts (if explicitly granted)
+
+Access is always constrained by GitHub's public API permission model and the authenticated user's privileges.
+
+## Control Mechanisms
+
+### 1. Copilot Editors (first-party) → MCP Servers in Copilot Policy
+
+* **Policy:** MCP servers in Copilot
+* **Location:** Enterprise/Org → Policies → Copilot
+* **What it controls:** When disabled, **completely blocks all GitHub MCP Server access** (both remote and local) for affected Copilot editors. Currently applies to VS Code and Copilot Coding Agent, with more Copilot editors expected to migrate to this policy over time.
+* **Impact when disabled:** Host applications governed by this policy cannot connect to the GitHub MCP Server through any authentication method (OAuth, PAT, or GitHub App).
+* **What it does NOT affect:**
+  * MCP support in Copilot on IDEs that are still in public preview (Visual Studio, JetBrains, Xcode, Eclipse)
+  * Third-party IDE or host apps (like Claude, Cursor, Windsurf) not governed by GitHub's Copilot policies
+  * Community-authored MCP servers using GitHub's public APIs
+
+> **Important:** This policy provides comprehensive control over GitHub MCP Server access in Copilot editors. When disabled, users in affected applications will not be able to use the GitHub MCP Server regardless of deployment mode (remote or local) or authentication method.
+
+#### Temporary: Copilot Editor Preview Policy
+
+* **Policy:** Editor Preview Features  
+* **Status:** Being phased out as editors migrate to the "MCP servers in Copilot" policy above, and once the Remote GitHub MCP server goes GA
+* **What it controls:** When disabled, prevents remaining Copilot editors from using the Remote GitHub MCP Server through OAuth connections in all first-party and third-party host applications (does not affect local deployments or PAT authentication)
+
+> **Note:** As Copilot editors migrate from the "Copilot Editor Preview" policy to the "MCP servers in Copilot" policy, the scope of control becomes more centralized, blocking both remote and local GitHub MCP Server access when disabled. Access in third-party hosts is governed separately by OAuth App, GitHub App, and PAT policies.
+
+### 2. Third-Party Host Apps (e.g., Claude, Cursor, Windsurf) → OAuth App or GitHub App Controls
+
+#### a. OAuth App Access Policies
+* **Control Mechanism:** OAuth App access restrictions
+* **Location:** Org → Settings → Third-party Access → OAuth app policy
+* **How it works:**
+  * Organization admins must approve OAuth App requests before host apps can access organization data
+  * Only applies when the host registers an OAuth App AND the user connects via OAuth 2.0 flow
+
+#### b. GitHub App Installation
+* **Control Mechanism:** GitHub App installation and permissions
+* **Location:** Org → Settings → Third-party Access → GitHub Apps
+* **What it controls:** Organization admins must install the app, select repositories, and grant permissions before the app can access organization-owned data or resources through the Remote GitHub Server.
+* **How it works:**
+  * Organization admins must install the app, specify repositories, and approve permissions
+  * Only applies when the host registers a GitHub App AND the user authenticates through that flow
+
+> **Note:** The authentication methods available depend on what your host application supports. While PATs work with any remote MCP-compatible host, OAuth and GitHub App authentication are only available if the host has registered an app with GitHub. Check your host application's documentation or support for more info.
+
+### 3. PAT Access from Any Host → PAT Restrictions
+
+* **Types:** Fine-grained PATs (recommended) and Classic tokens (legacy)
+* **Location:**
+  * User level: [Personal Settings → Developer Settings → Personal Access Tokens](https://docs.github.com/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens)
+  * Enterprise/Organization level: [Enterprise/Organization → Settings → Personal Access Tokens](https://docs.github.com/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization) (to control PAT creation/access policies)
+* **What it controls:** Applies to all host apps and both local & remote GitHub MCP servers when users authenticate via PAT.
+* **How it works:** Access limited to the repositories and scopes selected on the token.
+* **Limitations:** PATs do not adhere to OAuth App policies and GitHub App installation controls. They are user-scoped and not recommended for production automation.
+* **Organization controls:**
+  * Classic PATs: Can be completely disabled organization-wide
+  * Fine-grained PATs: Cannot be disabled but require explicit approval for organization access
+
+> **Recommendation:** We recommend using fine-grained PATs over classic tokens. Classic tokens have broader scopes and can be disabled in organization settings.
+
+### 4. SSO Enforcement (overlay control)
+
+* **Location:** Enterprise/Organization → SSO settings
+* **What it controls:** OAuth tokens and PATs must map to a recent SSO login to access SSO-protected organization data.
+* **How it works:** Applies to ALL host apps when using OAuth or PATs.
+
+> **Exception:** Does NOT apply to GitHub App installation tokens (these are installation-scoped, not user-scoped)
+
+## Current Limitations
+
+While the GitHub MCP Server provides dynamic tooling and capabilities, the following enterprise governance features are not yet available:
+
+### Single Enterprise/Organization-Level Toggle
+
+GitHub does not provide a single toggle that blocks all GitHub MCP server traffic for every user. Admins can achieve equivalent coverage by combining the controls shown here:
+* **First-party Copilot Editors (GitHub Copilot in VS Code, Visual Studio, JetBrains, Eclipse):**
+  * Disable the "MCP servers in Copilot" policy for comprehensive control
+  * Or disable the Editor Preview Features policy (for editors still using the legacy policy)
+* **Third-party Host Applications:**
+  * Configure OAuth app restrictions
+  * Manage GitHub App installations
+* **PAT Access in All Host Applications:**
+  * Implement fine-grained PAT policies (applies to both remote and local deployments)
+
+### MCP-Specific Audit Logging
+
+At present, MCP traffic appears in standard GitHub audit logs as normal API calls. Purpose-built logging for MCP is on the roadmap, but the following views are not yet available:
+* Real-time list of active MCP connections
+* Dashboards showing granular MCP usage data, like tools or host apps
+* Granular, action-by-action audit logs
+
+Until those arrive, teams can continue to monitor MCP activity through existing API log entries and OAuth/GitHub App events.
+
+## Security Best Practices
+
+### For Organizations
+
+**GitHub App Management**
+* Review [GitHub App installations](https://docs.github.com/apps/using-github-apps/reviewing-and-modifying-installed-github-apps) regularly
+* Audit permissions and repository access
+* Monitor installation events in audit logs
+* Document approved GitHub Apps and their business purposes
+
+**OAuth App Governance**
+* Manage [OAuth App access policies](https://docs.github.com/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions)
+* Establish review processes for approved applications
+* Monitor which third-party applications are requesting access
+* Maintain an allowlist of approved OAuth applications
+
+**Token Management**
+* Mandate fine-grained Personal Access Tokens over classic tokens
+* Establish token expiration policies (90 days maximum recommended)
+* Implement automated token rotation reminders
+* Review and enforce [PAT restrictions](https://docs.github.com/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization) at the appropriate level
+
+### For Developers and Users
+
+**Authentication Security**
+* Prioritize OAuth 2.0 flows over long-lived tokens
+* Prefer fine-grained PATs to PATs (Classic)
+* Store tokens securely using platform-appropriate credential management
+* Store credentials in secret management systems, not source code
+
+**Scope Minimization**
+* Request only the minimum required scopes for your use case
+* Regularly review and revoke unused token permissions
+* Use repository-specific access instead of organization-wide access
+* Document why each permission is needed for your integration
+
+## Resources
+
+**MCP:**
+* [Model Context Protocol Specification](https://modelcontextprotocol.io/specification/2025-03-26)
+* [Model Context Protocol Authorization](https://modelcontextprotocol.io/specification/draft/basic/authorization)
+
+**GitHub Governance & Controls:**
+* [Managing OAuth App Access](https://docs.github.com/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions)
+* [GitHub App Permissions](https://docs.github.com/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app)
+* [Updating permissions for a GitHub App](https://docs.github.com/apps/using-github-apps/approving-updated-permissions-for-a-github-app)
+* [PAT Policies](https://docs.github.com/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization)
+* [Fine-grained PATs](https://docs.github.com/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens)
+* [Setting a PAT policy for your organization](https://docs.github.com/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions)
+
+---
+
+**Questions or Feedback?**
+
+Open an [issue in the github-mcp-server repository](https://github.com/github/github-mcp-server/issues) with the label "policies & governance" attached.
+
+This document reflects GitHub MCP Server policies as of July 2025. Policies and capabilities continue to evolve based on customer feedback and security best practices.


### PR DESCRIPTION
This PR improves the docs structure and clarity for the GitHub MCP Server, and add a policies and governance doc for info on control mechanisms.

## Changes

- **Reorganized README** for better clarity and navigation
- **Created dedicated installation guides** for non-VS Code host applications:
  - `/docs/installation-guides/install-other-copilot-ides.md` - JetBrains, Visual Studio, Eclipse, Xcode
  - `/docs/installation-guides/install-claude.md` - Claude Web, Desktop, and Code CLI
  - `/docs/installation-guides/install-cursor.md` - Cursor IDE
  - `/docs/installation-guides/install-windsurf.md` - Windsurf IDE
- **Updated contribution guidelines** to clarify approval criteria for different types of requests
- **Added policies and governance documentation** at `/docs/policies-and-governance.md`

## Impact

These changes make it easier for users to find installation instructions for their specific host application, understand how requests are prioritized, and governance policies.