### PR TITLE
Improve registry release reliability

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -127,3 +127,19 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+      - name: Trigger registry publication
+        if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'docker-published',
+              client_payload: {
+                tag: context.ref.replace('refs/tags/', ''),
+                sha: context.sha,
+                image_digest: '${{ steps.build-and-push.outputs.digest }}'
+              }
+            });

--- a/.github/workflows/registry-releaser.yml
+++ b/.github/workflows/registry-releaser.yml
@@ -1,8 +1,8 @@
 name: Publish to MCP Registry
 
 on:
-  push:
-    tags: ["v*"]  # Triggers on version tags like v1.0.0
+  repository_dispatch:
+    types: [docker-published]  # Triggered after Docker image is published
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
@@ -23,11 +23,34 @@ jobs:
         
       - name: Fetch tags
         run: |
-          if [[ "${{ github.ref_type }}" != "tag" ]]; then
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "Triggered by docker-published event for tag: ${{ github.event.client_payload.tag }}"
+          elif [[ "${{ github.ref_type }}" != "tag" ]]; then
             git fetch --tags
           else
             echo "Skipping tag fetch - already on tag ${{ github.ref_name }}"
           fi
+
+      - name: Wait for Docker image
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            TAG="${{ github.event.client_payload.tag }}"
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+            TAG="${{ github.ref_name }}"
+          else
+            TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+          fi
+          IMAGE="ghcr.io/github/github-mcp-server:$TAG"
+          
+          for i in {1..6}; do
+            if docker manifest inspect "$IMAGE" &>/dev/null; then
+              echo "✅ Docker image ready: $TAG"
+              break
+            fi
+            [ $i -eq 6 ] && { echo "❌ Timeout waiting for $TAG after 3 minutes"; exit 1; }
+            echo "⏳ Waiting for Docker image ($i/6)..."
+            sleep 30
+          done
 
       - name: Install MCP Publisher
         run: |
@@ -37,7 +60,10 @@ jobs:
 
       - name: Update server.json version
         run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            TAG_VERSION=$(echo "${{ github.event.client_payload.tag }}" | sed 's/^v//')
+            echo "Using tag from dispatch: ${{ github.event.client_payload.tag }}"
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
             TAG_VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
           else
             LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$' | head -n 1)


### PR DESCRIPTION
This pull request updates the release workflow to decouple Docker image publishing from MCP Registry publication, ensuring that registry updates only occur after a successful image build and push. The workflows now communicate via a custom GitHub repository dispatch event. 