### PR TITLE
Update "Close inactive issues" workflow to close issues after 180 days of inactivity

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -7,8 +7,8 @@ jobs:
   close-issues:
     runs-on: ubuntu-latest
     env:
-      PR_DAYS_BEFORE_STALE: 170
-      PR_DAYS_BEFORE_CLOSE: 10
+      PR_DAYS_BEFORE_STALE: 60
+      PR_DAYS_BEFORE_CLOSE: 120
       PR_STALE_LABEL: stale
     permissions:
       issues: write


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

We should only close issues if they have been inactive for 180 days. With this PR, we mark an issue as stale and warn the user after 60 days of inactivity, and close the issue after another 120 days if still inactive.
