### PR TITLE
Add returning `ResourceLink` type from actions logs and file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ The following sets of tools are available (all are on by default):
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
   - `return_content`: Returns actual log content instead of URLs (boolean, optional)
+  - `return_resource_links`: Returns MCP ResourceLinks for accessing logs instead of direct content or URLs (boolean, optional)
   - `run_id`: Workflow run ID (required when using failed_only) (number, optional)
   - `tail_lines`: Number of lines to return from the end of the log (number, optional)
 
@@ -841,6 +842,7 @@ The following sets of tools are available (all are on by default):
   - `path`: Path to file/directory (directories must end with a slash '/') (string, optional)
   - `ref`: Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head` (string, optional)
   - `repo`: Repository name (string, required)
+  - `return_resource_links`: Return ResourceLinks instead of file content - useful for large files or when you want to reference the file for later access (boolean, optional)
   - `sha`: Accepts optional commit SHA. If specified, it will be used instead of ref (string, optional)
 
 - **get_latest_release** - Get latest release

--- a/pkg/github/__toolsnaps__/get_file_contents.snap
+++ b/pkg/github/__toolsnaps__/get_file_contents.snap
@@ -23,6 +23,10 @@
         "description": "Repository name",
         "type": "string"
       },
+      "return_resource_links": {
+        "description": "Return ResourceLinks instead of file content - useful for large files or when you want to reference the file for later access",
+        "type": "boolean"
+      },
       "sha": {
         "description": "Accepts optional commit SHA. If specified, it will be used instead of ref",
         "type": "string"

--- a/pkg/github/actions_resource.go
+++ b/pkg/github/actions_resource.go
@@ -1,0 +1,195 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/github/github-mcp-server/internal/profiler"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// GetWorkflowRunLogsResource defines the resource template and handler for getting workflow run logs.
+func GetWorkflowRunLogsResource(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.ResourceTemplate, server.ResourceTemplateHandlerFunc) {
+	return mcp.NewResourceTemplate(
+			"actions://{owner}/{repo}/runs/{runId}/logs", // Resource template
+			t("RESOURCE_WORKFLOW_RUN_LOGS_DESCRIPTION", "Workflow Run Logs"),
+		),
+		WorkflowRunLogsResourceHandler(getClient)
+}
+
+// GetJobLogsResource defines the resource template and handler for getting individual job logs.
+func GetJobLogsResource(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.ResourceTemplate, server.ResourceTemplateHandlerFunc) {
+	return mcp.NewResourceTemplate(
+			"actions://{owner}/{repo}/jobs/{jobId}/logs", // Resource template
+			t("RESOURCE_JOB_LOGS_DESCRIPTION", "Job Logs"),
+		),
+		JobLogsResourceHandler(getClient)
+}
+
+// WorkflowRunLogsResourceHandler returns a handler function for workflow run logs requests.
+func WorkflowRunLogsResourceHandler(getClient GetClientFn) func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		// Parse parameters from the URI template matcher
+		owner, ok := request.Params.Arguments["owner"].([]string)
+		if !ok || len(owner) == 0 {
+			return nil, errors.New("owner is required")
+		}
+
+		repo, ok := request.Params.Arguments["repo"].([]string)
+		if !ok || len(repo) == 0 {
+			return nil, errors.New("repo is required")
+		}
+
+		runIdStr, ok := request.Params.Arguments["runId"].([]string)
+		if !ok || len(runIdStr) == 0 {
+			return nil, errors.New("runId is required")
+		}
+
+		runId, err := strconv.ParseInt(runIdStr[0], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid runId: %w", err)
+		}
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+		}
+
+		// Get the JIT URL for workflow run logs
+		url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, owner[0], repo[0], runId, 1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get workflow run logs URL: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		// Download the logs content immediately using the JIT URL
+		content, err := downloadLogsFromJITURL(ctx, url.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to download workflow run logs: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/zip",
+				Text:     fmt.Sprintf("Workflow run logs for run %d (ZIP archive)\n\nNote: This is a ZIP archive containing all job logs. Download URL was: %s\n\nContent length: %d bytes", runId, url.String(), len(content)),
+			},
+		}, nil
+	}
+}
+
+// JobLogsResourceHandler returns a handler function for individual job logs requests.
+func JobLogsResourceHandler(getClient GetClientFn) func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		// Parse parameters from the URI template matcher
+		owner, ok := request.Params.Arguments["owner"].([]string)
+		if !ok || len(owner) == 0 {
+			return nil, errors.New("owner is required")
+		}
+
+		repo, ok := request.Params.Arguments["repo"].([]string)
+		if !ok || len(repo) == 0 {
+			return nil, errors.New("repo is required")
+		}
+
+		jobIdStr, ok := request.Params.Arguments["jobId"].([]string)
+		if !ok || len(jobIdStr) == 0 {
+			return nil, errors.New("jobId is required")
+		}
+
+		jobId, err := strconv.ParseInt(jobIdStr[0], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid jobId: %w", err)
+		}
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+		}
+
+		// Get the JIT URL for job logs
+		url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, owner[0], repo[0], jobId, 1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get job logs URL: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		// Download the logs content immediately using the JIT URL
+		content, err := downloadLogsFromJITURL(ctx, url.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to download job logs: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "text/plain",
+				Text:     content,
+			},
+		}, nil
+	}
+}
+
+// downloadLogsFromJITURL downloads content from a GitHub JIT URL
+func downloadLogsFromJITURL(ctx context.Context, jitURL string) (string, error) {
+	prof := profiler.New(nil, profiler.IsProfilingEnabled())
+	finish := prof.Start(ctx, "download_jit_logs")
+
+	httpResp, err := http.Get(jitURL) //nolint:gosec
+	if err != nil {
+		_ = finish(0, 0)
+		return "", fmt.Errorf("failed to download from JIT URL: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		_ = finish(0, 0)
+		return "", fmt.Errorf("failed to download logs: HTTP %d", httpResp.StatusCode)
+	}
+
+	// For large files, we should limit the content size to avoid memory issues
+	const maxContentSize = 10 * 1024 * 1024 // 10MB limit
+
+	// Read the content with a size limit
+	content := make([]byte, 0, 1024*1024) // Start with 1MB capacity
+	buffer := make([]byte, 32*1024)       // 32KB read buffer
+	totalRead := 0
+
+	for {
+		n, err := httpResp.Body.Read(buffer)
+		if n > 0 {
+			if totalRead+n > maxContentSize {
+				// Truncate if content is too large
+				remaining := maxContentSize - totalRead
+				content = append(content, buffer[:remaining]...)
+				content = append(content, []byte(fmt.Sprintf("\n\n[Content truncated - original size exceeded %d bytes]", maxContentSize))...)
+				break
+			}
+			content = append(content, buffer[:n]...)
+			totalRead += n
+		}
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			_ = finish(0, int64(totalRead))
+			return "", fmt.Errorf("failed to read response body: %w", err)
+		}
+	}
+
+	// Count lines for profiler
+	lines := 1
+	for _, b := range content {
+		if b == '\n' {
+			lines++
+		}
+	}
+
+	_ = finish(lines, int64(len(content)))
+	return string(content), nil
+}

--- a/pkg/github/actions_resource.go
+++ b/pkg/github/actions_resource.go
@@ -45,12 +45,12 @@ func WorkflowRunLogsResourceHandler(getClient GetClientFn) func(ctx context.Cont
 			return nil, errors.New("repo is required")
 		}
 
-		runIdStr, ok := request.Params.Arguments["runId"].([]string)
-		if !ok || len(runIdStr) == 0 {
+		runIDStr, ok := request.Params.Arguments["runId"].([]string)
+		if !ok || len(runIDStr) == 0 {
 			return nil, errors.New("runId is required")
 		}
 
-		runId, err := strconv.ParseInt(runIdStr[0], 10, 64)
+		runID, err := strconv.ParseInt(runIDStr[0], 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid runId: %w", err)
 		}
@@ -61,7 +61,7 @@ func WorkflowRunLogsResourceHandler(getClient GetClientFn) func(ctx context.Cont
 		}
 
 		// Get the JIT URL for workflow run logs
-		url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, owner[0], repo[0], runId, 1)
+		url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, owner[0], repo[0], runID, 1)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get workflow run logs URL: %w", err)
 		}
@@ -77,7 +77,7 @@ func WorkflowRunLogsResourceHandler(getClient GetClientFn) func(ctx context.Cont
 			mcp.TextResourceContents{
 				URI:      request.Params.URI,
 				MIMEType: "application/zip",
-				Text:     fmt.Sprintf("Workflow run logs for run %d (ZIP archive)\n\nNote: This is a ZIP archive containing all job logs. Download URL was: %s\n\nContent length: %d bytes", runId, url.String(), len(content)),
+				Text:     fmt.Sprintf("Workflow run logs for run %d (ZIP archive)\n\nNote: This is a ZIP archive containing all job logs. Download URL was: %s\n\nContent length: %d bytes", runID, url.String(), len(content)),
 			},
 		}, nil
 	}
@@ -97,12 +97,12 @@ func JobLogsResourceHandler(getClient GetClientFn) func(ctx context.Context, req
 			return nil, errors.New("repo is required")
 		}
 
-		jobIdStr, ok := request.Params.Arguments["jobId"].([]string)
-		if !ok || len(jobIdStr) == 0 {
+		jobIDStr, ok := request.Params.Arguments["jobId"].([]string)
+		if !ok || len(jobIDStr) == 0 {
 			return nil, errors.New("jobId is required")
 		}
 
-		jobId, err := strconv.ParseInt(jobIdStr[0], 10, 64)
+		jobID, err := strconv.ParseInt(jobIDStr[0], 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid jobId: %w", err)
 		}
@@ -113,7 +113,7 @@ func JobLogsResourceHandler(getClient GetClientFn) func(ctx context.Context, req
 		}
 
 		// Get the JIT URL for job logs
-		url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, owner[0], repo[0], jobId, 1)
+		url, resp, err := client.Actions.GetWorkflowJobLogs(ctx, owner[0], repo[0], jobID, 1)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get job logs URL: %w", err)
 		}

--- a/pkg/github/actions_resource_test.go
+++ b/pkg/github/actions_resource_test.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetJobLogsWithResourceLinks(t *testing.T) {
+	// Test that the tool has the new parameter
+	tool, _ := GetJobLogs(stubGetClientFn(nil), translations.NullTranslationHelper, 1000)
+
+	// Verify tool has the new parameter
+	schema := tool.InputSchema
+	assert.Contains(t, schema.Properties, "return_resource_links")
+
+	// Check that the parameter exists (we can't easily check types in this interface)
+	resourceLinkParam := schema.Properties["return_resource_links"]
+	assert.NotNil(t, resourceLinkParam)
+}
+
+func TestJobLogsResourceCreation(t *testing.T) {
+	// Test that we can create the resource templates without errors
+	jobLogsResource, jobLogsHandler := GetJobLogsResource(stubGetClientFn(nil), translations.NullTranslationHelper)
+	workflowRunLogsResource, workflowRunLogsHandler := GetWorkflowRunLogsResource(stubGetClientFn(nil), translations.NullTranslationHelper)
+
+	// Verify resource templates are created
+	assert.NotNil(t, jobLogsResource)
+	assert.NotNil(t, jobLogsHandler)
+	assert.Equal(t, "actions://{owner}/{repo}/jobs/{jobId}/logs", jobLogsResource.URITemplate.Raw())
+
+	assert.NotNil(t, workflowRunLogsResource)
+	assert.NotNil(t, workflowRunLogsHandler)
+	assert.Equal(t, "actions://{owner}/{repo}/runs/{runId}/logs", workflowRunLogsResource.URITemplate.Raw())
+}

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -471,6 +471,9 @@ func GetFileContents(getClient GetClientFn, getRawClient raw.GetRawClientFn, t t
 			mcp.WithString("sha",
 				mcp.Description("Accepts optional commit SHA. If specified, it will be used instead of ref"),
 			),
+			mcp.WithBoolean("return_resource_links",
+				mcp.Description("Return ResourceLinks instead of file content - useful for large files or when you want to reference the file for later access"),
+			),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			owner, err := RequiredParam[string](request, "owner")
@@ -492,6 +495,15 @@ func GetFileContents(getClient GetClientFn, getRawClient raw.GetRawClientFn, t t
 			sha, err := OptionalParam[string](request, "sha")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
+			}
+			returnResourceLinks, err := OptionalParam[bool](request, "return_resource_links")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			// Handle ResourceLink request
+			if returnResourceLinks {
+				return handleFileContentsResourceLink(owner, repo, path, ref, sha)
 			}
 
 			client, err := getClient(ctx)
@@ -1640,4 +1652,73 @@ func resolveGitReference(ctx context.Context, githubClient *github.Client, owner
 
 	sha = reference.GetObject().GetSHA()
 	return &raw.ContentOpts{Ref: ref, SHA: sha}, nil
+}
+
+// handleFileContentsResourceLink creates a ResourceLink for file content
+func handleFileContentsResourceLink(owner, repo, path, ref, sha string) (*mcp.CallToolResult, error) {
+	// Ensure path starts with / for consistency
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	// Determine the appropriate resource URI based on the parameters provided
+	var resourceURI string
+	var description string
+
+	switch {
+	case sha != "":
+		resourceURI = fmt.Sprintf("repo://%s/%s/sha/%s/contents%s", owner, repo, sha, path)
+		description = fmt.Sprintf("File content for %s at commit %s in %s/%s", path, sha[:8], owner, repo)
+	case ref != "":
+		// Handle different ref types
+		if strings.HasPrefix(ref, "refs/heads/") {
+			branch := strings.TrimPrefix(ref, "refs/heads/")
+			resourceURI = fmt.Sprintf("repo://%s/%s/refs/heads/%s/contents%s", owner, repo, branch, path)
+			description = fmt.Sprintf("File content for %s on branch %s in %s/%s", path, branch, owner, repo)
+		} else if strings.HasPrefix(ref, "refs/tags/") {
+			tag := strings.TrimPrefix(ref, "refs/tags/")
+			resourceURI = fmt.Sprintf("repo://%s/%s/refs/tags/%s/contents%s", owner, repo, tag, path)
+			description = fmt.Sprintf("File content for %s at tag %s in %s/%s", path, tag, owner, repo)
+		} else if strings.HasPrefix(ref, "refs/pull/") && strings.HasSuffix(ref, "/head") {
+			// Extract PR number from refs/pull/{number}/head
+			prNumber := strings.TrimSuffix(strings.TrimPrefix(ref, "refs/pull/"), "/head")
+			resourceURI = fmt.Sprintf("repo://%s/%s/pulls/%s/contents%s", owner, repo, prNumber, path)
+			description = fmt.Sprintf("File content for %s in PR #%s in %s/%s", path, prNumber, owner, repo)
+		} else {
+			// Generic ref handling - try to clean it up
+			cleanRef := strings.TrimPrefix(ref, "refs/")
+			resourceURI = fmt.Sprintf("repo://%s/%s/refs/%s/contents%s", owner, repo, cleanRef, path)
+			description = fmt.Sprintf("File content for %s at ref %s in %s/%s", path, ref, owner, repo)
+		}
+	default:
+		// Default branch/HEAD
+		resourceURI = fmt.Sprintf("repo://%s/%s/contents%s", owner, repo, path)
+		description = fmt.Sprintf("File content for %s in %s/%s", path, owner, repo)
+	}
+
+	resourceLink := mcp.ResourceLink{
+		URI:         resourceURI,
+		Description: description,
+	}
+
+	result := map[string]any{
+		"message":      "File content available via ResourceLink",
+		"path":         path,
+		"resource_uri": resourceLink.URI,
+	}
+
+	r, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{
+				Type: "text",
+				Text: string(r),
+			},
+			resourceLink,
+		},
+	}, nil
 }

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1671,20 +1671,21 @@ func handleFileContentsResourceLink(owner, repo, path, ref, sha string) (*mcp.Ca
 		description = fmt.Sprintf("File content for %s at commit %s in %s/%s", path, sha[:8], owner, repo)
 	case ref != "":
 		// Handle different ref types
-		if strings.HasPrefix(ref, "refs/heads/") {
+		switch {
+		case strings.HasPrefix(ref, "refs/heads/"):
 			branch := strings.TrimPrefix(ref, "refs/heads/")
 			resourceURI = fmt.Sprintf("repo://%s/%s/refs/heads/%s/contents%s", owner, repo, branch, path)
 			description = fmt.Sprintf("File content for %s on branch %s in %s/%s", path, branch, owner, repo)
-		} else if strings.HasPrefix(ref, "refs/tags/") {
+		case strings.HasPrefix(ref, "refs/tags/"):
 			tag := strings.TrimPrefix(ref, "refs/tags/")
 			resourceURI = fmt.Sprintf("repo://%s/%s/refs/tags/%s/contents%s", owner, repo, tag, path)
 			description = fmt.Sprintf("File content for %s at tag %s in %s/%s", path, tag, owner, repo)
-		} else if strings.HasPrefix(ref, "refs/pull/") && strings.HasSuffix(ref, "/head") {
+		case strings.HasPrefix(ref, "refs/pull/") && strings.HasSuffix(ref, "/head"):
 			// Extract PR number from refs/pull/{number}/head
 			prNumber := strings.TrimSuffix(strings.TrimPrefix(ref, "refs/pull/"), "/head")
 			resourceURI = fmt.Sprintf("repo://%s/%s/pulls/%s/contents%s", owner, repo, prNumber, path)
 			description = fmt.Sprintf("File content for %s in PR #%s in %s/%s", path, prNumber, owner, repo)
-		} else {
+		default:
 			// Generic ref handling - try to clean it up
 			cleanRef := strings.TrimPrefix(ref, "refs/")
 			resourceURI = fmt.Sprintf("repo://%s/%s/refs/%s/contents%s", owner, repo, cleanRef, path)

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -158,6 +158,10 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 			toolsets.NewServerTool(RerunFailedJobs(getClient, t)),
 			toolsets.NewServerTool(CancelWorkflowRun(getClient, t)),
 			toolsets.NewServerTool(DeleteWorkflowRunLogs(getClient, t)),
+		).
+		AddResourceTemplates(
+			toolsets.NewServerResourceTemplate(GetWorkflowRunLogsResource(getClient, t)),
+			toolsets.NewServerResourceTemplate(GetJobLogsResource(getClient, t)),
 		)
 
 	securityAdvisories := toolsets.NewToolset("security_advisories", "Security advisories related tools").


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: https://github.com/github/copilot-agent-services/issues/435
