### PR TITLE
Repository security advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,12 @@ The following sets of tools are available (all are on by default):
   - `type`: Advisory type. (string, optional)
   - `updated`: Filter by update date or date range (ISO 8601 date or range). (string, optional)
 
+- **list_org_repository_security_advisories** - List org repository security advisories
+  - `direction`: Sort direction. (string, optional)
+  - `org`: The organization login. (string, required)
+  - `sort`: Sort field. (string, optional)
+  - `state`: Filter by advisory state. (string, optional)
+
 - **list_repository_security_advisories** - List repository security advisories
   - `direction`: Sort direction. (string, optional)
   - `owner`: The owner of the repository. (string, required)

--- a/pkg/github/security_advisories_test.go
+++ b/pkg/github/security_advisories_test.go
@@ -385,3 +385,142 @@ func Test_ListRepositorySecurityAdvisories(t *testing.T) {
 		})
 	}
 }
+
+func Test_ListOrgRepositorySecurityAdvisories(t *testing.T) {
+	// Verify tool definition once
+	mockClient := github.NewClient(nil)
+	tool, _ := ListOrgRepositorySecurityAdvisories(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+
+	assert.Equal(t, "list_org_repository_security_advisories", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "org")
+	assert.Contains(t, tool.InputSchema.Properties, "direction")
+	assert.Contains(t, tool.InputSchema.Properties, "sort")
+	assert.Contains(t, tool.InputSchema.Properties, "state")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"org"})
+
+	// Endpoint pattern for org repository security advisories
+	var GetOrgsSecurityAdvisoriesByOrg = mock.EndpointPattern{
+		Pattern: "/orgs/{org}/security-advisories",
+		Method:  "GET",
+	}
+
+	adv1 := &github.SecurityAdvisory{
+		GHSAID:      github.Ptr("GHSA-aaaa-bbbb-cccc"),
+		Summary:     github.Ptr("Org repo advisory 1"),
+		Description: github.Ptr("First advisory"),
+		Severity:    github.Ptr("low"),
+	}
+	adv2 := &github.SecurityAdvisory{
+		GHSAID:      github.Ptr("GHSA-dddd-eeee-ffff"),
+		Summary:     github.Ptr("Org repo advisory 2"),
+		Description: github.Ptr("Second advisory"),
+		Severity:    github.Ptr("critical"),
+	}
+
+	tests := []struct {
+		name               string
+		mockedClient       *http.Client
+		requestArgs        map[string]interface{}
+		expectError        bool
+		expectedAdvisories []*github.SecurityAdvisory
+		expectedErrMsg     string
+	}{
+		{
+			name: "successful listing (no filters)",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					GetOrgsSecurityAdvisoriesByOrg,
+					expect(t, expectations{
+						path:        "/orgs/octo/security-advisories",
+						queryParams: map[string]string{},
+					}).andThen(
+						mockResponse(t, http.StatusOK, []*github.SecurityAdvisory{adv1, adv2}),
+					),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"org": "octo",
+			},
+			expectError:        false,
+			expectedAdvisories: []*github.SecurityAdvisory{adv1, adv2},
+		},
+		{
+			name: "successful listing with filters",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					GetOrgsSecurityAdvisoriesByOrg,
+					expect(t, expectations{
+						path: "/orgs/octo/security-advisories",
+						queryParams: map[string]string{
+							"direction": "asc",
+							"sort":      "created",
+							"state":     "triage",
+						},
+					}).andThen(
+						mockResponse(t, http.StatusOK, []*github.SecurityAdvisory{adv1}),
+					),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"org":       "octo",
+				"direction": "asc",
+				"sort":      "created",
+				"state":     "triage",
+			},
+			expectError:        false,
+			expectedAdvisories: []*github.SecurityAdvisory{adv1},
+		},
+		{
+			name: "listing fails",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					GetOrgsSecurityAdvisoriesByOrg,
+					expect(t, expectations{
+						path:        "/orgs/octo/security-advisories",
+						queryParams: map[string]string{},
+					}).andThen(
+						mockResponse(t, http.StatusForbidden, map[string]string{"message": "Forbidden"}),
+					),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"org": "octo",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to list organization repository security advisories",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := github.NewClient(tc.mockedClient)
+			_, handler := ListOrgRepositorySecurityAdvisories(stubGetClientFn(client), translations.NullTranslationHelper)
+
+			request := createMCPRequest(tc.requestArgs)
+
+			result, err := handler(context.Background(), request)
+
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			textContent := getTextResult(t, result)
+
+			var returnedAdvisories []*github.SecurityAdvisory
+			err = json.Unmarshal([]byte(textContent.Text), &returnedAdvisories)
+			assert.NoError(t, err)
+			assert.Len(t, returnedAdvisories, len(tc.expectedAdvisories))
+			for i, advisory := range returnedAdvisories {
+				assert.Equal(t, *tc.expectedAdvisories[i].GHSAID, *advisory.GHSAID)
+				assert.Equal(t, *tc.expectedAdvisories[i].Summary, *advisory.Summary)
+				assert.Equal(t, *tc.expectedAdvisories[i].Description, *advisory.Description)
+				assert.Equal(t, *tc.expectedAdvisories[i].Severity, *advisory.Severity)
+			}
+		})
+	}
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -165,6 +165,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 			toolsets.NewServerTool(ListGlobalSecurityAdvisories(getClient, t)),
 			toolsets.NewServerTool(GetGlobalSecurityAdvisory(getClient, t)),
 			toolsets.NewServerTool(ListRepositorySecurityAdvisories(getClient, t)),
+			toolsets.NewServerTool(ListOrgRepositorySecurityAdvisories(getClient, t)),
 		)
 
 	// Keep experiments alive so the system doesn't error out when it's always enabled


### PR DESCRIPTION
This pull request adds new functionality to list security advisories for both individual repositories and entire organizations, along with corresponding tests and documentation updates. ~This builds on https://github.com/github/github-mcp-server/pull/919 and the PR is stacked against that, we can either merge it into that branch, or have it rebased against main when it lands.~

<img width="1134" height="819" alt="Screenshot 2025-08-19 at 14 30 11" src="https://github.com/user-attachments/assets/3ff494de-9282-462e-9650-84731362b620" />
