### PR TITLE
feat: add reviewers parameter to create_pull_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ The following sets of tools are available (all are on by default):
   - `maintainer_can_modify`: Allow maintainer edits (boolean, optional)
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
+  - `reviewers`: GitHub usernames to request reviews from (array[string], optional)
   - `title`: PR title (string, required)
 
 - **delete_pending_pull_request_review** - Delete the requester's latest pending pull request review

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ The following sets of tools are available (all are on by default):
   - `maintainer_can_modify`: Allow maintainer edits (boolean, optional)
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
-  - `reviewers`: GitHub usernames to request reviews from (array[string], optional)
+  - `reviewers`: GitHub usernames to request reviews from (string[], optional)
   - `title`: PR title (string, required)
 
 - **delete_pending_pull_request_review** - Delete the requester's latest pending pull request review

--- a/pkg/github/__toolsnaps__/create_pull_request.snap
+++ b/pkg/github/__toolsnaps__/create_pull_request.snap
@@ -34,6 +34,13 @@
         "description": "Repository name",
         "type": "string"
       },
+      "reviewers": {
+        "description": "GitHub usernames to request reviews from",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
       "title": {
         "description": "PR title",
         "type": "string"


### PR DESCRIPTION
## Summary

This PR adds support for specifying reviewers when creating a pull request, bringing feature parity with the `update_pull_request` tool which already supports this functionality.

## Changes

- ✨ Add `reviewers` parameter to `create_pull_request` tool
- 🔧 Request reviewers immediately after PR creation using GitHub API
- 🔄 Refresh PR data after adding reviewers to return complete information
- ✅ Add comprehensive test coverage for the new parameter

## Implementation Details

The implementation follows the same pattern as `update_pull_request`:
1. Accept an array of GitHub usernames in the `reviewers` parameter
2. After successfully creating the PR, call `RequestReviewers` API if reviewers are specified
3. Fetch the updated PR data to include reviewer information in the response

## Testing

- Added test case for PR creation with reviewers
- Updated tool snapshot to include the new parameter
- All existing tests continue to pass
- Linter checks pass with 0 issues

## Related

This brings consistency with PR #285 which added reviewers parameter to `update_pull_request`.

🤖 Generated with [Claude Code](https://claude.ai/code)