### PR TITLE
Change role from "system" to "user" in prompt messages for `AssignCodingAgentPrompt` and `IssueToFixWorkflowPrompt`

### DIFF
--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1552,7 +1552,7 @@ func AssignCodingAgentPrompt(t translations.TranslationHelperFunc) (tool mcp.Pro
 
 			messages := []mcp.PromptMessage{
 				{
-					Role:    "system",
+					Role:    "user",
 					Content: mcp.NewTextContent("You are a personal assistant for GitHub the Copilot GitHub Coding Agent. Your task is to help the user assign tasks to the Coding Agent based on their open GitHub issues. You can use `assign_copilot_to_issue` tool to assign the Coding Agent to issues that are suitable for autonomous work, and `search_issues` tool to find issues that match the user's criteria. You can also use `list_issues` to get a list of issues in the repository."),
 				},
 				{

--- a/pkg/github/workflow_prompts.go
+++ b/pkg/github/workflow_prompts.go
@@ -37,7 +37,7 @@ func IssueToFixWorkflowPrompt(t translations.TranslationHelperFunc) (tool mcp.Pr
 
 			messages := []mcp.PromptMessage{
 				{
-					Role:    "system",
+					Role:    "user",
 					Content: mcp.NewTextContent("You are a development workflow assistant helping to create GitHub issues and generate corresponding pull requests to fix them. You should: 1) Create a well-structured issue with clear problem description, 2) Assign it to Copilot coding agent to generate a solution, and 3) Monitor the PR creation process."),
 				},
 				{


### PR DESCRIPTION
## Issue Description
Role "system" is not allowed by Claude Code in MCP provided prompts (they allow only role "user" and "assistant").
 In Claude Code terminal, when user try to use `/gh:AssignCodingAgent (MCP)` or `/gh:IssueToFixWorkflow (MCP)` provided by Github MCP server, they will face the below error:
<img width="892" height="416" alt="Screenshot 2025-08-16 at 4 37 12 PM" src="https://github.com/user-attachments/assets/96784178-5665-4459-a75f-ae79f6ce2d82" />


## Solution
Simply change the role from "system" to "user" fix this issue without impacting the functionality of the features: `/gh:AssignCodingAgent` and `/gh:IssueToFixWorkflow`. 
Claude Code now accept the prompt from Github MCP server and proceed as expected.
<img width="1501" height="885" alt="Screenshot 2025-08-16 at 4 41 46 PM" src="https://github.com/user-attachments/assets/8579d9cb-d3ca-4502-bea9-47a65a82399c" />
    

## Remark: 
I couldn't find any existing issue on Github Repo for this yet. If an issue is required to merge this changes. Let me know i will create a new one.
