### PR TITLE
docs: Change `trust` for Gemini CLI configuration from true to false

### DIFF
--- a/docs/installation-guides/install-gemini-cli.md
+++ b/docs/installation-guides/install-gemini-cli.md
@@ -40,7 +40,7 @@ The simplest way is to use GitHub's hosted MCP server:
     "mcpServers": {
         "github": {
             "httpUrl": "https://api.githubcopilot.com/mcp/",
-            "trust": true,
+            "trust": false,
             "headers": {
                 "Authorization": "Bearer $GITHUB_PAT"
             }


### PR DESCRIPTION
See https://github.com/google-gemini/gemini-cli/issues/5512.
