### PR TITLE
Fix environment variable mapping for read-only mode

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -95,6 +95,7 @@ func init() {
 func initConfig() {
 	// Initialize Viper configuration
 	viper.SetEnvPrefix("github")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 }


### PR DESCRIPTION
Fix environment variable mapping for read-only mode configuration

Add SetEnvKeyReplacer to viper configuration to properly map environment variables with underscores to flag names with dashes. This enables the documented GITHUB_READ_ONLY=1 environment variable to work correctly.

Without this fix, viper was looking for GITHUB_READ-ONLY (with dash) but the documentation and standard convention use GITHUB_READ_ONLY (with underscore).

Fixes issue where read-only mode was not being activated when using GITHUB_READ_ONLY=1 in Docker containers.

**Incorrect Read-Only Tools when `GITHUB_READ_ONLY=1` passed:**
<img width="736" height="561" alt="Incorrect Read-Only Tools" src="https://github.com/user-attachments/assets/22cd84d6-9ff7-4b82-b1ef-57e9242da303" />

**Test with `GITHUB_READ-ONLY=1` (Dash):**
<img width="736" height="623" alt="Test With Dash" src="https://github.com/user-attachments/assets/29cb36bc-0f38-409d-be3c-b1354ec43974" />

**Correct Result After The Patch:**
<img width="736" height="623" alt="Patched" src="https://github.com/user-attachments/assets/0a972ddf-9357-439b-bfe0-51f31e002329" />


| Requirement | Command | Status |
|-------------|---------|--------|
| ✅ Tests pass | `go test -v ./...` | **PASSED** |
| ✅ Linter passes | `golangci-lint run` | **PASSED** |
| ✅ Project linter | `script/lint` | **PASSED** |
| ✅ Update snapshots | `UPDATE_TOOLSNAPS=true go test ./...` | **COMPLETED** |
| ✅ Update docs | `script/generate-docs` | **COMPLETED** |

<br class="Apple-interchange-newline">

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
