### PR TITLE
Adding option to manually dispatch docker container build workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,13 @@ on:
     tags: ["v*.*.*"]
   pull_request:
     branches: ["main", "next"]
+  workflow_dispatch:
+    inputs:
+        description:
+          required: false
+          description: "Description of the run."
+          type: string
+          default: "Manual run"
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
This PR adds manual dispatch option to `Docker` workflow to simplify creating containers for certain branches.

Tested here: https://github.com/github/github-mcp-server/actions/runs/17944955492