### PR TITLE
Tommy/improve-ref-handling

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1407,7 +1407,6 @@ func resolveGitReference(ctx context.Context, githubClient *github.Client, owner
 	var resp *github.Response
 	var err error
 
-	// Only enter the resolution logic if the ref is NOT already fully qualified.
 	switch {
 	case strings.HasPrefix(ref, "refs/"):
 		// 2b) Already fully qualified. The reference will be fetched at the end.

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1363,23 +1363,23 @@ func filterPaths(entries []*github.TreeEntry, path string, maxResults int) []str
 //
 // The resolution logic follows a clear priority:
 //
-// 1.  If a specific commit `sha` is provided, it takes precedence and is used directly,
+//  1. If a specific commit `sha` is provided, it takes precedence and is used directly,
 //     and all reference resolution is skipped.
 //
-// 2.  If no `sha` is provided, the function resolves the `ref`
+//  2. If no `sha` is provided, the function resolves the `ref`
 //     string into a fully-qualified format (e.g., "refs/heads/main") by trying
 //     the following steps in order:
-//     a. **Empty Ref:** If `ref` is empty, the repository's default branch is used.
-//     b. **Fully-Qualified:** If `ref` already starts with "refs/", it's considered fully
-//        qualified and used as-is.
-//     c. **Partially-Qualified:** If `ref` starts with "heads/" or "tags/", it is
-//        prefixed with "refs/" to make it fully-qualified.
-//     d. **Short Name:** Otherwise, the `ref` is treated as a short name. The function
-//        first attempts to resolve it as a branch ("refs/heads/<ref>"). If that
-//        returns a 404 Not Found error, it then attempts to resolve it as a tag
-//        ("refs/tags/<ref>").
+//     a). **Empty Ref:** If `ref` is empty, the repository's default branch is used.
+//     b). **Fully-Qualified:** If `ref` already starts with "refs/", it's considered fully
+//     qualified and used as-is.
+//     c). **Partially-Qualified:** If `ref` starts with "heads/" or "tags/", it is
+//     prefixed with "refs/" to make it fully-qualified.
+//     d). **Short Name:** Otherwise, the `ref` is treated as a short name. The function
+//     first attempts to resolve it as a branch ("refs/heads/<ref>"). If that
+//     returns a 404 Not Found error, it then attempts to resolve it as a tag
+//     ("refs/tags/<ref>").
 //
-// 3.  **Final Lookup:** Once a fully-qualified ref is determined, a final API call
+//  3. **Final Lookup:** Once a fully-qualified ref is determined, a final API call
 //     is made to fetch that reference's definitive commit SHA.
 //
 // Any unexpected (non-404) errors during the resolution process are returned
@@ -1414,7 +1414,7 @@ func resolveGitReference(ctx context.Context, githubClient *github.Client, owner
 		// try to resolve the ref as a branch first.
 		if err == nil {
 			ref = "refs/heads/" + ref // It's a branch.
-		} else { 
+		} else {
 			// The branch lookup failed. Check if it was a 404 Not Found error.
 			// If it was, we will try to resolve it as a tag.
 			ghErr, isGhErr := err.(*github.ErrorResponse)

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1400,7 +1400,8 @@ func resolveGitReference(ctx context.Context, githubClient *github.Client, owner
 			_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get repository info", resp, err)
 			return nil, fmt.Errorf("failed to get repository info: %w", err)
 		}
-		ref = repoInfo.GetDefaultBranch()
+		ref = fmt.Sprintf("refs/heads/%s", repoInfo.GetDefaultBranch())
+
 	}
 
 	var reference *github.Reference

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1358,36 +1358,96 @@ func filterPaths(entries []*github.TreeEntry, path string, maxResults int) []str
 	return matchedPaths
 }
 
-// resolveGitReference resolves git references with the following logic:
-// 1. If SHA is provided, it takes precedence
-// 2. If neither is provided, use the default branch as ref
-// 3. Get commit SHA from the ref
-// Refs can look like `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`
-// The function returns the resolved ref, commit SHA and any error.
+// resolveGitReference takes a user-provided ref and sha and resolves them into a
+// definitive commit SHA and its corresponding fully-qualified reference.
+//
+// The resolution logic follows a clear priority:
+//
+// 1.  If a specific commit `sha` is provided, it takes precedence and is used directly,
+//     and all reference resolution is skipped.
+//
+// 2.  If no `sha` is provided, the function resolves the `ref`
+//     string into a fully-qualified format (e.g., "refs/heads/main") by trying
+//     the following steps in order:
+//     a. **Empty Ref:** If `ref` is empty, the repository's default branch is used.
+//     b. **Fully-Qualified:** If `ref` already starts with "refs/", it's considered fully
+//        qualified and used as-is.
+//     c. **Partially-Qualified:** If `ref` starts with "heads/" or "tags/", it is
+//        prefixed with "refs/" to make it fully-qualified.
+//     d. **Short Name:** Otherwise, the `ref` is treated as a short name. The function
+//        first attempts to resolve it as a branch ("refs/heads/<ref>"). If that
+//        returns a 404 Not Found error, it then attempts to resolve it as a tag
+//        ("refs/tags/<ref>").
+//
+// 3.  **Final Lookup:** Once a fully-qualified ref is determined, a final API call
+//     is made to fetch that reference's definitive commit SHA.
+//
+// Any unexpected (non-404) errors during the resolution process are returned
+// immediately. All API errors are logged with rich context to aid diagnostics.
 func resolveGitReference(ctx context.Context, githubClient *github.Client, owner, repo, ref, sha string) (*raw.ContentOpts, error) {
-	// 1. If SHA is provided, use it directly
+	// 1) If SHA explicitly provided, it's the highest priority.
 	if sha != "" {
 		return &raw.ContentOpts{Ref: "", SHA: sha}, nil
 	}
 
-	// 2. If neither provided, use the default branch as ref
+	// 2) If no SHA is provided, we try to resolve the ref into a fully-qualified format.
+	// 2a) If ref is empty, determine the default branch.
 	if ref == "" {
 		repoInfo, resp, err := githubClient.Repositories.Get(ctx, owner, repo)
 		if err != nil {
 			_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get repository info", resp, err)
 			return nil, fmt.Errorf("failed to get repository info: %w", err)
 		}
-		ref = fmt.Sprintf("refs/heads/%s", repoInfo.GetDefaultBranch())
+		ref = repoInfo.GetDefaultBranch()
 	}
 
-	// 3. Get the SHA from the ref
+	originalRef := ref // Keep original ref for clearer error messages down the line.
+
+	if strings.HasPrefix(ref, "refs/") {
+		// 2b) Already fully qualified. We will use it.
+	} else if strings.HasPrefix(ref, "heads/") || strings.HasPrefix(ref, "tags/") {
+		ref = "refs/" + ref // 2c) Partially qualified. Make it fully qualified.
+	} else {
+		// 2d) Short name. Try to resolve it as a branch or tag.
+		_, resp, err := githubClient.Git.GetRef(ctx, owner, repo, "refs/heads/"+ref)
+
+		// try to resolve the ref as a branch first.
+		if err == nil {
+			ref = "refs/heads/" + ref // It's a branch.
+		} else { 
+			// The branch lookup failed. Check if it was a 404 Not Found error.
+			// If it was, we will try to resolve it as a tag.
+			ghErr, isGhErr := err.(*github.ErrorResponse)
+			if isGhErr && ghErr.Response.StatusCode == http.StatusNotFound {
+				// The branch wasn't found, so try as a tag.
+				_, resp2, err2 := githubClient.Git.GetRef(ctx, owner, repo, "refs/tags/"+ref)
+				if err2 == nil {
+					ref = "refs/tags/" + ref // It's a tag.
+				} else {
+					// The tag lookup also failed. Check if it was a 404 Not Found error.
+					ghErr2, isGhErr2 := err2.(*github.ErrorResponse)
+					if isGhErr2 && ghErr2.Response.StatusCode == http.StatusNotFound {
+						return nil, fmt.Errorf("could not resolve ref %q as a branch or a tag", originalRef)
+					}
+					// The tag lookup failed for a different reason.
+					_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get reference (tag)", resp2, err2)
+					return nil, fmt.Errorf("failed to get reference for tag '%s': %w", originalRef, err2)
+				}
+			} else {
+				// The branch lookup failed for a different reason.
+				_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get reference (branch)", resp, err)
+				return nil, fmt.Errorf("failed to get reference for branch '%s': %w", originalRef, err)
+			}
+		}
+	}
+
+	// Now that 'ref' is a valid, fully-qualified name, we get the definitive reference object.
 	reference, resp, err := githubClient.Git.GetRef(ctx, owner, repo, ref)
 	if err != nil {
-		_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get reference", resp, err)
-		return nil, fmt.Errorf("failed to get reference: %w", err)
+		_, _ = ghErrors.NewGitHubAPIErrorToCtx(ctx, "failed to get final reference", resp, err)
+		return nil, fmt.Errorf("failed to get final reference for %q: %w", ref, err)
 	}
-	sha = reference.GetObject().GetSHA()
 
-	// Use provided ref, or it will be empty which defaults to the default branch
+	sha = reference.GetObject().GetSHA()
 	return &raw.ContentOpts{Ref: ref, SHA: sha}, nil
 }

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2210,250 +2210,250 @@ func Test_filterPaths(t *testing.T) {
 }
 
 func Test_resolveGitReference(t *testing.T) {
-    ctx := context.Background()
-    owner := "owner"
-    repo := "repo"
+	ctx := context.Background()
+	owner := "owner"
+	repo := "repo"
 
-    tests := []struct {
-        name           string
-        ref            string
-        sha            string
-        mockSetup      func() *http.Client
-        expectedOutput *raw.ContentOpts
-        expectError    bool
-        errorContains  string
-    }{
-        {
-            name: "sha takes precedence over ref",
-            ref:  "refs/heads/main",
-            sha:  "123sha456",
-            mockSetup: func() *http.Client {
-                // No API calls should be made when SHA is provided
-                return mock.NewMockedHTTPClient()
-            },
-            expectedOutput: &raw.ContentOpts{
-                SHA: "123sha456",
-            },
-            expectError: false,
-        },
-        {
-            name: "use default branch if ref and sha both empty",
-            ref:  "",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposByOwnerByRepo,
-                        http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-                            w.WriteHeader(http.StatusOK)
-                            _, _ = w.Write([]byte(`{"name": "repo", "default_branch": "main"}`))
-                        }),
-                    ),
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            assert.Contains(t, r.URL.Path, "/git/ref/heads/main")
-                            w.WriteHeader(http.StatusOK)
-                            _, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "main-sha"}}`))
-                        }),
-                    ),
-                )
-            },
-            expectedOutput: &raw.ContentOpts{
-                Ref: "refs/heads/main",
-                SHA: "main-sha",
-            },
-            expectError: false,
-        },
-        {
-            name: "fully qualified ref passed through unchanged",
-            ref:  "refs/heads/feature-branch",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            assert.Contains(t, r.URL.Path, "/git/ref/heads/feature-branch")
-                            w.WriteHeader(http.StatusOK)
-                            _, _ = w.Write([]byte(`{"ref": "refs/heads/feature-branch", "object": {"sha": "feature-sha"}}`))
-                        }),
-                    ),
-                )
-            },
-            expectedOutput: &raw.ContentOpts{
-                Ref: "refs/heads/feature-branch",
-                SHA: "feature-sha",
-            },
-            expectError: false,
-        },
-        {
-            name: "short branch name resolves to refs/heads/",
-            ref:  "main",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                callCount := 0
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            callCount++
-                            if strings.Contains(r.URL.Path, "/git/ref/heads/main") {
-                                w.WriteHeader(http.StatusOK)
-                                _, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "main-sha"}}`))
-                            } else {
-                                t.Errorf("Unexpected path: %s", r.URL.Path)
-                                w.WriteHeader(http.StatusNotFound)
-                            }
-                        }),
-                    ),
-                )
-            },
-            expectedOutput: &raw.ContentOpts{
-                Ref: "refs/heads/main",
-                SHA: "main-sha",
-            },
-            expectError: false,
-        },
-        {
-            name: "short tag name falls back to refs/tags/ when branch not found",
-            ref:  "v1.0.0",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            if strings.Contains(r.URL.Path, "/git/ref/heads/v1.0.0") {
-                                w.WriteHeader(http.StatusNotFound)
-                                _, _ = w.Write([]byte(`{"message": "Not Found"}`))
-                            } else if strings.Contains(r.URL.Path, "/git/ref/tags/v1.0.0") {
-                                w.WriteHeader(http.StatusOK)
-                                _, _ = w.Write([]byte(`{"ref": "refs/tags/v1.0.0", "object": {"sha": "tag-sha"}}`))
-                            } else {
-                                t.Errorf("Unexpected path: %s", r.URL.Path)
-                                w.WriteHeader(http.StatusNotFound)
-                            }
-                        }),
-                    ),
-                )
-            },
-            expectedOutput: &raw.ContentOpts{
-                Ref: "refs/tags/v1.0.0",
-                SHA: "tag-sha",
-            },
-            expectError: false,
-        },
-        {
-            name: "heads/ prefix gets refs/ prepended",
-            ref:  "heads/feature-branch",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            assert.Contains(t, r.URL.Path, "/git/ref/heads/feature-branch")
-                            w.WriteHeader(http.StatusOK)
-                            _, _ = w.Write([]byte(`{"ref": "refs/heads/feature-branch", "object": {"sha": "feature-sha"}}`))
-                        }),
-                    ),
-                )
-            },
-            expectedOutput: &raw.ContentOpts{
-                Ref: "refs/heads/feature-branch",
-                SHA: "feature-sha",
-            },
-            expectError: false,
-        },
-        {
-            name: "tags/ prefix gets refs/ prepended",
-            ref:  "tags/v1.0.0",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            assert.Contains(t, r.URL.Path, "/git/ref/tags/v1.0.0")
-                            w.WriteHeader(http.StatusOK)
-                            _, _ = w.Write([]byte(`{"ref": "refs/tags/v1.0.0", "object": {"sha": "tag-sha"}}`))
-                        }),
-                    ),
-                )
-            },
-            expectedOutput: &raw.ContentOpts{
-                Ref: "refs/tags/v1.0.0",
-                SHA: "tag-sha",
-            },
-            expectError: false,
-        },
-        {
-            name: "invalid short name that doesn't exist as branch or tag",
-            ref:  "nonexistent",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            // Both branch and tag attempts should return 404
-                            w.WriteHeader(http.StatusNotFound)
-                            _, _ = w.Write([]byte(`{"message": "Not Found"}`))
-                        }),
-                    ),
-                )
-            },
-            expectError:   true,
-            errorContains: "could not resolve ref \"nonexistent\" as a branch or a tag",
-        },
-        {
-            name: "fully qualified pull request ref",
-            ref:  "refs/pull/123/head",
-            sha:  "",
-            mockSetup: func() *http.Client {
-                return mock.NewMockedHTTPClient(
-                    mock.WithRequestMatchHandler(
-                        mock.GetReposGitRefByOwnerByRepoByRef,
-                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                            assert.Contains(t, r.URL.Path, "/git/ref/pull/123/head")
-                            w.WriteHeader(http.StatusOK)
-                            _, _ = w.Write([]byte(`{"ref": "refs/pull/123/head", "object": {"sha": "pr-sha"}}`))
-                        }),
-                    ),
-                )
-            },
-            expectedOutput: &raw.ContentOpts{
-                Ref: "refs/pull/123/head",
-                SHA: "pr-sha",
-            },
-            expectError: false,
-        },
-    }
+	tests := []struct {
+		name           string
+		ref            string
+		sha            string
+		mockSetup      func() *http.Client
+		expectedOutput *raw.ContentOpts
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name: "sha takes precedence over ref",
+			ref:  "refs/heads/main",
+			sha:  "123sha456",
+			mockSetup: func() *http.Client {
+				// No API calls should be made when SHA is provided
+				return mock.NewMockedHTTPClient()
+			},
+			expectedOutput: &raw.ContentOpts{
+				SHA: "123sha456",
+			},
+			expectError: false,
+		},
+		{
+			name: "use default branch if ref and sha both empty",
+			ref:  "",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposByOwnerByRepo,
+						http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write([]byte(`{"name": "repo", "default_branch": "main"}`))
+						}),
+					),
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							assert.Contains(t, r.URL.Path, "/git/ref/heads/main")
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "main-sha"}}`))
+						}),
+					),
+				)
+			},
+			expectedOutput: &raw.ContentOpts{
+				Ref: "refs/heads/main",
+				SHA: "main-sha",
+			},
+			expectError: false,
+		},
+		{
+			name: "fully qualified ref passed through unchanged",
+			ref:  "refs/heads/feature-branch",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							assert.Contains(t, r.URL.Path, "/git/ref/heads/feature-branch")
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write([]byte(`{"ref": "refs/heads/feature-branch", "object": {"sha": "feature-sha"}}`))
+						}),
+					),
+				)
+			},
+			expectedOutput: &raw.ContentOpts{
+				Ref: "refs/heads/feature-branch",
+				SHA: "feature-sha",
+			},
+			expectError: false,
+		},
+		{
+			name: "short branch name resolves to refs/heads/",
+			ref:  "main",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				callCount := 0
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							callCount++
+							if strings.Contains(r.URL.Path, "/git/ref/heads/main") {
+								w.WriteHeader(http.StatusOK)
+								_, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "main-sha"}}`))
+							} else {
+								t.Errorf("Unexpected path: %s", r.URL.Path)
+								w.WriteHeader(http.StatusNotFound)
+							}
+						}),
+					),
+				)
+			},
+			expectedOutput: &raw.ContentOpts{
+				Ref: "refs/heads/main",
+				SHA: "main-sha",
+			},
+			expectError: false,
+		},
+		{
+			name: "short tag name falls back to refs/tags/ when branch not found",
+			ref:  "v1.0.0",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							if strings.Contains(r.URL.Path, "/git/ref/heads/v1.0.0") {
+								w.WriteHeader(http.StatusNotFound)
+								_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+							} else if strings.Contains(r.URL.Path, "/git/ref/tags/v1.0.0") {
+								w.WriteHeader(http.StatusOK)
+								_, _ = w.Write([]byte(`{"ref": "refs/tags/v1.0.0", "object": {"sha": "tag-sha"}}`))
+							} else {
+								t.Errorf("Unexpected path: %s", r.URL.Path)
+								w.WriteHeader(http.StatusNotFound)
+							}
+						}),
+					),
+				)
+			},
+			expectedOutput: &raw.ContentOpts{
+				Ref: "refs/tags/v1.0.0",
+				SHA: "tag-sha",
+			},
+			expectError: false,
+		},
+		{
+			name: "heads/ prefix gets refs/ prepended",
+			ref:  "heads/feature-branch",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							assert.Contains(t, r.URL.Path, "/git/ref/heads/feature-branch")
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write([]byte(`{"ref": "refs/heads/feature-branch", "object": {"sha": "feature-sha"}}`))
+						}),
+					),
+				)
+			},
+			expectedOutput: &raw.ContentOpts{
+				Ref: "refs/heads/feature-branch",
+				SHA: "feature-sha",
+			},
+			expectError: false,
+		},
+		{
+			name: "tags/ prefix gets refs/ prepended",
+			ref:  "tags/v1.0.0",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							assert.Contains(t, r.URL.Path, "/git/ref/tags/v1.0.0")
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write([]byte(`{"ref": "refs/tags/v1.0.0", "object": {"sha": "tag-sha"}}`))
+						}),
+					),
+				)
+			},
+			expectedOutput: &raw.ContentOpts{
+				Ref: "refs/tags/v1.0.0",
+				SHA: "tag-sha",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid short name that doesn't exist as branch or tag",
+			ref:  "nonexistent",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							// Both branch and tag attempts should return 404
+							w.WriteHeader(http.StatusNotFound)
+							_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+						}),
+					),
+				)
+			},
+			expectError:   true,
+			errorContains: "could not resolve ref \"nonexistent\" as a branch or a tag",
+		},
+		{
+			name: "fully qualified pull request ref",
+			ref:  "refs/pull/123/head",
+			sha:  "",
+			mockSetup: func() *http.Client {
+				return mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.GetReposGitRefByOwnerByRepoByRef,
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							assert.Contains(t, r.URL.Path, "/git/ref/pull/123/head")
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write([]byte(`{"ref": "refs/pull/123/head", "object": {"sha": "pr-sha"}}`))
+						}),
+					),
+				)
+			},
+			expectedOutput: &raw.ContentOpts{
+				Ref: "refs/pull/123/head",
+				SHA: "pr-sha",
+			},
+			expectError: false,
+		},
+	}
 
