### PR TITLE
Add server instructions based on toolsets

### DIFF
--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -105,8 +105,6 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 		},
 	}
 
-	ghServer := github.NewServer(cfg.Version, server.WithHooks(hooks))
-
 	enabledToolsets := cfg.EnabledToolsets
 	if cfg.DynamicToolsets {
 		// filter "all" from the enabled toolsets
@@ -117,6 +115,16 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 			}
 		}
 	}
+
+	// Generate instructions based on enabled toolsets
+	instructions := github.GenerateInstructions(enabledToolsets)
+	var serverOpts []server.ServerOption
+	if instructions != "" {
+		serverOpts = append(serverOpts, server.WithInstructions(instructions))
+	}
+	serverOpts = append(serverOpts, server.WithHooks(hooks))
+
+	ghServer := github.NewServer(cfg.Version, serverOpts...)
 
 	getClient := func(_ context.Context) (*gogithub.Client, error) {
 		return restClient, nil // closing over client

--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -118,13 +118,11 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 
 	// Generate instructions based on enabled toolsets
 	instructions := github.GenerateInstructions(enabledToolsets)
-	var serverOpts []server.ServerOption
-	if instructions != "" {
-		serverOpts = append(serverOpts, server.WithInstructions(instructions))
-	}
-	serverOpts = append(serverOpts, server.WithHooks(hooks))
-
-	ghServer := github.NewServer(cfg.Version, serverOpts...)
+	
+	ghServer := github.NewServer(cfg.Version, 
+		server.WithInstructions(instructions),
+		server.WithHooks(hooks),
+	)
 
 	getClient := func(_ context.Context) (*gogithub.Client, error) {
 		return restClient, nil // closing over client

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -1,0 +1,88 @@
+package github
+
+import "strings"
+
+// GenerateInstructions creates server instructions based on enabled toolsets
+func GenerateInstructions(enabledToolsets []string) string {
+	var instructions []string
+	
+	// Core instruction - always included if context toolset enabled
+	if contains(enabledToolsets, "context") {
+		instructions = append(instructions, "Always call 'get_me' first to understand current user permissions and context.")
+	}
+	
+	// Individual toolset instructions
+	for _, toolset := range enabledToolsets {
+		if inst := getToolsetInstructions(toolset); inst != "" {
+			instructions = append(instructions, inst)
+		}
+	}
+	
+	// Cross-toolset conditional instructions
+	if contains(enabledToolsets, "pull_requests") && contains(enabledToolsets, "context") {
+		instructions = append(instructions, "For team workflows: Use 'get_teams' and 'get_team_members' before assigning PR reviewers.")
+	}
+	
+	if hasAnySecurityToolset(enabledToolsets) {
+		instructions = append(instructions, "Security alert priority: secret_scanning → dependabot → code_scanning alerts.")
+	}
+	
+	if contains(enabledToolsets, "issues") && contains(enabledToolsets, "pull_requests") {
+		instructions = append(instructions, "Link issues to PRs using 'closes #123' or 'fixes #123' in PR descriptions.")
+	}
+	
+	if contains(enabledToolsets, "repos") && contains(enabledToolsets, "actions") {
+		instructions = append(instructions, "For repository operations: Check workflow status before major changes using 'list_workflow_runs'.")
+	}
+	
+	// Only add base instruction if we have specific instructions
+	if len(instructions) > 0 {
+		baseInstruction := "GitHub MCP Server provides GitHub API tools. Common parameters: 'owner' (repo owner), 'repo' (repo name), 'page'/'perPage' (pagination)."
+		instructions = append([]string{baseInstruction}, instructions...)
+	}
+	
+	return strings.Join(instructions, " ")
+}
+
+// getToolsetInstructions returns specific instructions for individual toolsets
+func getToolsetInstructions(toolset string) string {
+	switch toolset {
+	case "pull_requests":
+		return "PR review workflow: Use 'create_pending_pull_request_review' → 'add_comment_to_pending_review' → 'submit_pending_pull_request_review' for complex reviews with line-specific comments."
+	case "actions":
+		return "CI/CD debugging: Use 'get_job_logs' with 'failed_only=true' and 'return_content=true' for immediate log analysis. Use 'rerun_failed_jobs' instead of 'rerun_workflow_run' to save resources."
+	case "issues":
+		return "Issue workflow: Check 'list_issue_types' first for organizations to use proper issue types. Use 'search_issues' before creating new issues to avoid duplicates. Always set 'state_reason' when closing issues."
+	case "repos":
+		return "File operations: Use 'get_file_contents' to check if file exists before 'create_or_update_file'. Always specify 'sha' parameter when updating existing files. Use 'push_files' for multiple file operations in single commit."
+	case "notifications":
+		return "Notifications: Filter by 'participating' for issues/PRs you're involved in. Use 'mark_all_notifications_read' with repository filters to avoid marking unrelated notifications."
+	case "gists":
+		return "Gists: Use 'list_gists' with 'since' parameter to find recent gists. Specify 'public=false' for private gists in 'create_gist'."
+	case "discussions":
+		return "Discussions: Use 'list_discussion_categories' to understand available categories before creating discussions. Filter by category for better organization."
+	default:
+		return ""
+	}
+}
+
+// hasAnySecurityToolset checks if any security-related toolsets are enabled
+func hasAnySecurityToolset(toolsets []string) bool {
+	securityToolsets := []string{"code_security", "secret_protection", "dependabot"}
+	for _, security := range securityToolsets {
+		if contains(toolsets, security) {
+			return true
+		}
+	}
+	return false
+}
+
+// contains checks if a slice contains a specific string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -19,28 +19,14 @@ func GenerateInstructions(enabledToolsets []string) string {
 	}
 	
 	// Cross-toolset conditional instructions
-	if contains(enabledToolsets, "pull_requests") && contains(enabledToolsets, "context") {
-		instructions = append(instructions, "For team workflows: Use 'get_teams' and 'get_team_members' before assigning PR reviewers.")
-	}
-	
-	if hasAnySecurityToolset(enabledToolsets) {
-		instructions = append(instructions, "Security alert priority: secret_scanning → dependabot → code_scanning alerts.")
-	}
-	
 	if contains(enabledToolsets, "issues") && contains(enabledToolsets, "pull_requests") {
 		instructions = append(instructions, "Link issues to PRs using 'closes #123' or 'fixes #123' in PR descriptions.")
 	}
 	
-	if contains(enabledToolsets, "repos") && contains(enabledToolsets, "actions") {
-		instructions = append(instructions, "For repository operations: Check workflow status before major changes using 'list_workflow_runs'.")
-	}
+	// Base instruction with context management
+	baseInstruction := "The GitHub MCP Server provides GitHub API tools. GitHub API responses can overflow context windows. Strategy: 1) Always prefer 'search_*' tools over 'list_*' tools when possible - search tools return filtered results, 2) Process large datasets in batches rather than all at once, 3) For summarization tasks, fetch minimal data first, then drill down into specifics, 4) When analyzing multiple items (issues, PRs, etc), process in groups of 5-10 to manage context."
 	
-	baseInstruction := "The GitHub MCP Server provides GitHub API tools."
-	
-	// Add context management instruction for all configurations
-	contextInstruction := " GitHub API responses can overflow context windows. Strategy: 1) Always prefer 'search_*' tools over 'list_*' tools when possible - search tools return filtered results, 2) Process large datasets in batches rather than all at once, 3) For summarization tasks, fetch minimal data first, then drill down into specifics, 4) When analyzing multiple items (issues, PRs, etc), process in groups of 5-10 to manage context."
-	
-	allInstructions := []string{baseInstruction, contextInstruction}
+	allInstructions := []string{baseInstruction}
 	allInstructions = append(allInstructions, instructions...)
 	
 	return strings.Join(allInstructions, " ")
@@ -68,16 +54,6 @@ func getToolsetInstructions(toolset string) string {
 	}
 }
 
