### PR TITLE
docs: Update optional headers and path params for remote server

### DIFF
--- a/docs/remote-server.md
+++ b/docs/remote-server.md
@@ -45,10 +45,43 @@ These toolsets are only available in the remote GitHub MCP Server and are not in
 | -------------------- | --------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Copilot coding agent | Perform task with GitHub Copilot coding agent | https://api.githubcopilot.com/mcp/x/copilot | [Install](https://insiders.vscode.dev/redirect/mcp/install?name=gh-copilot&config=%7B%22type%22%3A%20%22http%22%2C%22url%22%3A%20%22https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2Fx%2Fcopilot%22%7D) | [read-only](https://api.githubcopilot.com/mcp/x/copilot/readonly) | [Install read-only](https://insiders.vscode.dev/redirect/mcp/install?name=gh-copilot&config=%7B%22type%22%3A%20%22http%22%2C%22url%22%3A%20%22https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2Fx%2Fcopilot%2Freadonly%22%7D) |
 
-### Headers
+### Optional Headers
 
-You can configure toolsets and readonly mode by providing HTTP headers in your server configuration.
+The Remote GitHub MCP server has optional headers equivalent to the Local server env vars:
 
-The headers are:
-- `X-MCP-Toolsets=<toolset>,<toolset>...`
-- `X-MCP-Readonly=true`
+- `X-MCP-Toolsets`: Comma-separated list of toolsets to enable. E.g. "repos,issue".
+    - Equivalent to `GITHUB_TOOLSETS` env var for Local server.
+    - If the list is empty, default toolsets will be used. If a bad toolset is provided, the server will fail to start and emit a 400 bad request status. Whitespace is ignored.
+- `X-MCP-Readonly`: Enables only "read" tools.
+    - Equivalent to `GITHUB_READ_ONLY` env var for Local server.
+    - If this header is empty, "false", "f", "no", "n", "0", or "off" (ignoring whitespace and case), it will be interpreted as false. All other values are interpreted as true.
+
+Example:
+
+```json
+{
+    "type": "https",
+    "url": "https://api.githubcopilot.com/mcp/",
+    "headers": {
+        "X-MCP-Toolsets": "issues",
+        "X-MCP-Readonly": "true"
+    }
+}
+```
+
+### URL Path Parameters
+
+The Remote GitHub MCP server also supports the URL path parameters:
+
+- `/x/{toolset}`
+- `/x/{toolset}/readonly`
+- `/readonly`
+
+Example:
+
+```json
+{
+    "type": "https",
+    "url": "https://api.githubcopilot.com/mcp/x/issues/readonly"
+}
+```


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes: https://github.com/github/github-mcp-server/issues/1108

Adds description of optional headers and URL path params that can be used to restrict the Remote GitHub MCP server's toolsets and read-only mode.
