### PR TITLE
feat: Add update_issue_comment tool

### DIFF
--- a/pkg/github/__toolsnaps__/update_issue_comment.snap
+++ b/pkg/github/__toolsnaps__/update_issue_comment.snap
@@ -1,0 +1,40 @@
+{
+  "annotations": {
+    "title": "Update issue comment",
+    "readOnlyHint": false
+  },
+  "description": "Update an existing comment on a specific issue in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "New comment content",
+        "type": "string"
+      },
+      "comment_id": {
+        "description": "Comment's unique identifier",
+        "type": "string"
+      },
+      "issue_number": {
+        "description": "Target issue number",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "comment_id",
+      "issue_number",
+      "owner",
+      "repo",
+      "body"
+    ],
+    "type": "object"
+  },
+  "name": "update_issue_comment"
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -65,6 +65,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 		AddWriteTools(
 			toolsets.NewServerTool(CreateIssue(getClient, t)),
 			toolsets.NewServerTool(AddIssueComment(getClient, t)),
+			toolsets.NewServerTool(UpdateIssueComment(getClient, t)),
 			toolsets.NewServerTool(UpdateIssue(getClient, getGQLClient, t)),
 			toolsets.NewServerTool(AssignCopilotToIssue(getGQLClient, t)),
 			toolsets.NewServerTool(AddSubIssue(getClient, t)),


### PR DESCRIPTION
## Summary
Implements issue #1083 by adding a new `update_issue_comment` tool to the GitHub MCP server, enabling users to modify existing issue comments programmatically.

## Changes Made
- **New Tool**: `update_issue_comment` with full parameter validation
- **API Integration**: Uses GitHub's `EditComment` API endpoint
- **Error Handling**: Comprehensive validation and error responses
- **Testing**: 5 test cases covering success, errors, and edge cases
- **Documentation**: Auto-generated tool schema snapshots

## Implementation Details

### Tool Parameters
- `comment_id` (string, required): Comment's unique identifier
- `issue_number` (number, required): Target issue number  
- `owner` (string, required): Repository owner
- `repo` (string, required): Repository name
- `body` (string, required): New comment content

### Features
✅ **Parameter Validation**: Validates all required parameters with meaningful error messages  
✅ **ID Parsing**: Proper comment ID validation (must be positive integer)  
✅ **Content Validation**: Prevents empty or whitespace-only comments  
✅ **Error Handling**: Handles GitHub API errors (404, permissions, etc.)  
✅ **Existing Patterns**: Follows codebase conventions and patterns  

### Files Modified
- `pkg/github/issues.go`: Added `UpdateIssueComment` function and helper
- `pkg/github/issues_test.go`: Added comprehensive test suite (5 test cases)
- `pkg/github/tools.go`: Registered tool in issues toolset
- `pkg/github/__toolsnaps__/update_issue_comment.snap`: Tool schema validation

## Test Results
```
✅ TestUpdateIssueComment/success - Updates comment successfully
✅ TestUpdateIssueComment/not_found - Handles 404 responses gracefully  
✅ TestUpdateIssueComment/missing_parameters - Validates required parameters
✅ TestUpdateIssueComment/invalid_comment_id - Validates ID format
✅ TestUpdateIssueComment/empty_body - Prevents empty content
```

## Test plan
- [x] Unit tests pass for new functionality
- [x] All existing tests continue to pass (no regressions)
- [x] Tool schema validation via snapshots
- [x] Manual testing with GitHub API responses
- [x] Parameter validation edge cases covered

Fixes #1083

🤖 Generated with [Claude Code](https://claude.ai/code)