### PR TITLE
Fix link to Installation Guides Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ For other MCP host applications, please refer to our installation guides:
 - **[Cursor](docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE  
 - **[Windsurf](docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
 
-For a complete overview of all installation options, see our **[Installation Guides Index](docs/installation-guides/installation-guides.md)**.
+For a complete overview of all installation options, see our **[Installation Guides Index](docs/installation-guides/README.md)**.
 
 > **Note:** Any host application that supports local MCP servers should be able to access the local GitHub MCP server. However, the specific configuration process, syntax and stability of the integration will vary by host application. While many may follow a similar format to the examples above, this is not guaranteed. Please refer to your host application's documentation for the correct MCP configuration syntax and setup process.
 


### PR DESCRIPTION
Updated link to Installation Guides Index to point to proper README path. It was 404ing.

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: Quick fix for a broken link