### PR TITLE
Handle Actions Cancel Workflow Run returning a 202

### DIFF
--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -955,7 +955,9 @@ func CancelWorkflowRun(getClient GetClientFn, t translations.TranslationHelperFu
 
 			resp, err := client.Actions.CancelWorkflowRunByID(ctx, owner, repo, runID)
 			if err != nil {
-				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to cancel workflow run", resp, err), nil
+				if _, ok := err.(*github.AcceptedError); !ok {
+					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to cancel workflow run", resp, err), nil
+				}
 			}
 			defer func() { _ = resp.Body.Close() }()
 

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -323,12 +323,14 @@ func Test_CancelWorkflowRun(t *testing.T) {
 		{
 			name: "successful workflow run cancellation",
 			mockedClient: mock.NewMockedHTTPClient(
-				mock.WithRequestMatch(
+				mock.WithRequestMatchHandler(
 					mock.EndpointPattern{
 						Pattern: "/repos/owner/repo/actions/runs/12345/cancel",
 						Method:  "POST",
 					},
-					"", // Empty response body for 202 Accepted
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusAccepted)
+					}),
 				),
 			),
 			requestArgs: map[string]any{
@@ -337,6 +339,27 @@ func Test_CancelWorkflowRun(t *testing.T) {
 				"run_id": float64(12345),
 			},
 			expectError: false,
+		},
+		{
+			name: "conflict when cancelling a workflow run",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.EndpointPattern{
+						Pattern: "/repos/owner/repo/actions/runs/12345/cancel",
+						Method:  "POST",
+					},
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusConflict)
+					}),
+				),
+			),
+			requestArgs: map[string]any{
+				"owner":  "owner",
+				"repo":   "repo",
+				"run_id": float64(12345),
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to cancel workflow run",
 		},
 		{
 			name:         "missing required parameter run_id",
@@ -369,7 +392,7 @@ func Test_CancelWorkflowRun(t *testing.T) {
 			textContent := getTextResult(t, result)
 
 			if tc.expectedErrMsg != "" {
-				assert.Equal(t, tc.expectedErrMsg, textContent.Text)
+				assert.Contains(t, textContent.Text, tc.expectedErrMsg)
 				return
 			}
 


### PR DESCRIPTION
Actions Cancel Workflow Run returns a 202 on success, but this is returned as an error in `google/go-github`. We need to check if the error is a `*github.AcceptedError`, and only if not respond that this failed. 
