### PR TITLE
[Draft] Add Visual Studio installation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Built for developers who want to connect their AI tools to GitHub context and ca
 ## Remote GitHub MCP Server
 
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=github&config=%7B%22type%22%3A%20%22http%22%2C%22url%22%3A%20%22https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F%22%7D) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=github&config=%7B%22type%22%3A%20%22http%22%2C%22url%22%3A%20%22https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F%22%7D&quality=insiders)
-[![Install in VS](https://img.shields.io/badge/Visual_Studio-Install_Server-68217a?style=flat-square&logo=visualstudio&logoColor=white)](vsweb+mcp:/install?%7B%22name%22%3A%22github%22%2C%22gallery%22%3Atrue%2C%22url%22%3A%22https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F%22%7D)
+[![Install in VS](https://img.shields.io/badge/Visual_Studio-Install_Server-68217a?style=flat-square&logo=visualstudio&logoColor=white)](vsweb+mcp:/install?name=github&config=%7B%22type%22%3A%20%22http%22%2C%22url%22%3A%20%22https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F%22%7D)
 
 The remote GitHub MCP Server is hosted by GitHub and provides the easiest method for getting up and running. If your MCP host does not support remote MCP servers, don't worry! You can use the [local version of the GitHub MCP Server](https://github.com/github/github-mcp-server?tab=readme-ov-file#local-github-mcp-server) instead.
 


### PR DESCRIPTION

Add Visual Studio installation badge to README.md file. This button will allow for direct, one-click installation of the server into Visual Studio. 