### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,7 @@ When using Docker, you can pass the read-only mode as an environment variable:
 ```bash
 docker run -i --rm \
   -e GITHUB_PERSONAL_ACCESS_TOKEN=<your-token> \
-  -e GITHUB_READ_ONLY=1 \
+  -e GITHUB_READ-ONLY=1 \
   ghcr.io/github/github-mcp-server
 ```
 


### PR DESCRIPTION
The viper binding at https://github.com/github/github-mcp-server/blob/2a0c7bff82ea8d8f1d4999b3f222c8e8c13b05cc/cmd/github-mcp-server/main.go#L84 means the environment flag is GITHUB_READ-ONLY not GITHUB_READ_ONLY. To be backward compatible I think we need to honor the flag as it works. So probably best to just fix the docs here.
