### PR TITLE
docs: add docs for Rovo Dev CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 - **[Claude Applications](/docs/installation-guides/install-claude.md)** - Installation guide for Claude Web, Claude Desktop and Claude Code CLI
 - **[Cursor](/docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE
 - **[Windsurf](/docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
+- **[Rovo Dev CLI](/docs/installation-guides/install-rovo-dev-cli.md)** - Installation guide for Rovo Dev CLI
 
 > **Note:** Each MCP host application needs to configure a GitHub App or OAuth App to support remote access via OAuth. Any host application that supports remote MCP servers should support the remote GitHub server with PAT authentication. Configuration details and support levels vary by host. Make sure to refer to the host application's documentation for more info.
 

--- a/docs/installation-guides/install-rovo-dev-cli.md
+++ b/docs/installation-guides/install-rovo-dev-cli.md
@@ -1,0 +1,32 @@
+# Install GitHub MCP Server in Rovo Dev CLI
+
+## Prerequisites
+
+1. Rovo Dev CLI installed (latest version)
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new) with appropriate scopes
+
+## MCP Server Setup
+
+Uses GitHub's hosted server at https://api.githubcopilot.com/mcp/.
+
+### Install steps
+
+1. Run `acli rovodev mcp` to open the MCP configuration for Rovo Dev CLI
+2. Add configuration by following example below.
+3. Replace `YOUR_GITHUB_PAT` with your actual [GitHub Personal Access Token](https://github.com/settings/tokens)
+4. Save the file and restart Rovo Dev CLI with `acli rovodev`
+
+### Example configuration
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
This adds docs for how to setup the MCP server in Atlassian's Rovo Dev CLI. 