### PR TITLE
feat: add add_reply_to_pull_request_comment tool

### DIFF
--- a/pkg/github/__toolsnaps__/add_reply_to_pull_request_comment.snap
+++ b/pkg/github/__toolsnaps__/add_reply_to_pull_request_comment.snap
@@ -1,0 +1,40 @@
+{
+  "annotations": {
+    "title": "Add reply to pull request comment",
+    "readOnlyHint": false
+  },
+  "description": "Add a reply to an existing pull request comment. This creates a new comment that is linked as a reply to the specified comment.",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "The text of the reply comment",
+        "type": "string"
+      },
+      "commentId": {
+        "description": "The ID of the comment to reply to",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "pullNumber": {
+        "description": "Pull request number",
+        "type": "number"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "pullNumber",
+      "commentId",
+      "body"
+    ],
+    "type": "object"
+  },
+  "name": "add_reply_to_pull_request_comment"
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -85,6 +85,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 			toolsets.NewServerTool(CreatePullRequest(getClient, t)),
 			toolsets.NewServerTool(UpdatePullRequest(getClient, t)),
 			toolsets.NewServerTool(RequestCopilotReview(getClient, t)),
+			toolsets.NewServerTool(AddReplyToPullRequestComment(getClient, t)),
 
 			// Reviews
 			toolsets.NewServerTool(CreateAndSubmitPullRequestReview(getGQLClient, t)),


### PR DESCRIPTION
Add a new tool that allows AI agents to reply to existing pull request comments. This tool uses GitHub's CreateCommentInReplyTo REST API to create threaded conversations on pull requests.

Features:
- Reply to any existing PR comment using its ID
- Proper error handling for missing parameters and API failures
- Comprehensive test coverage (8 test cases)
- Follows project patterns and conventions
- Registered in pull_requests toolset as a write operation

Parameters:
- owner: Repository owner (required)
- repo: Repository name (required)
- pullNumber: Pull request number (required)
- commentId: ID of comment to reply to (required)
- body: Reply text content (required)

This tool complements the existing add_comment_to_pending_review tool by enabling responses to already-posted comments, enhancing AI-powered code review workflows.

Closes: #635 