### PR TITLE
Add title field to discussion in get_discussion tool

### DIFF
--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -295,6 +295,7 @@ func GetDiscussion(getGQLClient GetGQLClientFn, t translations.TranslationHelper
 				Repository struct {
 					Discussion struct {
 						Number    githubv4.Int
+						Title     githubv4.String
 						Body      githubv4.String
 						CreatedAt githubv4.DateTime
 						URL       githubv4.String `graphql:"url"`
@@ -315,6 +316,7 @@ func GetDiscussion(getGQLClient GetGQLClientFn, t translations.TranslationHelper
 			d := q.Repository.Discussion
 			discussion := &github.Discussion{
 				Number:    github.Ptr(int(d.Number)),
+				Title:     github.Ptr(string(d.Title)),
 				Body:      github.Ptr(string(d.Body)),
 				HTMLURL:   github.Ptr(string(d.URL)),
 				CreatedAt: &github.Timestamp{Time: d.CreatedAt.Time},

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -484,7 +484,7 @@ func Test_GetDiscussion(t *testing.T) {
 	assert.ElementsMatch(t, toolDef.InputSchema.Required, []string{"owner", "repo", "discussionNumber"})
 
 	// Use exact string query that matches implementation output
-	qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,body,createdAt,url,category{name}}}}"
+    qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,title,body,createdAt,url,category{name}}}}"
 
 	vars := map[string]interface{}{
 		"owner":            "owner",
@@ -503,6 +503,7 @@ func Test_GetDiscussion(t *testing.T) {
 			response: githubv4mock.DataResponse(map[string]any{
 				"repository": map[string]any{"discussion": map[string]any{
 					"number":    1,
+					"title":     "Test Discussion Title",
 					"body":      "This is a test discussion",
 					"url":       "https://github.com/owner/repo/discussions/1",
 					"createdAt": "2025-04-25T12:00:00Z",
@@ -513,6 +514,7 @@ func Test_GetDiscussion(t *testing.T) {
 			expected: &github.Discussion{
 				HTMLURL:   github.Ptr("https://github.com/owner/repo/discussions/1"),
 				Number:    github.Ptr(1),
+				Title:     github.Ptr("Test Discussion Title"),
 				Body:      github.Ptr("This is a test discussion"),
 				CreatedAt: &github.Timestamp{Time: time.Date(2025, 4, 25, 12, 0, 0, 0, time.UTC)},
 				DiscussionCategory: &github.DiscussionCategory{
@@ -549,6 +551,7 @@ func Test_GetDiscussion(t *testing.T) {
 			require.NoError(t, json.Unmarshal([]byte(text), &out))
 			assert.Equal(t, *tc.expected.HTMLURL, *out.HTMLURL)
 			assert.Equal(t, *tc.expected.Number, *out.Number)
+			assert.Equal(t, *tc.expected.Title, *out.Title)
 			assert.Equal(t, *tc.expected.Body, *out.Body)
 			// Check category label
 			assert.Equal(t, *tc.expected.DiscussionCategory.Name, *out.DiscussionCategory.Name)


### PR DESCRIPTION
Closes #802 

### Overview
This PR adds the discussion `title` field to the query in the `get_discussion` tool. Without it, the model seems to hallucinate title information (see screenshot below), and in general this seems like an important field for this tool

### Demos using this discussion https://github.com/facebook/react/discussions/34039
**Before (model hallucination)**
<img width="376" height="1043" alt="Screenshot 2025-08-01 at 16 16 09" src="https://github.com/user-attachments/assets/ed1b2dc0-9943-4b91-aa34-c9a46318d2fe" />


**After (retrieves title correctly)** 
<img width="376" height="1043" alt="Screenshot 2025-08-01 at 16 21 33" src="https://github.com/user-attachments/assets/fff50ae1-6fc6-4e52-add6-d69a151d32ed" />

