### PR TITLE
Add support for org-level discussions in list_discussion_categories tool

### DIFF
--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -484,7 +484,7 @@ func Test_GetDiscussion(t *testing.T) {
 	assert.ElementsMatch(t, toolDef.InputSchema.Required, []string{"owner", "repo", "discussionNumber"})
 
 	// Use exact string query that matches implementation output
-    qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,title,body,createdAt,url,category{name}}}}"
+	qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,title,body,createdAt,url,category{name}}}}"
 
 	vars := map[string]interface{}{
 		"owner":            "owner",
@@ -638,17 +638,33 @@ func Test_GetDiscussionComments(t *testing.T) {
 }
 
 func Test_ListDiscussionCategories(t *testing.T) {
+	mockClient := githubv4.NewClient(nil)
+	toolDef, _ := ListDiscussionCategories(stubGetGQLClientFn(mockClient), translations.NullTranslationHelper)
+	assert.Equal(t, "list_discussion_categories", toolDef.Name)
+	assert.NotEmpty(t, toolDef.Description)
+	assert.Contains(t, toolDef.Description, "or organisation")
+	assert.Contains(t, toolDef.InputSchema.Properties, "owner")
+	assert.Contains(t, toolDef.InputSchema.Properties, "repo")
+	assert.ElementsMatch(t, toolDef.InputSchema.Required, []string{"owner"})
+
 	// Use exact string query that matches implementation output
 	qListCategories := "query($first:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussionCategories(first: $first){nodes{id,name},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
 
-	// Variables matching what GraphQL receives after JSON marshaling/unmarshaling
-	vars := map[string]interface{}{
+	// Variables for repository-level categories
+	varsRepo := map[string]interface{}{
 		"owner": "owner",
 		"repo":  "repo",
 		"first": float64(25),
 	}
 
-	mockResp := githubv4mock.DataResponse(map[string]any{
+	// Variables for organization-level categories (using .github repo)
+	varsOrg := map[string]interface{}{
+		"owner": "owner",
+		"repo":  ".github",
+		"first": float64(25),
+	}
+
+	mockRespRepo := githubv4mock.DataResponse(map[string]any{
 		"repository": map[string]any{
 			"discussionCategories": map[string]any{
 				"nodes": []map[string]any{
@@ -665,37 +681,104 @@ func Test_ListDiscussionCategories(t *testing.T) {
 			},
 		},
 	})
-	matcher := githubv4mock.NewQueryMatcher(qListCategories, vars, mockResp)
-	httpClient := githubv4mock.NewMockedHTTPClient(matcher)
-	gqlClient := githubv4.NewClient(httpClient)
 
-	tool, handler := ListDiscussionCategories(stubGetGQLClientFn(gqlClient), translations.NullTranslationHelper)
-	assert.Equal(t, "list_discussion_categories", tool.Name)
-	assert.NotEmpty(t, tool.Description)
-	assert.Contains(t, tool.InputSchema.Properties, "owner")
-	assert.Contains(t, tool.InputSchema.Properties, "repo")
-	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo"})
+	mockRespOrg := githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"discussionCategories": map[string]any{
+				"nodes": []map[string]any{
+					{"id": "789", "name": "Announcements"},
+					{"id": "101", "name": "General"},
+					{"id": "112", "name": "Ideas"},
+				},
+				"pageInfo": map[string]any{
+					"hasNextPage":     false,
+					"hasPreviousPage": false,
+					"startCursor":     "",
+					"endCursor":       "",
+				},
+				"totalCount": 3,
+			},
+		},
+	})
 
-	request := createMCPRequest(map[string]interface{}{"owner": "owner", "repo": "repo"})
-	result, err := handler(context.Background(), request)
-	require.NoError(t, err)
-
-	text := getTextResult(t, result).Text
-
-	var response struct {
-		Categories []map[string]string `json:"categories"`
-		PageInfo   struct {
-			HasNextPage     bool   `json:"hasNextPage"`
-			HasPreviousPage bool   `json:"hasPreviousPage"`
-			StartCursor     string `json:"startCursor"`
-			EndCursor       string `json:"endCursor"`
-		} `json:"pageInfo"`
-		TotalCount int `json:"totalCount"`
+	tests := []struct {
+		name          string
+		reqParams     map[string]interface{}
+		vars          map[string]interface{}
+		mockResponse  githubv4mock.GQLResponse
+		expectError   bool
+		expectedCount int
+	}{
+		{
+			name: "list repository-level discussion categories",
+			reqParams: map[string]interface{}{
+				"owner": "owner",
+				"repo":  "repo",
+			},
+			vars:          varsRepo,
+			mockResponse:  mockRespRepo,
+			expectError:   false,
+			expectedCount: 2,
+		},
+		{
+			name: "list org-level discussion categories (no repo provided)",
+			reqParams: map[string]interface{}{
+				"owner": "owner",
+				// repo is not provided, it will default to ".github"
+			},
+			vars:          varsOrg,
+			mockResponse:  mockRespOrg,
+			expectError:   false,
+			expectedCount: 3,
+		},
 	}
-	require.NoError(t, json.Unmarshal([]byte(text), &response))
-	assert.Len(t, response.Categories, 2)
-	assert.Equal(t, "123", response.Categories[0]["id"])
-	assert.Equal(t, "CategoryOne", response.Categories[0]["name"])
-	assert.Equal(t, "456", response.Categories[1]["id"])
-	assert.Equal(t, "CategoryTwo", response.Categories[1]["name"])
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := githubv4mock.NewQueryMatcher(qListCategories, tc.vars, tc.mockResponse)
+			httpClient := githubv4mock.NewMockedHTTPClient(matcher)
+			gqlClient := githubv4.NewClient(httpClient)
+
+			_, handler := ListDiscussionCategories(stubGetGQLClientFn(gqlClient), translations.NullTranslationHelper)
+
+			req := createMCPRequest(tc.reqParams)
+			res, err := handler(context.Background(), req)
+			text := getTextResult(t, res).Text
+
+			if tc.expectError {
+				require.True(t, res.IsError)
+				return
+			}
+			require.NoError(t, err)
+
+			var response struct {
+				Categories []map[string]string `json:"categories"`
+				PageInfo   struct {
+					HasNextPage     bool   `json:"hasNextPage"`
+					HasPreviousPage bool   `json:"hasPreviousPage"`
+					StartCursor     string `json:"startCursor"`
+					EndCursor       string `json:"endCursor"`
+				} `json:"pageInfo"`
+				TotalCount int `json:"totalCount"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(text), &response))
+			assert.Len(t, response.Categories, tc.expectedCount)
+
+			// Verify specific content based on test case
+			switch tc.name {
+			case "list repository-level discussion categories":
+				assert.Equal(t, "123", response.Categories[0]["id"])
+				assert.Equal(t, "CategoryOne", response.Categories[0]["name"])
+				assert.Equal(t, "456", response.Categories[1]["id"])
+				assert.Equal(t, "CategoryTwo", response.Categories[1]["name"])
+			case "list org-level discussion categories (no repo provided)":
+				assert.Equal(t, "789", response.Categories[0]["id"])
+				assert.Equal(t, "Announcements", response.Categories[0]["name"])
+				assert.Equal(t, "101", response.Categories[1]["id"])
+				assert.Equal(t, "General", response.Categories[1]["name"])
+				assert.Equal(t, "112", response.Categories[2]["id"])
+				assert.Equal(t, "Ideas", response.Categories[2]["name"])
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

### Overview
Closes: https://github.com/github/github-mcp-server/issues/818

This PR improves the existing `list_discussion_categories` tool, by adding logic to handle organisation-level discussions. (It implements similar logic to what I implemented in [PR #775](https://github.com/github/github-mcp-server/pull/775) ) 

### Changes introduced
Before, the "repo" argument was required, so when the user would ask to query org-level discussions the model would either (i) hallucinate random values for `repo` or (ii) it would have to know the implementation detail about the Github API which is that org-level discussions are stored in a hidden `.github` repo.
With these changes:
- the `repo` argument is made optional
- the tool description is updated so that the model knows to omit `repo` if discussions are to be queried at the org-level
- the `repo` value is deterministically set to `.github` when needed
- the tests are updated to reflect these changes 


**Before (the model hallucinates repo values)**
<img width="357" height="1061" alt="Screenshot 2025-08-04 at 17 14 44" src="https://github.com/user-attachments/assets/d61fb815-c0b3-4b1b-b11e-8d1aff8a5894" />


**After (the model correctly omits the repo argument, and the tool uses the deterministic flow to query org-level discussions)**
<img width="357" height="1061" alt="Screenshot 2025-08-04 at 17 18 12" src="https://github.com/user-attachments/assets/4f450de0-d8ae-41c0-9494-f4ed9e7078d4" />