-// hasAnySecurityToolset checks if any security-related toolsets are enabled
-func hasAnySecurityToolset(toolsets []string) bool {
-	securityToolsets := []string{"code_security", "secret_protection", "dependabot"}
-	for _, security := range securityToolsets {
-		if contains(toolsets, security) {
-			return true
-		}
-	}
-	return false
-}
 
 // contains checks if a slice contains a specific string
 func contains(slice []string, item string) bool {

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -1,9 +1,17 @@
 package github
 
-import "strings"
+import (
+	"os"
+	"strings"
+)
 
 // GenerateInstructions creates server instructions based on enabled toolsets
 func GenerateInstructions(enabledToolsets []string) string {
+	// For testing - add a flag to disable instructions
+	if os.Getenv("DISABLE_INSTRUCTIONS") == "true" {
+		return "" // Baseline mode
+	}
+	
 	var instructions []string
 	
 	// Core instruction - always included if context toolset enabled

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -39,7 +39,7 @@ func GenerateInstructions(enabledToolsets []string) string {
 func getToolsetInstructions(toolset string) string {
 	switch toolset {
 	case "pull_requests":
-		return "PR review workflow: Use 'create_pending_pull_request_review' → 'add_comment_to_pending_review' → 'submit_pending_pull_request_review' for complex reviews with line-specific comments."
+		return "PR review workflow: Always use 'create_pending_pull_request_review' → 'add_comment_to_pending_review' → 'submit_pending_pull_request_review' for complex reviews with line-specific comments."
 	case "issues":
 		return "Issue workflow: Check 'list_issue_types' first for organizations to use proper issue types. Use 'search_issues' before creating new issues to avoid duplicates. Always set 'state_reason' when closing issues."
 	case "notifications":

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -35,11 +35,10 @@ func GenerateInstructions(enabledToolsets []string) string {
 		instructions = append(instructions, "For repository operations: Check workflow status before major changes using 'list_workflow_runs'.")
 	}
 	
-	// Always add base instructions - they provide universal value
-	baseInstruction := "GitHub MCP Server provides GitHub API tools. Common parameters: 'owner' (repo owner), 'repo' (repo name), 'page'/'perPage' (pagination)."
+	baseInstruction := "The GitHub MCP Server provides GitHub API tools."
 	
 	// Add context management instruction for all configurations
-	contextInstruction := "GitHub API responses can overflow context windows. Strategy: 1) Always prefer 'search_*' tools over 'list_*' tools when possible - search tools return filtered results, 2) Process large datasets in batches rather than all at once, 3) For summarization tasks, fetch minimal data first, then drill down into specifics, 4) When analyzing multiple items (issues, PRs, etc), process in groups of 5-10 to manage context."
+	contextInstruction := " GitHub API responses can overflow context windows. Strategy: 1) Always prefer 'search_*' tools over 'list_*' tools when possible - search tools return filtered results, 2) Process large datasets in batches rather than all at once, 3) For summarization tasks, fetch minimal data first, then drill down into specifics, 4) When analyzing multiple items (issues, PRs, etc), process in groups of 5-10 to manage context."
 	
 	allInstructions := []string{baseInstruction, contextInstruction}
 	allInstructions = append(allInstructions, instructions...)

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -18,11 +18,6 @@ func GenerateInstructions(enabledToolsets []string) string {
 		}
 	}
 	
-	// Cross-toolset conditional instructions
-	if contains(enabledToolsets, "issues") && contains(enabledToolsets, "pull_requests") {
-		instructions = append(instructions, "Link issues to PRs using 'closes #123' or 'fixes #123' in PR descriptions.")
-	}
-	
 	// Base instruction with context management
 	baseInstruction := "The GitHub MCP Server provides GitHub API tools. GitHub API responses can overflow context windows. Strategy: 1) Always prefer 'search_*' tools over 'list_*' tools when possible - search tools return filtered results, 2) Process large datasets in batches rather than all at once, 3) For summarization tasks, fetch minimal data first, then drill down into specifics, 4) When analyzing multiple items (issues, PRs, etc), process in groups of 5-10 to manage context."
 	
@@ -37,23 +32,16 @@ func getToolsetInstructions(toolset string) string {
 	switch toolset {
 	case "pull_requests":
 		return "PR review workflow: Use 'create_pending_pull_request_review' → 'add_comment_to_pending_review' → 'submit_pending_pull_request_review' for complex reviews with line-specific comments."
-	case "actions":
-		return "CI/CD debugging: Use 'get_job_logs' with 'failed_only=true' and 'return_content=true' for immediate log analysis. Use 'rerun_failed_jobs' instead of 'rerun_workflow_run' to save resources."
 	case "issues":
 		return "Issue workflow: Check 'list_issue_types' first for organizations to use proper issue types. Use 'search_issues' before creating new issues to avoid duplicates. Always set 'state_reason' when closing issues."
-	case "repos":
-		return "File operations: Use 'get_file_contents' to check if file exists before 'create_or_update_file'. Always specify 'sha' parameter when updating existing files. Use 'push_files' for multiple file operations in single commit."
 	case "notifications":
 		return "Notifications: Filter by 'participating' for issues/PRs you're involved in. Use 'mark_all_notifications_read' with repository filters to avoid marking unrelated notifications."
-	case "gists":
-		return "Gists: Use 'list_gists' with 'since' parameter to find recent gists. Specify 'public=false' for private gists in 'create_gist'."
 	case "discussions":
 		return "Discussions: Use 'list_discussion_categories' to understand available categories before creating discussions. Filter by category for better organization."
 	default:
 		return ""
 	}
 }
-
 
 // contains checks if a slice contains a specific string
 func contains(slice []string, item string) bool {

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -35,13 +35,16 @@ func GenerateInstructions(enabledToolsets []string) string {
 		instructions = append(instructions, "For repository operations: Check workflow status before major changes using 'list_workflow_runs'.")
 	}
 	
-	// Only add base instruction if we have specific instructions
-	if len(instructions) > 0 {
-		baseInstruction := "GitHub MCP Server provides GitHub API tools. Common parameters: 'owner' (repo owner), 'repo' (repo name), 'page'/'perPage' (pagination)."
-		instructions = append([]string{baseInstruction}, instructions...)
-	}
+	// Always add base instructions - they provide universal value
+	baseInstruction := "GitHub MCP Server provides GitHub API tools. Common parameters: 'owner' (repo owner), 'repo' (repo name), 'page'/'perPage' (pagination)."
 	
-	return strings.Join(instructions, " ")
+	// Add context management instruction for all configurations
+	contextInstruction := "GitHub API responses can overflow context windows. Strategy: 1) Always prefer 'search_*' tools over 'list_*' tools when possible - search tools return filtered results, 2) Process large datasets in batches rather than all at once, 3) For summarization tasks, fetch minimal data first, then drill down into specifics, 4) When analyzing multiple items (issues, PRs, etc), process in groups of 5-10 to manage context."
+	
+	allInstructions := []string{baseInstruction, contextInstruction}
+	allInstructions = append(allInstructions, instructions...)
+	
+	return strings.Join(allInstructions, " ")
 }
 
 // getToolsetInstructions returns specific instructions for individual toolsets

--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -19,7 +19,7 @@ func GenerateInstructions(enabledToolsets []string) string {
 	}
 	
 	// Base instruction with context management
-	baseInstruction := "The GitHub MCP Server provides GitHub API tools. GitHub API responses can overflow context windows. Strategy: 1) Always prefer 'search_*' tools over 'list_*' tools when possible - search tools return filtered results, 2) Process large datasets in batches rather than all at once, 3) For summarization tasks, fetch minimal data first, then drill down into specifics, 4) When analyzing multiple items (issues, PRs, etc), process in groups of 5-10 to manage context."
+	baseInstruction := "The GitHub MCP Server provides GitHub API tools. Tool selection guidance: Use 'list_*' tools for broad, simple retrieval and pagination of all items of a type (e.g., all issues, all PRs, all branches) with basic filtering. Use 'search_*' tools for targeted queries with specific criteria, keywords, or complex filters (e.g., issues with certain text, PRs by author, code containing functions). Context management: 1) GitHub API responses can overflow context windows, 2) Process large datasets in batches of 5-10 items, 3) For summarization tasks, fetch minimal data first, then drill down into specifics."
 	
 	allInstructions := []string{baseInstruction}
 	allInstructions = append(allInstructions, instructions...)

--- a/pkg/github/instructions_test.go
+++ b/pkg/github/instructions_test.go
@@ -17,7 +17,8 @@ func TestGenerateInstructions(t *testing.T) {
 			enabledToolsets: []string{},
 			expectedContains: []string{
 				"GitHub MCP Server provides GitHub API tools",
-				"prefer 'search_*' tools over 'list_*' tools",
+				"Use 'list_*' tools for broad, simple retrieval",
+				"Use 'search_*' tools for targeted queries",
 				"context windows",
 			},
 		},

--- a/pkg/github/instructions_test.go
+++ b/pkg/github/instructions_test.go
@@ -39,7 +39,33 @@ func TestGenerateInstructions(t *testing.T) {
 			},
 		},
 		{
-			name:            "cross-toolset instructions",
+			name:            "issues toolset",
+			enabledToolsets: []string{"issues"},
+			expectedContains: []string{
+				"search_issues",
+				"list_issue_types",
+				"state_reason",
+			},
+		},
+		{
+			name:            "notifications toolset",
+			enabledToolsets: []string{"notifications"},
+			expectedContains: []string{
+				"participating",
+				"mark_all_notifications_read",
+				"repository filters",
+			},
+		},
+		{
+			name:            "discussions toolset",
+			enabledToolsets: []string{"discussions"},
+			expectedContains: []string{
+				"list_discussion_categories",
+				"Filter by category",
+			},
+		},
+		{
+			name:            "multiple toolsets (context + pull_requests)",
 			enabledToolsets: []string{"context", "pull_requests"},
 			expectedContains: []string{
 				"get_me",
@@ -47,7 +73,7 @@ func TestGenerateInstructions(t *testing.T) {
 			},
 		},
 		{
-			name:            "issues and pull_requests combination",
+			name:            "multiple toolsets (issues + pull_requests)",
 			enabledToolsets: []string{"issues", "pull_requests"},
 			expectedContains: []string{
 				"search_issues",
@@ -89,6 +115,14 @@ func TestGetToolsetInstructions(t *testing.T) {
 		{
 			toolset:  "issues",
 			expected: "list_issue_types",
+		},
+		{
+			toolset:  "notifications",
+			expected: "participating",
+		},
+		{
+			toolset:  "discussions",
+			expected: "list_discussion_categories",
 		},
 		{
 			toolset:  "nonexistent",

--- a/pkg/github/instructions_test.go
+++ b/pkg/github/instructions_test.go
@@ -1,0 +1,181 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateInstructions(t *testing.T) {
+	tests := []struct {
+		name             string
+		enabledToolsets  []string
+		expectedContains []string
+		expectedEmpty    bool
+	}{
+		{
+			name:            "empty toolsets",
+			enabledToolsets: []string{},
+			expectedEmpty:   true,
+		},
+		{
+			name:            "only context toolset",
+			enabledToolsets: []string{"context"},
+			expectedContains: []string{
+				"GitHub MCP Server provides GitHub API tools",
+				"Always call 'get_me' first",
+			},
+		},
+		{
+			name:            "pull requests toolset",
+			enabledToolsets: []string{"pull_requests"},
+			expectedContains: []string{
+				"create_pending_pull_request_review",
+				"add_comment_to_pending_review",
+				"submit_pending_pull_request_review",
+			},
+		},
+		{
+			name:            "actions toolset",
+			enabledToolsets: []string{"actions"},
+			expectedContains: []string{
+				"get_job_logs",
+				"failed_only=true",
+				"rerun_failed_jobs",
+			},
+		},
+		{
+			name:            "security toolsets",
+			enabledToolsets: []string{"code_security", "secret_protection", "dependabot"},
+			expectedContains: []string{
+				"Security alert priority",
+				"secret_scanning",
+				"dependabot",
+				"code_scanning",
+			},
+		},
+		{
+			name:            "cross-toolset instructions",
+			enabledToolsets: []string{"context", "pull_requests"},
+			expectedContains: []string{
+				"get_me",
+				"get_teams",
+				"get_team_members",
+			},
+		},
+		{
+			name:            "issues and pull_requests combination",
+			enabledToolsets: []string{"issues", "pull_requests"},
+			expectedContains: []string{
+				"closes #123",
+				"fixes #123",
+				"search_issues",
+				"list_issue_types",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenerateInstructions(tt.enabledToolsets)
+
+			if tt.expectedEmpty {
+				if result != "" {
+					t.Errorf("Expected empty instructions but got: %s", result)
+				}
+				return
+			}
+
+			for _, expectedContent := range tt.expectedContains {
+				if !strings.Contains(result, expectedContent) {
+					t.Errorf("Expected instructions to contain '%s', but got: %s", expectedContent, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGetToolsetInstructions(t *testing.T) {
+	tests := []struct {
+		toolset  string
+		expected string
+	}{
+		{
+			toolset:  "pull_requests",
+			expected: "create_pending_pull_request_review",
+		},
+		{
+			toolset:  "actions",
+			expected: "get_job_logs",
+		},
+		{
+			toolset:  "issues",
+			expected: "list_issue_types",
+		},
+		{
+			toolset:  "repos",
+			expected: "get_file_contents",
+		},
+		{
+			toolset:  "nonexistent",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.toolset, func(t *testing.T) {
+			result := getToolsetInstructions(tt.toolset)
+			if tt.expected == "" {
+				if result != "" {
+					t.Errorf("Expected empty result for toolset '%s', but got: %s", tt.toolset, result)
+				}
+			} else {
+				if !strings.Contains(result, tt.expected) {
+					t.Errorf("Expected instructions for '%s' to contain '%s', but got: %s", tt.toolset, tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestHasAnySecurityToolset(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolsets []string
+		expected bool
+	}{
+		{
+			name:     "no security toolsets",
+			toolsets: []string{"repos", "issues"},
+			expected: false,
+		},
+		{
+			name:     "has code_security",
+			toolsets: []string{"repos", "code_security"},
+			expected: true,
+		},
+		{
+			name:     "has secret_protection",
+			toolsets: []string{"secret_protection", "issues"},
+			expected: true,
+		},
+		{
+			name:     "has dependabot",
+			toolsets: []string{"dependabot"},
+			expected: true,
+		},
+		{
+			name:     "has all security toolsets",
+			toolsets: []string{"code_security", "secret_protection", "dependabot"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasAnySecurityToolset(tt.toolsets)
+			if result != tt.expected {
+				t.Errorf("Expected %v for toolsets %v, but got %v", tt.expected, tt.toolsets, result)
+			}
+		})
+	}
+}

--- a/pkg/github/instructions_test.go
+++ b/pkg/github/instructions_test.go
@@ -39,15 +39,6 @@ func TestGenerateInstructions(t *testing.T) {
 			},
 		},
 		{
-			name:            "actions toolset",
-			enabledToolsets: []string{"actions"},
-			expectedContains: []string{
-				"get_job_logs",
-				"failed_only=true",
-				"rerun_failed_jobs",
-			},
-		},
-		{
 			name:            "cross-toolset instructions",
 			enabledToolsets: []string{"context", "pull_requests"},
 			expectedContains: []string{
@@ -59,10 +50,9 @@ func TestGenerateInstructions(t *testing.T) {
 			name:            "issues and pull_requests combination",
 			enabledToolsets: []string{"issues", "pull_requests"},
 			expectedContains: []string{
-				"closes #123",
-				"fixes #123",
 				"search_issues",
 				"list_issue_types",
+				"create_pending_pull_request_review",
 			},
 		},
 	}
@@ -97,16 +87,8 @@ func TestGetToolsetInstructions(t *testing.T) {
 			expected: "create_pending_pull_request_review",
 		},
 		{
-			toolset:  "actions",
-			expected: "get_job_logs",
-		},
-		{
 			toolset:  "issues",
 			expected: "list_issue_types",
-		},
-		{
-			toolset:  "repos",
-			expected: "get_file_contents",
 		},
 		{
 			toolset:  "nonexistent",
@@ -129,4 +111,3 @@ func TestGetToolsetInstructions(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/github/instructions_test.go
+++ b/pkg/github/instructions_test.go
@@ -15,7 +15,11 @@ func TestGenerateInstructions(t *testing.T) {
 		{
 			name:            "empty toolsets",
 			enabledToolsets: []string{},
-			expectedEmpty:   true,
+			expectedContains: []string{
+				"GitHub MCP Server provides GitHub API tools",
+				"prefer 'search_*' tools over 'list_*' tools",
+				"context windows",
+			},
 		},
 		{
 			name:            "only context toolset",

--- a/pkg/github/instructions_test.go
+++ b/pkg/github/instructions_test.go
@@ -48,22 +48,11 @@ func TestGenerateInstructions(t *testing.T) {
 			},
 		},
 		{
-			name:            "security toolsets",
-			enabledToolsets: []string{"code_security", "secret_protection", "dependabot"},
-			expectedContains: []string{
-				"Security alert priority",
-				"secret_scanning",
-				"dependabot",
-				"code_scanning",
-			},
-		},
-		{
 			name:            "cross-toolset instructions",
 			enabledToolsets: []string{"context", "pull_requests"},
 			expectedContains: []string{
 				"get_me",
-				"get_teams",
-				"get_team_members",
+				"create_pending_pull_request_review",
 			},
 		},
 		{
@@ -141,45 +130,3 @@ func TestGetToolsetInstructions(t *testing.T) {
 	}
 }
 
-func TestHasAnySecurityToolset(t *testing.T) {
-	tests := []struct {
-		name     string
-		toolsets []string
-		expected bool
-	}{
-		{
-			name:     "no security toolsets",
-			toolsets: []string{"repos", "issues"},
-			expected: false,
-		},
-		{
-			name:     "has code_security",
-			toolsets: []string{"repos", "code_security"},
-			expected: true,
-		},
-		{
-			name:     "has secret_protection",
-			toolsets: []string{"secret_protection", "issues"},
-			expected: true,
-		},
-		{
-			name:     "has dependabot",
-			toolsets: []string{"dependabot"},
-			expected: true,
-		},
-		{
-			name:     "has all security toolsets",
-			toolsets: []string{"code_security", "secret_protection", "dependabot"},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasAnySecurityToolset(tt.toolsets)
-			if result != tt.expected {
-				t.Errorf("Expected %v for toolsets %v, but got %v", tt.expected, tt.toolsets, result)
-			}
-		})
-	}
-}


### PR DESCRIPTION
Hi, I am working on a post for the official MCP blog that focuses on server instructions (since clients have recently started to support this feature).

So far, I did some simple controlled evaluations using these changes locally, which you can find more details on here: https://github.com/olaservo/mcp-server-instructions-demo

Here is the PR for my blog post: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1334/files

I haven't methodically tested all of these yet, but can do a similar evaluation and expand my tests to more models and clients, if we think this approach is promising.

Thanks!