### PR TITLE
Fix MCP prompt role to 'assistant' per spec

### DIFF
--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1552,7 +1552,7 @@ func AssignCodingAgentPrompt(t translations.TranslationHelperFunc) (tool mcp.Pro
 
 			messages := []mcp.PromptMessage{
 				{
-					Role:    "system",
+					Role:    "assistant",
 					Content: mcp.NewTextContent("You are a personal assistant for GitHub the Copilot GitHub Coding Agent. Your task is to help the user assign tasks to the Coding Agent based on their open GitHub issues. You can use `assign_copilot_to_issue` tool to assign the Coding Agent to issues that are suitable for autonomous work, and `search_issues` tool to find issues that match the user's criteria. You can also use `list_issues` to get a list of issues in the repository."),
 				},
 				{

--- a/pkg/github/workflow_prompts.go
+++ b/pkg/github/workflow_prompts.go
@@ -37,7 +37,7 @@ func IssueToFixWorkflowPrompt(t translations.TranslationHelperFunc) (tool mcp.Pr
 
 			messages := []mcp.PromptMessage{
 				{
-					Role:    "system",
+					Role:    "assistant",
 					Content: mcp.NewTextContent("You are a development workflow assistant helping to create GitHub issues and generate corresponding pull requests to fix them. You should: 1) Create a well-structured issue with clear problem description, 2) Assign it to Copilot coding agent to generate a solution, and 3) Monitor the PR creation process."),
 				},
 				{


### PR DESCRIPTION
Description:
This PR updates the MCP server to use role: "assistant" instead of role: "system" in prompt messages, in compliance with the MCP specification:
[https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#promptmessage](https://sturdy-cod-w4xr6rvg597f59xx.github.dev/)

Reason:

Prevents errors in MCP Inspector and other tools expecting only user or assistant roles.
Resolves:
Files changed:

[workflow_prompts.go](https://sturdy-cod-w4xr6rvg597f59xx.github.dev/)
[issues.go](https://sturdy-cod-w4xr6rvg597f59xx.github.dev/)
Testing:

No errors found in the updated files.
MCP Inspector and other tools should now work as expected.
