### PR TITLE
Add tools for Projects V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,8 +664,6 @@ The following sets of tools are available (all are on by default):
   - `project_number`: The project's number (number, required)
 
 - **list_projects** - List projects
-  - `after`: Cursor for items after (forward pagination) (string, optional)
-  - `before`: Cursor for items before (backwards pagination) (string, optional)
   - `owner`: If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive. (string, required)
   - `owner_type`: Owner type (string, required)
   - `per_page`: Number of results per page (max 100, default: 30) (number, optional)

--- a/README.md
+++ b/README.md
@@ -659,12 +659,18 @@ The following sets of tools are available (all are on by default):
 <summary>Projects</summary>
 
 - **get_project** - Get project
-  - `owner`: If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive. (string, required)
+  - `owner`: If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive. (string, required)
   - `owner_type`: Owner type (string, required)
   - `project_number`: The project's number (number, required)
 
+- **list_project_fields** - List project fields
+  - `owner`: If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive. (string, required)
+  - `owner_type`: Owner type (string, required)
+  - `per_page`: Number of results per page (max 100, default: 30) (number, optional)
+  - `projectNumber`: The project's number. (string, required)
+
 - **list_projects** - List projects
-  - `owner`: If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive. (string, required)
+  - `owner`: If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive. (string, required)
   - `owner_type`: Owner type (string, required)
   - `per_page`: Number of results per page (max 100, default: 30) (number, optional)
   - `query`: Filter projects by a search query (matches title and description) (string, optional)

--- a/README.md
+++ b/README.md
@@ -658,6 +658,11 @@ The following sets of tools are available (all are on by default):
 
 <summary>Projects</summary>
 
+- **get_project** - Get project
+  - `owner`: If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive. (string, required)
+  - `owner_type`: Owner type (string, required)
+  - `project_number`: The project's number (number, required)
+
 - **list_projects** - List projects
   - `after`: Cursor for items after (forward pagination) (string, optional)
   - `before`: Cursor for items before (backwards pagination) (string, optional)

--- a/pkg/github/__toolsnaps__/get_project.snap
+++ b/pkg/github/__toolsnaps__/get_project.snap
@@ -3,7 +3,7 @@
     "title": "Get project",
     "readOnlyHint": true
   },
