### PR TITLE
Add note for GitHub Enterprise Cloud Data Residency configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ For quick installation, use one of the one-click install buttons above. Once you
 
 Alternatively, to manually configure VS Code, choose the appropriate JSON block from the examples below and add it to your host configuration:
 
+> [!NOTE]
+> If you are using GitHub Enterprise Cloud with Data Residency, update the URL in the JSON configuration.
+> For example, if your enterprise's subdomain is octocorp, update the URL to `https://copilot-api.octocorp.ghe.com/mcp`.
+
 <table>
 <tr><th>Using OAuth</th><th>Using a GitHub PAT</th></tr>
 <tr><th align=left colspan=2>VS Code (version 1.101 or greater)</th></tr>


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Clarifies that users of GitHub Enterprise Cloud with Data Residency need to update the API URL in their JSON configuration, providing a concrete example for clarity consistent with examples in other documentation: https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency/about-github-enterprise-cloud-with-data-residency#api-access 