-    for _, tc := range tests {
-        t.Run(tc.name, func(t *testing.T) {
-            // Setup client with mock
-            client := github.NewClient(tc.mockSetup())
-            opts, err := resolveGitReference(ctx, client, owner, repo, tc.ref, tc.sha)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup client with mock
+			client := github.NewClient(tc.mockSetup())
+			opts, err := resolveGitReference(ctx, client, owner, repo, tc.ref, tc.sha)
 
-            if tc.expectError {
-                require.Error(t, err)
-                if tc.errorContains != "" {
-                    assert.Contains(t, err.Error(), tc.errorContains)
-                }
-                return
-            }
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
 
-            require.NoError(t, err)
-            require.NotNil(t, opts)
+			require.NoError(t, err)
+			require.NotNil(t, opts)
 
-            if tc.expectedOutput.SHA != "" {
-                assert.Equal(t, tc.expectedOutput.SHA, opts.SHA)
-            }
-            if tc.expectedOutput.Ref != "" {
-                assert.Equal(t, tc.expectedOutput.Ref, opts.Ref)
-            }
-        })
-    }
+			if tc.expectedOutput.SHA != "" {
+				assert.Equal(t, tc.expectedOutput.SHA, opts.SHA)
+			}
+			if tc.expectedOutput.Ref != "" {
+				assert.Equal(t, tc.expectedOutput.Ref, opts.Ref)
+			}
+		})
+	}
 }

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2324,13 +2324,14 @@ func Test_resolveGitReference(t *testing.T) {
 					mock.WithRequestMatchHandler(
 						mock.GetReposGitRefByOwnerByRepoByRef,
 						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							if strings.Contains(r.URL.Path, "/git/ref/heads/v1.0.0") {
+							switch {
+							case strings.Contains(r.URL.Path, "/git/ref/heads/v1.0.0"):
 								w.WriteHeader(http.StatusNotFound)
 								_, _ = w.Write([]byte(`{"message": "Not Found"}`))
-							} else if strings.Contains(r.URL.Path, "/git/ref/tags/v1.0.0") {
+							case strings.Contains(r.URL.Path, "/git/ref/tags/v1.0.0"):
 								w.WriteHeader(http.StatusOK)
 								_, _ = w.Write([]byte(`{"ref": "refs/tags/v1.0.0", "object": {"sha": "tag-sha"}}`))
-							} else {
+							default:
 								t.Errorf("Unexpected path: %s", r.URL.Path)
 								w.WriteHeader(http.StatusNotFound)
 							}
@@ -2396,7 +2397,7 @@ func Test_resolveGitReference(t *testing.T) {
 				return mock.NewMockedHTTPClient(
 					mock.WithRequestMatchHandler(
 						mock.GetReposGitRefByOwnerByRepoByRef,
-						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 							// Both branch and tag attempts should return 404
 							w.WriteHeader(http.StatusNotFound)
 							_, _ = w.Write([]byte(`{"message": "Not Found"}`))

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2292,12 +2292,10 @@ func Test_resolveGitReference(t *testing.T) {
 			ref:  "main",
 			sha:  "",
 			mockSetup: func() *http.Client {
-				callCount := 0
 				return mock.NewMockedHTTPClient(
 					mock.WithRequestMatchHandler(
 						mock.GetReposGitRefByOwnerByRepoByRef,
 						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							callCount++
 							if strings.Contains(r.URL.Path, "/git/ref/heads/main") {
 								w.WriteHeader(http.StatusOK)
 								_, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "main-sha"}}`))

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -2209,73 +2210,250 @@ func Test_filterPaths(t *testing.T) {
 }
 
 func Test_resolveGitReference(t *testing.T) {
-	ctx := context.Background()
-	owner := "owner"
-	repo := "repo"
-	mockedClient := mock.NewMockedHTTPClient(
-		mock.WithRequestMatchHandler(
-			mock.GetReposByOwnerByRepo,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"name": "repo", "default_branch": "main"}`))
-			}),
-		),
-		mock.WithRequestMatchHandler(
-			mock.GetReposGitRefByOwnerByRepoByRef,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "123sha456"}}`))
-			}),
-		),
-	)
+    ctx := context.Background()
+    owner := "owner"
+    repo := "repo"
 
-	tests := []struct {
-		name           string
-		ref            string
-		sha            string
-		expectedOutput *raw.ContentOpts
-	}{
-		{
-			name: "sha takes precedence over ref",
-			ref:  "refs/heads/main",
-			sha:  "123sha456",
-			expectedOutput: &raw.ContentOpts{
-				SHA: "123sha456",
-			},
-		},
-		{
-			name: "use default branch if ref and sha both empty",
-			ref:  "",
-			sha:  "",
-			expectedOutput: &raw.ContentOpts{
-				Ref: "refs/heads/main",
-				SHA: "123sha456",
-			},
-		},
-		{
-			name: "get SHA from ref",
-			ref:  "refs/heads/main",
-			sha:  "",
-			expectedOutput: &raw.ContentOpts{
-				Ref: "refs/heads/main",
-				SHA: "123sha456",
-			},
-		},
-	}
+    tests := []struct {
+        name           string
+        ref            string
+        sha            string
+        mockSetup      func() *http.Client
+        expectedOutput *raw.ContentOpts
+        expectError    bool
+        errorContains  string
+    }{
+        {
+            name: "sha takes precedence over ref",
+            ref:  "refs/heads/main",
+            sha:  "123sha456",
+            mockSetup: func() *http.Client {
+                // No API calls should be made when SHA is provided
+                return mock.NewMockedHTTPClient()
+            },
+            expectedOutput: &raw.ContentOpts{
+                SHA: "123sha456",
+            },
+            expectError: false,
+        },
+        {
+            name: "use default branch if ref and sha both empty",
+            ref:  "",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposByOwnerByRepo,
+                        http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+                            w.WriteHeader(http.StatusOK)
+                            _, _ = w.Write([]byte(`{"name": "repo", "default_branch": "main"}`))
+                        }),
+                    ),
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            assert.Contains(t, r.URL.Path, "/git/ref/heads/main")
+                            w.WriteHeader(http.StatusOK)
+                            _, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "main-sha"}}`))
+                        }),
+                    ),
+                )
+            },
+            expectedOutput: &raw.ContentOpts{
+                Ref: "refs/heads/main",
+                SHA: "main-sha",
+            },
+            expectError: false,
+        },
+        {
+            name: "fully qualified ref passed through unchanged",
+            ref:  "refs/heads/feature-branch",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            assert.Contains(t, r.URL.Path, "/git/ref/heads/feature-branch")
+                            w.WriteHeader(http.StatusOK)
+                            _, _ = w.Write([]byte(`{"ref": "refs/heads/feature-branch", "object": {"sha": "feature-sha"}}`))
+                        }),
+                    ),
+                )
+            },
+            expectedOutput: &raw.ContentOpts{
+                Ref: "refs/heads/feature-branch",
+                SHA: "feature-sha",
+            },
+            expectError: false,
+        },
+        {
+            name: "short branch name resolves to refs/heads/",
+            ref:  "main",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                callCount := 0
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            callCount++
+                            if strings.Contains(r.URL.Path, "/git/ref/heads/main") {
+                                w.WriteHeader(http.StatusOK)
+                                _, _ = w.Write([]byte(`{"ref": "refs/heads/main", "object": {"sha": "main-sha"}}`))
+                            } else {
+                                t.Errorf("Unexpected path: %s", r.URL.Path)
+                                w.WriteHeader(http.StatusNotFound)
+                            }
+                        }),
+                    ),
+                )
+            },
+            expectedOutput: &raw.ContentOpts{
+                Ref: "refs/heads/main",
+                SHA: "main-sha",
+            },
+            expectError: false,
+        },
+        {
+            name: "short tag name falls back to refs/tags/ when branch not found",
+            ref:  "v1.0.0",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            if strings.Contains(r.URL.Path, "/git/ref/heads/v1.0.0") {
+                                w.WriteHeader(http.StatusNotFound)
+                                _, _ = w.Write([]byte(`{"message": "Not Found"}`))
+                            } else if strings.Contains(r.URL.Path, "/git/ref/tags/v1.0.0") {
+                                w.WriteHeader(http.StatusOK)
+                                _, _ = w.Write([]byte(`{"ref": "refs/tags/v1.0.0", "object": {"sha": "tag-sha"}}`))
+                            } else {
+                                t.Errorf("Unexpected path: %s", r.URL.Path)
+                                w.WriteHeader(http.StatusNotFound)
+                            }
+                        }),
+                    ),
+                )
+            },
+            expectedOutput: &raw.ContentOpts{
+                Ref: "refs/tags/v1.0.0",
+                SHA: "tag-sha",
+            },
+            expectError: false,
+        },
+        {
+            name: "heads/ prefix gets refs/ prepended",
+            ref:  "heads/feature-branch",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            assert.Contains(t, r.URL.Path, "/git/ref/heads/feature-branch")
+                            w.WriteHeader(http.StatusOK)
+                            _, _ = w.Write([]byte(`{"ref": "refs/heads/feature-branch", "object": {"sha": "feature-sha"}}`))
+                        }),
+                    ),
+                )
+            },
+            expectedOutput: &raw.ContentOpts{
+                Ref: "refs/heads/feature-branch",
+                SHA: "feature-sha",
+            },
+            expectError: false,
+        },
+        {
+            name: "tags/ prefix gets refs/ prepended",
+            ref:  "tags/v1.0.0",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            assert.Contains(t, r.URL.Path, "/git/ref/tags/v1.0.0")
+                            w.WriteHeader(http.StatusOK)
+                            _, _ = w.Write([]byte(`{"ref": "refs/tags/v1.0.0", "object": {"sha": "tag-sha"}}`))
+                        }),
+                    ),
+                )
+            },
+            expectedOutput: &raw.ContentOpts{
+                Ref: "refs/tags/v1.0.0",
+                SHA: "tag-sha",
+            },
+            expectError: false,
+        },
+        {
+            name: "invalid short name that doesn't exist as branch or tag",
+            ref:  "nonexistent",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            // Both branch and tag attempts should return 404
+                            w.WriteHeader(http.StatusNotFound)
+                            _, _ = w.Write([]byte(`{"message": "Not Found"}`))
+                        }),
+                    ),
+                )
+            },
+            expectError:   true,
+            errorContains: "could not resolve ref \"nonexistent\" as a branch or a tag",
+        },
+        {
+            name: "fully qualified pull request ref",
+            ref:  "refs/pull/123/head",
+            sha:  "",
+            mockSetup: func() *http.Client {
+                return mock.NewMockedHTTPClient(
+                    mock.WithRequestMatchHandler(
+                        mock.GetReposGitRefByOwnerByRepoByRef,
+                        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                            assert.Contains(t, r.URL.Path, "/git/ref/pull/123/head")
+                            w.WriteHeader(http.StatusOK)
+                            _, _ = w.Write([]byte(`{"ref": "refs/pull/123/head", "object": {"sha": "pr-sha"}}`))
+                        }),
+                    ),
+                )
+            },
+            expectedOutput: &raw.ContentOpts{
+                Ref: "refs/pull/123/head",
+                SHA: "pr-sha",
+            },
+            expectError: false,
+        },
+    }
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup client with mock
-			client := github.NewClient(mockedClient)
-			opts, err := resolveGitReference(ctx, client, owner, repo, tc.ref, tc.sha)
-			require.NoError(t, err)
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            // Setup client with mock
+            client := github.NewClient(tc.mockSetup())
+            opts, err := resolveGitReference(ctx, client, owner, repo, tc.ref, tc.sha)
 
