### PR TITLE
Update install-claude.md

### DIFF
--- a/docs/installation-guides/install-claude.md
+++ b/docs/installation-guides/install-claude.md
@@ -43,16 +43,6 @@ Claude Code CLI provides command-line access to Claude with MCP server integrati
 Run the following command to add the GitHub MCP server using Docker:
 
 ```bash
-claude mcp add github -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
-```
-
-Then set the environment variable:
-```bash
-claude mcp update github -e GITHUB_PERSONAL_ACCESS_TOKEN=your_github_pat
-```
-
-Or as a single command with the token inline:
-```bash
 claude mcp add-json github '{"command": "docker", "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"], "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "your_github_pat"}}'
 ```
 


### PR DESCRIPTION
Removed instructions to add MCP server using `claude mcp add` and then `claude mcp update` (to add Github PAT env variable) as `claude mcp update` command no longer exists (https://docs.anthropic.com/en/docs/claude-code/cli-reference)

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
n/a