### PR TITLE
Update Cursor installation link

### DIFF
--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -1,17 +1,19 @@
 # Install GitHub MCP Server in Cursor
 
 ## Prerequisites
+
 1. Cursor IDE installed (latest version)
 2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new) with appropriate scopes
 3. For local installation: [Docker](https://www.docker.com/) installed and running
 
 ## Remote Server Setup (Recommended)
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=github&config=eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWJjb3BpbG90LmNvbS9tY3AvIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIFlPVVJfR0lUSFVCX1BBVCJ9LCJ0eXBlIjoiaHR0cCJ9)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=github&config=eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWJjb3BpbG90LmNvbS9tY3AvIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIFlPVVJfR0lUSFVCX1BBVCJ9fQ%3D%3D)
 
 Uses GitHub's hosted server at https://api.githubcopilot.com/mcp/. Requires Cursor v0.48.0+ for Streamable HTTP support. While Cursor supports OAuth for some MCP servers, the GitHub server currently requires a Personal Access Token.
 
 ### Install steps
+
 1. Click the install button above and follow the flow, or go directly to your global MCP configuration file at `~/.cursor/mcp.json` and enter the code block below
 2. In Tools & Integrations > MCP tools, click the pencil icon next to "github"
 3. Replace `YOUR_GITHUB_PAT` with your actual [GitHub Personal Access Token](https://github.com/settings/tokens)
@@ -40,6 +42,7 @@ Uses GitHub's hosted server at https://api.githubcopilot.com/mcp/. Requires Curs
 The local GitHub MCP server runs via Docker and requires Docker Desktop to be installed and running.
 
 ### Install steps
+
 1. Click the install button above and follow the flow, or go directly to your global MCP configuration file at `~/.cursor/mcp.json` and enter the code block below
 2. In Tools & Integrations > MCP tools, click the pencil icon next to "github"
 3. Replace `YOUR_GITHUB_PAT` with your actual [GitHub Personal Access Token](https://github.com/settings/tokens)
@@ -77,6 +80,7 @@ The local GitHub MCP server runs via Docker and requires Docker Desktop to be in
 - **Project-specific**: `.cursor/mcp.json` in project root
 
 ## Verify Installation
+
 1. Restart Cursor completely
 2. Check for green dot in Settings → Tools & Integrations → MCP Tools
 3. In chat/composer, check "Available Tools"
@@ -85,16 +89,19 @@ The local GitHub MCP server runs via Docker and requires Docker Desktop to be in
 ## Troubleshooting
 
 ### Remote Server Issues
+
 - **Streamable HTTP not working**: Ensure you're using Cursor v0.48.0 or later
 - **Authentication failures**: Verify PAT has correct scopes
 - **Connection errors**: Check firewall/proxy settings
 
 ### Local Server Issues
+
 - **Docker errors**: Ensure Docker Desktop is running
 - **Image pull failures**: Try `docker logout ghcr.io` then retry
 - **Docker not found**: Install Docker Desktop and ensure it's running
 
 ### General Issues
+
 - **MCP not loading**: Restart Cursor completely after configuration
 - **Invalid JSON**: Validate that json format is correct
 - **Tools not appearing**: Check server shows green dot in MCP settings

--- a/docs/installation-guides/install-cursor.md
+++ b/docs/installation-guides/install-cursor.md
@@ -37,7 +37,7 @@ Uses GitHub's hosted server at https://api.githubcopilot.com/mcp/. Requires Curs
 
 ## Local Server Setup
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=github&config=eyJjb21tYW5kIjoiZG9ja2VyIiwiYXJncyI6WyJydW4iLCItaSIsIi0tcm0iLCItZSIsIkdJVEhVQl9QRVJTT05BTF9BQ0NFU1NfVE9LRU4iLCJnaGNyLmlvL2dpdGh1Yi9naXRodWItbWNwLXNlcnZlciJdLCJlbnYiOnsiR0lUSFVCX1BFUlNPTkFMX0FDQ0VTU19UT0tFTiI6IllPVVJfR0lUSFVCX1BHVCJ9fQ==)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=github&config=eyJjb21tYW5kIjoiZG9ja2VyIHJ1biAtaSAtLXJtIC1lIEdJVEhVQl9QRVJTT05BTF9BQ0NFU1NfVE9LRU4gZ2hjci5pby9naXRodWIvZ2l0aHViLW1jcC1zZXJ2ZXIiLCJlbnYiOnsiR0lUSFVCX1BFUlNPTkFMX0FDQ0VTU19UT0tFTiI6IllPVVJfR0lUSFVCX1BBVCJ9fQ%3D%3D)
 
 The local GitHub MCP server runs via Docker and requires Docker Desktop to be installed and running.
 


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: #860 

The current installation links for both the remote and the local MCP is broken due to an update on Cursor's side. This PR updates the link to a working one. The links were generated using Cursor's [guide](https://docs.cursor.com/en/tools/developers)