-			if tc.expectedOutput.SHA != "" {
-				assert.Equal(t, tc.expectedOutput.SHA, opts.SHA)
-			}
-			if tc.expectedOutput.Ref != "" {
-				assert.Equal(t, tc.expectedOutput.Ref, opts.Ref)
-			}
-		})
-	}
+            if tc.expectError {
+                require.Error(t, err)
+                if tc.errorContains != "" {
+                    assert.Contains(t, err.Error(), tc.errorContains)
+                }
+                return
+            }
+
+            require.NoError(t, err)
+            require.NotNil(t, opts)
+
+            if tc.expectedOutput.SHA != "" {
+                assert.Equal(t, tc.expectedOutput.SHA, opts.SHA)
+            }
+            if tc.expectedOutput.Ref != "" {
+                assert.Equal(t, tc.expectedOutput.Ref, opts.Ref)
+            }
+        })
+    }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: [#728](https://github.com/github/github-mcp-server/issues/728)

### Overview
This PR significantly improves how we handle refs in the `get_file_contents` tool, after users [reported](https://github.com/github/github-mcp-server/issues/728) the tool being often broken from bad ref handling. 

### The problem
Despite the tool description, models can pass as argument to the tool a `ref` formatted either as fully qualified (e.g. `refs/heads/beanch_name`) or as short user-friendly names (e.g. `branch_name`). 

The [get_repository_content](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content) endpoint from the Github API is able to handle both flexibly:
<img width="1250" height="443" alt="Screenshot 2025-08-11 at 11 47 24" src="https://github.com/user-attachments/assets/26e1bb14-b9ea-47c3-976e-39a931119083" />
<img width="1250" height="443" alt="Screenshot 2025-08-11 at 11 47 39" src="https://github.com/user-attachments/assets/210eab97-aeed-4c33-9917-0f94031deb60" />



However, the `get_reference` endpoint doesn't (it requires a `ref` formatted in a specific way):
<img width="1250" height="443" alt="Screenshot 2025-08-11 at 11 51 42" src="https://github.com/user-attachments/assets/5330a155-3d52-4fd6-9b78-b08ef12b0b91" />
<img width="1250" height="443" alt="Screenshot 2025-08-11 at 11 51 33" src="https://github.com/user-attachments/assets/8223aa83-7014-4d6d-89b0-4515d43ebfe8" />


Our previous logic would fail often because it uses both endpoints but it was not handling user-friendly refs (e.g. `branch_name`, `heads/branch_name`, `tag_name`), which are often provided by models to the tool. This would thus break the tool.

### The Solution
This PR introduces new, robust logic to resolve a `ref` by identifying the format in which it was provided and constructing a fully qualified `ref` accordingly. In short, the new `resolveGitReference` function now handles:
- Fully-Qualified refs: `refs/heads/main`
- Partially-Qualified refs: `heads/main`
- Short Name refs: `main` (discovering automatically if it's a branch or a tag)

This ensures that the tool can handle the most common ways in which the `ref` input is provided by the user.

Additionally, I added:
- Comprehensive tests that cover all new logic paths.
- I have added quite detailed comments to the function itself to make the resolution logic, which can be tedious, much easier to follow

**Demo**
<img width="457" height="415" alt="Screenshot 2025-08-11 at 11 43 38" src="https://github.com/user-attachments/assets/c59767e6-bcfb-4f19-9cfa-1d656c98eaaa" />
<img width="452" height="402" alt="Screenshot 2025-08-11 at 11 39 53" src="https://github.com/user-attachments/assets/2c5130cf-2bbc-4022-aac3-13a2cc5759e3" />
<img width="351" height="938" alt="Screenshot 2025-08-07 at 17 55 20" src="https://github.com/user-attachments/assets/40c8e510-e602-461b-bf33-5d2793f57665" />