-  "description": "Get Project for an user or org",
+  "description": "Get Project for a user or org",
   "inputSchema": {
     "properties": {
       "owner": {

--- a/pkg/github/__toolsnaps__/get_project.snap
+++ b/pkg/github/__toolsnaps__/get_project.snap
@@ -1,0 +1,34 @@
+{
+  "annotations": {
+    "title": "Get project",
+    "readOnlyHint": true
+  },
+  "description": "Get Project for a user or organization",
+  "inputSchema": {
+    "properties": {
+      "owner": {
+        "description": "If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive.",
+        "type": "string"
+      },
+      "owner_type": {
+        "description": "Owner type",
+        "enum": [
+          "user",
+          "organization"
+        ],
+        "type": "string"
+      },
+      "project_number": {
+        "description": "The project's number",
+        "type": "number"
+      }
+    },
+    "required": [
+      "project_number",
+      "owner_type",
+      "owner"
+    ],
+    "type": "object"
+  },
+  "name": "get_project"
+}

--- a/pkg/github/__toolsnaps__/get_project.snap
+++ b/pkg/github/__toolsnaps__/get_project.snap
@@ -3,7 +3,7 @@
     "title": "Get project",
     "readOnlyHint": true
   },
-  "description": "Get Project for a user or organization",
+  "description": "Get Project for an user or organization",
   "inputSchema": {
     "properties": {
       "owner": {

--- a/pkg/github/__toolsnaps__/get_project.snap
+++ b/pkg/github/__toolsnaps__/get_project.snap
@@ -3,18 +3,18 @@
     "title": "Get project",
     "readOnlyHint": true
   },
-  "description": "Get Project for an user or organization",
+  "description": "Get Project for an user or org",
   "inputSchema": {
     "properties": {
       "owner": {
-        "description": "If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive.",
+        "description": "If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.",
         "type": "string"
       },
       "owner_type": {
         "description": "Owner type",
         "enum": [
           "user",
-          "organization"
+          "org"
         ],
         "type": "string"
       },

--- a/pkg/github/__toolsnaps__/list_project_fields.snap
+++ b/pkg/github/__toolsnaps__/list_project_fields.snap
@@ -3,7 +3,7 @@
     "title": "List project fields",
     "readOnlyHint": true
   },
-  "description": "List Project fields for an user or org",
+  "description": "List Project fields for a user or org",
   "inputSchema": {
     "properties": {
       "owner": {

--- a/pkg/github/__toolsnaps__/list_project_fields.snap
+++ b/pkg/github/__toolsnaps__/list_project_fields.snap
@@ -1,9 +1,9 @@
 {
   "annotations": {
-    "title": "List projects",
+    "title": "List project fields",
     "readOnlyHint": true
   },
-  "description": "List Projects for an user or org",
+  "description": "List Project fields for an user or org",
   "inputSchema": {
     "properties": {
       "owner": {
@@ -22,16 +22,17 @@
         "description": "Number of results per page (max 100, default: 30)",
         "type": "number"
       },
-      "query": {
-        "description": "Filter projects by a search query (matches title and description)",
+      "projectNumber": {
+        "description": "The project's number.",
         "type": "string"
       }
     },
     "required": [
       "owner_type",
-      "owner"
+      "owner",
+      "projectNumber"
     ],
     "type": "object"
   },
-  "name": "list_projects"
+  "name": "list_project_fields"
 }

--- a/pkg/github/__toolsnaps__/list_projects.snap
+++ b/pkg/github/__toolsnaps__/list_projects.snap
@@ -3,7 +3,7 @@
     "title": "List projects",
     "readOnlyHint": true
   },
-  "description": "List Projects for an user or org",
+  "description": "List Projects for a user or org",
   "inputSchema": {
     "properties": {
       "owner": {

--- a/pkg/github/__toolsnaps__/list_projects.snap
+++ b/pkg/github/__toolsnaps__/list_projects.snap
@@ -6,14 +6,6 @@
   "description": "List Projects for a user or organization",
   "inputSchema": {
     "properties": {
-      "after": {
-        "description": "Cursor for items after (forward pagination)",
-        "type": "string"
-      },
-      "before": {
-        "description": "Cursor for items before (backwards pagination)",
-        "type": "string"
-      },
       "owner": {
         "description": "If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive.",
         "type": "string"

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -19,7 +19,7 @@ import (
 
 func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_projects",
-			mcp.WithDescription(t("TOOL_LIST_PROJECTS_DESCRIPTION", "List Projects for an user or org")),
+			mcp.WithDescription(t("TOOL_LIST_PROJECTS_DESCRIPTION", "List Projects for a user or org")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{Title: t("TOOL_LIST_PROJECTS_USER_TITLE", "List projects"), ReadOnlyHint: ToBoolPtr(true)}),
 			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "org")),
 			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.")),
@@ -101,7 +101,7 @@ func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (
 
 func GetProject(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_project",
-			mcp.WithDescription(t("TOOL_GET_PROJECT_DESCRIPTION", "Get Project for an user or org")),
+			mcp.WithDescription(t("TOOL_GET_PROJECT_DESCRIPTION", "Get Project for a user or org")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{Title: t("TOOL_GET_PROJECT_USER_TITLE", "Get project"), ReadOnlyHint: ToBoolPtr(true)}),
 			mcp.WithNumber("project_number", mcp.Required(), mcp.Description("The project's number")),
 			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "org")),
@@ -170,7 +170,7 @@ func GetProject(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 
 func ListProjectFields(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_project_fields",
-			mcp.WithDescription(t("TOOL_LIST_PROJECT_FIELDS_DESCRIPTION", "List Project fields for an user or org")),
+			mcp.WithDescription(t("TOOL_LIST_PROJECT_FIELDS_DESCRIPTION", "List Project fields for a user or org")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{Title: t("TOOL_LIST_PROJECT_FIELDS_USER_TITLE", "List project fields"), ReadOnlyHint: ToBoolPtr(true)}),
 			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "org")),
 			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.")),

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -24,8 +24,6 @@ func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (
 			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "organization")),
 			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive.")),
 			mcp.WithString("query", mcp.Description("Filter projects by a search query (matches title and description)")),
-			mcp.WithString("before", mcp.Description("Cursor for items before (backwards pagination)")),
-			mcp.WithString("after", mcp.Description("Cursor for items after (forward pagination)")),
 			mcp.WithNumber("per_page", mcp.Description("Number of results per page (max 100, default: 30)")),
 		), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			owner, err := RequiredParam[string](req, "owner")
@@ -37,15 +35,6 @@ func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			queryStr, err := OptionalParam[string](req, "query")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			beforeCursor, err := OptionalParam[string](req, "before")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-			afterCursor, err := OptionalParam[string](req, "after")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -68,12 +57,7 @@ func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (
 			projects := []github.ProjectV2{}
 
 			opts := ListProjectsOptions{PerPage: perPage}
-			if afterCursor != "" {
-				opts.After = afterCursor
-			}
-			if beforeCursor != "" {
-				opts.Before = beforeCursor
-			}
+
 			if queryStr != "" {
 				opts.Query = queryStr
 			}
@@ -183,12 +167,6 @@ func GetProject(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 }
 
 type ListProjectsOptions struct {
-	// A cursor, as given in the Link header. If specified, the query only searches for events before this cursor.
-	Before string `url:"before,omitempty"`
-
-	// A cursor, as given in the Link header. If specified, the query only searches for events after this cursor.
-	After string `url:"after,omitempty"`
-
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty"`
 

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -19,10 +19,10 @@ import (
 
 func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_projects",
-			mcp.WithDescription(t("TOOL_LIST_PROJECTS_DESCRIPTION", "List Projects for a user or organization")),
+			mcp.WithDescription(t("TOOL_LIST_PROJECTS_DESCRIPTION", "List Projects for an user or org")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{Title: t("TOOL_LIST_PROJECTS_USER_TITLE", "List projects"), ReadOnlyHint: ToBoolPtr(true)}),
-			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "organization")),
-			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive.")),
+			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "org")),
+			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.")),
 			mcp.WithString("query", mcp.Description("Filter projects by a search query (matches title and description)")),
 			mcp.WithNumber("per_page", mcp.Description("Number of results per page (max 100, default: 30)")),
 		), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -48,7 +48,7 @@ func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (
 			}
 
 			var url string
-			if ownerType == "organization" {
+			if ownerType == "org" {
 				url = fmt.Sprintf("orgs/%s/projectsV2", owner)
 			} else {
 				url = fmt.Sprintf("users/%s/projectsV2", owner)
@@ -101,11 +101,11 @@ func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (
 
 func GetProject(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_project",
-			mcp.WithDescription(t("TOOL_GET_PROJECT_DESCRIPTION", "Get Project for an user or organization")),
+			mcp.WithDescription(t("TOOL_GET_PROJECT_DESCRIPTION", "Get Project for an user or org")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{Title: t("TOOL_GET_PROJECT_USER_TITLE", "Get project"), ReadOnlyHint: ToBoolPtr(true)}),
 			mcp.WithNumber("project_number", mcp.Required(), mcp.Description("The project's number")),
-			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "organization")),
-			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == organization it is the name of the organization. The name is not case sensitive.")),
+			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "org")),
+			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.")),
 		), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 
 			projectNumber, err := RequiredInt(req, "project_number")
@@ -129,7 +129,7 @@ func GetProject(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 			}
 
 			var url string
-			if ownerType == "organization" {
+			if ownerType == "org" {
 				url = fmt.Sprintf("orgs/%s/projectsV2/%d", owner, projectNumber)
 			} else {
 				url = fmt.Sprintf("users/%s/projectsV2/%d", owner, projectNumber)
@@ -166,6 +166,96 @@ func GetProject(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 
 			return mcp.NewToolResultText(string(r)), nil
 		}
+}
+
+func ListProjectFields(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("list_project_fields",
+			mcp.WithDescription(t("TOOL_LIST_PROJECT_FIELDS_DESCRIPTION", "List Project fields for an user or org")),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{Title: t("TOOL_LIST_PROJECT_FIELDS_USER_TITLE", "List project fields"), ReadOnlyHint: ToBoolPtr(true)}),
+			mcp.WithString("owner_type", mcp.Required(), mcp.Description("Owner type"), mcp.Enum("user", "org")),
+			mcp.WithString("owner", mcp.Required(), mcp.Description("If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.")),
+			mcp.WithString("projectNumber", mcp.Required(), mcp.Description("The project's number.")),
+			mcp.WithNumber("per_page", mcp.Description("Number of results per page (max 100, default: 30)")),
+		), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			owner, err := RequiredParam[string](req, "owner")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			ownerType, err := RequiredParam[string](req, "owner_type")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			projectNumber, err := RequiredParam[string](req, "projectNumber")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			perPage, err := OptionalIntParamWithDefault(req, "per_page", 30)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			client, err := getClient(ctx)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			var url string
+			if ownerType == "org" {
+				url = fmt.Sprintf("orgs/%s/projectsV2/%s/fields", owner, projectNumber)
+			} else {
+				url = fmt.Sprintf("users/%s/projectsV2/%s/fields", owner, projectNumber)
+			}
+			projectFields := []projectV2Field{}
+
+			opts := listProjectsOptions{PerPage: perPage}
+
+			if perPage > 0 {
+				opts.PerPage = perPage
+			}
+			url, err = addOptions(url, opts)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add options to request: %w", err)
+			}
+
+			httpRequest, err := client.NewRequest("GET", url, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create request: %w", err)
+			}
+
+			resp, err := client.Do(ctx, httpRequest, &projectFields)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to list projects",
+					resp,
+					err,
+				), nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return mcp.NewToolResultError(fmt.Sprintf("failed to list projects: %s", string(body))), nil
+			}
+			r, err := json.Marshal(projectFields)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}
+
+type projectV2Field struct {
+	ID        *int64            `json:"id,omitempty"`         // The unique identifier for this field.
+	NodeID    string            `json:"node_id,omitempty"`    // The GraphQL node ID for this field.
+	Name      string            `json:"name,omitempty"`       // The display name of the field.
+	DataType  string            `json:"dataType,omitempty"`   // The data type of the field (e.g., "text", "number", "date", "single_select", "multi_select").
+	URL       string            `json:"url,omitempty"`        // The API URL for this field.
+	Options   []*any            `json:"options,omitempty"`    // Available options for single_select and multi_select fields.
+	CreatedAt *github.Timestamp `json:"created_at,omitempty"` // The time when this field was created.
+	UpdatedAt *github.Timestamp `json:"updated_at,omitempty"` // The time when this field was last updated.
 }
 
 type listProjectsOptions struct {

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -50,9 +50,9 @@ func ListProjects(getClient GetClientFn, t translations.TranslationHelperFunc) (
 
 			var url string
 			if ownerType == "organization" {
-				url = fmt.Sprintf("/orgs/%s/projectsV2", owner)
+				url = fmt.Sprintf("orgs/%s/projectsV2", owner)
 			} else {
-				url = fmt.Sprintf("/users/%s/projectsV2", owner)
+				url = fmt.Sprintf("users/%s/projectsV2", owner)
 			}
 			projects := []github.ProjectV2{}
 
@@ -130,7 +130,7 @@ func GetProject(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 			if ownerType == "organization" {
 				url = fmt.Sprintf("orgs/%s/projectsV2/%d", owner, projectNumber)
 			} else {
-				url = fmt.Sprintf("/users/%s/projectsV2/%d", owner, projectNumber)
+				url = fmt.Sprintf("users/%s/projectsV2/%d", owner, projectNumber)
 			}
 
 			projects := []github.ProjectV2{}

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -75,7 +75,6 @@ func Test_ListProjects(t *testing.T) {
 					mock.EndpointPattern{Pattern: "/orgs/{org}/projectsV2", Method: http.MethodGet},
 					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						q := r.URL.Query()
-						// Assert query params present
 						if q.Get("per_page") == "50" && q.Get("q") == "roadmap" {
 							w.WriteHeader(http.StatusOK)
 							_, _ = w.Write(mock.MustMarshal(orgProjects))
@@ -142,7 +141,6 @@ func Test_ListProjects(t *testing.T) {
 				if tc.expectedErrMsg != "" {
 					assert.Contains(t, text, tc.expectedErrMsg)
 				}
-				// Parameter missing cases
 				if tc.name == "missing owner" {
 					assert.Contains(t, text, "missing required parameter: owner")
 				}
@@ -227,7 +225,7 @@ func Test_GetProject(t *testing.T) {
 				"owner_type":     "org",
 			},
 			expectError:    true,
-			expectedErrMsg: "failed to get project", // updated to match implementation
+			expectedErrMsg: "failed to get project",
 		},
 		{
 			name:         "missing project_number",
@@ -294,7 +292,6 @@ func Test_GetProject(t *testing.T) {
 }
 
 func Test_ListProjectFields(t *testing.T) {
-	// Verify tool definition & schema snapshot
 	mockClient := gh.NewClient(nil)
 	tool, _ := ListProjectFields(stubGetClientFn(mockClient), translations.NullTranslationHelper)
 	require.NoError(t, toolsnaps.Test(tool.Name, tool))
@@ -307,7 +304,6 @@ func Test_ListProjectFields(t *testing.T) {
 	assert.Contains(t, tool.InputSchema.Properties, "per_page")
 	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner_type", "owner", "projectNumber"})
 
-	// Minimal field objects
 	orgFields := []map[string]any{
 		{"id": 101, "name": "Status", "dataType": "single_select"},
 	}

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Test_ListProjects(t *testing.T) {
-	// Verify tool definition and schema once
 	mockClient := gh.NewClient(nil)
 	tool, _ := ListProjects(stubGetClientFn(mockClient), translations.NullTranslationHelper)
 	require.NoError(t, toolsnaps.Test(tool.Name, tool))
@@ -28,7 +27,6 @@ func Test_ListProjects(t *testing.T) {
 	assert.Contains(t, tool.InputSchema.Properties, "per_page")
 	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "owner_type"})
 
-	// Minimal project objects (fields chosen to likely exist on ProjectV2; test only asserts round-trip JSON array length)
 	orgProjects := []map[string]any{{"id": 1, "title": "Org Project"}}
 	userProjects := []map[string]any{{"id": 2, "title": "User Project"}}
 
@@ -176,15 +174,13 @@ func Test_GetProject(t *testing.T) {
 	assert.Contains(t, tool.InputSchema.Properties, "owner_type")
 	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"project_number", "owner", "owner_type"})
 
-	// Minimal project object for response array
-	project := []map[string]any{{"id": 123, "title": "Project Title"}}
+	project := map[string]any{"id": 123, "title": "Project Title"}
 
 	tests := []struct {
 		name           string
 		mockedClient   *http.Client
 		requestArgs    map[string]interface{}
 		expectError    bool
-		expectedLength int
 		expectedErrMsg string
 	}{
 		{
@@ -200,8 +196,7 @@ func Test_GetProject(t *testing.T) {
 				"owner":          "octo-org",
 				"owner_type":     "organization",
 			},
-			expectError:    false,
-			expectedLength: 1,
+			expectError: false,
 		},
 		{
 			name: "success user project fetch",
@@ -216,8 +211,7 @@ func Test_GetProject(t *testing.T) {
 				"owner":          "octocat",
 				"owner_type":     "user",
 			},
-			expectError:    false,
-			expectedLength: 1,
+			expectError: false,
 		},
 		{
 			name: "api error",
@@ -292,10 +286,9 @@ func Test_GetProject(t *testing.T) {
 
 			require.False(t, result.IsError)
 			textContent := getTextResult(t, result)
-			var arr []map[string]any
+			var arr map[string]any
 			err = json.Unmarshal([]byte(textContent.Text), &arr)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedLength, len(arr))
 		})
 	}
 }

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -25,8 +25,6 @@ func Test_ListProjects(t *testing.T) {
 	assert.Contains(t, tool.InputSchema.Properties, "owner")
 	assert.Contains(t, tool.InputSchema.Properties, "owner_type")
 	assert.Contains(t, tool.InputSchema.Properties, "query")
-	assert.Contains(t, tool.InputSchema.Properties, "before")
-	assert.Contains(t, tool.InputSchema.Properties, "after")
 	assert.Contains(t, tool.InputSchema.Properties, "per_page")
 	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "owner_type"})
 
@@ -80,7 +78,7 @@ func Test_ListProjects(t *testing.T) {
 					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						q := r.URL.Query()
 						// Assert query params present
-						if q.Get("after") == "cursor123" && q.Get("per_page") == "50" && q.Get("q") == "roadmap" {
+						if q.Get("per_page") == "50" && q.Get("q") == "roadmap" {
 							w.WriteHeader(http.StatusOK)
 							_, _ = w.Write(mock.MustMarshal(orgProjects))
 							return
@@ -93,7 +91,6 @@ func Test_ListProjects(t *testing.T) {
 			requestArgs: map[string]interface{}{
 				"owner":      "octo-org",
 				"owner_type": "organization",
-				"after":      "cursor123",
 				"per_page":   float64(50),
 				"query":      "roadmap",
 			},

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -48,7 +48,7 @@ func Test_ListProjects(t *testing.T) {
 			),
 			requestArgs: map[string]interface{}{
 				"owner":      "octo-org",
-				"owner_type": "organization",
+				"owner_type": "org",
 			},
 			expectError:    false,
 			expectedLength: 1,
@@ -88,7 +88,7 @@ func Test_ListProjects(t *testing.T) {
 			),
 			requestArgs: map[string]interface{}{
 				"owner":      "octo-org",
-				"owner_type": "organization",
+				"owner_type": "org",
 				"per_page":   float64(50),
 				"query":      "roadmap",
 			},
@@ -105,7 +105,7 @@ func Test_ListProjects(t *testing.T) {
 			),
 			requestArgs: map[string]interface{}{
 				"owner":      "octo-org",
-				"owner_type": "organization",
+				"owner_type": "org",
 			},
 			expectError:    true,
 			expectedErrMsg: "failed to list projects",
@@ -114,7 +114,7 @@ func Test_ListProjects(t *testing.T) {
 			name:         "missing owner",
 			mockedClient: mock.NewMockedHTTPClient(),
 			requestArgs: map[string]interface{}{
-				"owner_type": "organization",
+				"owner_type": "org",
 			},
 			expectError: true,
 		},
@@ -194,7 +194,7 @@ func Test_GetProject(t *testing.T) {
 			requestArgs: map[string]interface{}{
 				"project_number": float64(123),
 				"owner":          "octo-org",
-				"owner_type":     "organization",
+				"owner_type":     "org",
 			},
 			expectError: false,
 		},
@@ -224,7 +224,7 @@ func Test_GetProject(t *testing.T) {
 			requestArgs: map[string]interface{}{
 				"project_number": float64(999),
 				"owner":          "octo-org",
-				"owner_type":     "organization",
+				"owner_type":     "org",
 			},
 			expectError:    true,
 			expectedErrMsg: "failed to get project", // updated to match implementation
@@ -234,7 +234,7 @@ func Test_GetProject(t *testing.T) {
 			mockedClient: mock.NewMockedHTTPClient(),
 			requestArgs: map[string]interface{}{
 				"owner":      "octo-org",
-				"owner_type": "organization",
+				"owner_type": "org",
 			},
 			expectError: true,
 		},
@@ -243,7 +243,7 @@ func Test_GetProject(t *testing.T) {
 			mockedClient: mock.NewMockedHTTPClient(),
 			requestArgs: map[string]interface{}{
 				"project_number": float64(123),
-				"owner_type":     "organization",
+				"owner_type":     "org",
 			},
 			expectError: true,
 		},
@@ -289,6 +289,157 @@ func Test_GetProject(t *testing.T) {
 			var arr map[string]any
 			err = json.Unmarshal([]byte(textContent.Text), &arr)
 			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_ListProjectFields(t *testing.T) {
+	// Verify tool definition & schema snapshot
+	mockClient := gh.NewClient(nil)
+	tool, _ := ListProjectFields(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
+	assert.Equal(t, "list_project_fields", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "owner_type")
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "projectNumber")
+	assert.Contains(t, tool.InputSchema.Properties, "per_page")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner_type", "owner", "projectNumber"})
+
+	// Minimal field objects
+	orgFields := []map[string]any{
+		{"id": 101, "name": "Status", "dataType": "single_select"},
+	}
+	userFields := []map[string]any{
+		{"id": 201, "name": "Priority", "dataType": "single_select"},
+	}
+
+	tests := []struct {
+		name           string
+		mockedClient   *http.Client
+		requestArgs    map[string]interface{}
+		expectError    bool
+		expectedLength int
+		expectedErrMsg string
+	}{
+		{
+			name: "success organization fields",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.EndpointPattern{Pattern: "/orgs/{org}/projectsV2/{project}/fields", Method: http.MethodGet},
+					mockResponse(t, http.StatusOK, orgFields),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner":         "octo-org",
+				"owner_type":    "org",
+				"projectNumber": "123",
+			},
+			expectedLength: 1,
+		},
+		{
+			name: "success user fields with per_page override",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.EndpointPattern{Pattern: "/users/{user}/projectsV2/{project}/fields", Method: http.MethodGet},
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						q := r.URL.Query()
+						if q.Get("per_page") == "50" {
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write(mock.MustMarshal(userFields))
+							return
+						}
+						w.WriteHeader(http.StatusBadRequest)
+						_, _ = w.Write([]byte(`{"message":"unexpected query params"}`))
+					}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner":         "octocat",
+				"owner_type":    "user",
+				"projectNumber": "456",
+				"per_page":      float64(50),
+			},
+			expectedLength: 1,
+		},
+		{
+			name: "api error",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.EndpointPattern{Pattern: "/orgs/{org}/projectsV2/{project}/fields", Method: http.MethodGet},
+					mockResponse(t, http.StatusInternalServerError, map[string]string{"message": "boom"}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner":         "octo-org",
+				"owner_type":    "org",
+				"projectNumber": "789",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to list projects",
+		},
+		{
+			name:         "missing owner",
+			mockedClient: mock.NewMockedHTTPClient(),
+			requestArgs: map[string]interface{}{
+				"owner_type":    "org",
+				"projectNumber": "10",
+			},
+			expectError: true,
+		},
+		{
+			name:         "missing owner_type",
+			mockedClient: mock.NewMockedHTTPClient(),
+			requestArgs: map[string]interface{}{
+				"owner":         "octo-org",
+				"projectNumber": "10",
+			},
+			expectError: true,
+		},
+		{
+			name:         "missing projectNumber",
+			mockedClient: mock.NewMockedHTTPClient(),
+			requestArgs: map[string]interface{}{
+				"owner":      "octo-org",
+				"owner_type": "org",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := gh.NewClient(tc.mockedClient)
+			_, handler := ListProjectFields(stubGetClientFn(client), translations.NullTranslationHelper)
+			request := createMCPRequest(tc.requestArgs)
+			result, err := handler(context.Background(), request)
+
+			require.NoError(t, err)
+			if tc.expectError {
+				require.True(t, result.IsError)
+				text := getTextResult(t, result).Text
+				if tc.expectedErrMsg != "" {
+					assert.Contains(t, text, tc.expectedErrMsg)
+				}
+				if tc.name == "missing owner" {
+					assert.Contains(t, text, "missing required parameter: owner")
+				}
+				if tc.name == "missing owner_type" {
+					assert.Contains(t, text, "missing required parameter: owner_type")
+				}
+				if tc.name == "missing projectNumber" {
+					assert.Contains(t, text, "missing required parameter: projectNumber")
+				}
+				return
+			}
+
+			require.False(t, result.IsError)
+			textContent := getTextResult(t, result)
+			var fields []map[string]any
+			err = json.Unmarshal([]byte(textContent.Text), &fields)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedLength, len(fields))
 		})
 	}
 }

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -166,3 +166,139 @@ func Test_ListProjects(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetProject(t *testing.T) {
+	mockClient := gh.NewClient(nil)
+	tool, _ := GetProject(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
+	assert.Equal(t, "get_project", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "project_number")
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "owner_type")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"project_number", "owner", "owner_type"})
+
+	// Minimal project object for response array
+	project := []map[string]any{{"id": 123, "title": "Project Title"}}
+
+	tests := []struct {
+		name           string
+		mockedClient   *http.Client
+		requestArgs    map[string]interface{}
+		expectError    bool
+		expectedLength int
+		expectedErrMsg string
+	}{
+		{
+			name: "success organization project fetch",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.EndpointPattern{Pattern: "/orgs/{org}/projectsV2/123", Method: http.MethodGet},
+					mockResponse(t, http.StatusOK, project),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"project_number": float64(123),
+				"owner":          "octo-org",
+				"owner_type":     "organization",
+			},
+			expectError:    false,
+			expectedLength: 1,
+		},
+		{
+			name: "success user project fetch",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.EndpointPattern{Pattern: "/users/{username}/projectsV2/456", Method: http.MethodGet},
+					mockResponse(t, http.StatusOK, project),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"project_number": float64(456),
+				"owner":          "octocat",
+				"owner_type":     "user",
+			},
+			expectError:    false,
+			expectedLength: 1,
+		},
+		{
+			name: "api error",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.EndpointPattern{Pattern: "/orgs/{org}/projectsV2/999", Method: http.MethodGet},
+					mockResponse(t, http.StatusInternalServerError, map[string]string{"message": "boom"}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"project_number": float64(999),
+				"owner":          "octo-org",
+				"owner_type":     "organization",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to get project", // updated to match implementation
+		},
+		{
+			name:         "missing project_number",
+			mockedClient: mock.NewMockedHTTPClient(),
+			requestArgs: map[string]interface{}{
+				"owner":      "octo-org",
+				"owner_type": "organization",
+			},
+			expectError: true,
+		},
+		{
+			name:         "missing owner",
+			mockedClient: mock.NewMockedHTTPClient(),
+			requestArgs: map[string]interface{}{
+				"project_number": float64(123),
+				"owner_type":     "organization",
+			},
+			expectError: true,
+		},
+		{
+			name:         "missing owner_type",
+			mockedClient: mock.NewMockedHTTPClient(),
+			requestArgs: map[string]interface{}{
+				"project_number": float64(123),
+				"owner":          "octo-org",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := gh.NewClient(tc.mockedClient)
+			_, handler := GetProject(stubGetClientFn(client), translations.NullTranslationHelper)
+			request := createMCPRequest(tc.requestArgs)
+			result, err := handler(context.Background(), request)
+
+			require.NoError(t, err)
+			if tc.expectError {
+				require.True(t, result.IsError)
+				text := getTextResult(t, result).Text
+				if tc.expectedErrMsg != "" {
+					assert.Contains(t, text, tc.expectedErrMsg)
+				}
+				if tc.name == "missing project_number" {
+					assert.Contains(t, text, "missing required parameter: project_number")
+				}
+				if tc.name == "missing owner" {
+					assert.Contains(t, text, "missing required parameter: owner")
+				}
+				if tc.name == "missing owner_type" {
+					assert.Contains(t, text, "missing required parameter: owner_type")
+				}
+				return
+			}
+
+			require.False(t, result.IsError)
+			textContent := getTextResult(t, result)
+			var arr []map[string]any
+			err = json.Unmarshal([]byte(textContent.Text), &arr)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedLength, len(arr))
+		})
+	}
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -194,6 +194,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 		AddReadTools(
 			toolsets.NewServerTool(ListProjects(getClient, t)),
 			toolsets.NewServerTool(GetProject(getClient, t)),
+			toolsets.NewServerTool(ListProjectFields(getClient, t)),
 		)
 
 	// Add toolsets to the group

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -193,6 +193,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 	projects := toolsets.NewToolset("projects", "GitHub Projects related tools").
 		AddReadTools(
 			toolsets.NewServerTool(ListProjects(getClient, t)),
+			toolsets.NewServerTool(GetProject(getClient, t)),
 		)
 
 	// Add toolsets to the group


### PR DESCRIPTION
This pr:
1. Removes (for now) pagination for `list_projects` tool
2. Adds tools:
- `get_project` tool for user and org
- `list_project_fields` tool for user and org

Implements https://github.com/github/github-mcp-server/issues/44

Implements new projects V2 API. FYI implementation of project tools will use google/go-github when they implement the new API.
Pagination will be added in the next step.