### PR TITLE
feat: add include_archived parameter to repository search

### DIFF
--- a/pkg/github/__toolsnaps__/search_repositories.snap
+++ b/pkg/github/__toolsnaps__/search_repositories.snap
@@ -6,6 +6,11 @@
   "description": "Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.",
   "inputSchema": {
     "properties": {
+      "include_archived": {
+        "default": true,
+        "description": "Include archived repositories in search results (default: true). When false, excludes archived repositories.",
+        "type": "boolean"
+      },
       "minimal_output": {
         "default": true,
         "description": "Return minimal repository information (default: true). When false, returns full GitHub API repository objects.",


### PR DESCRIPTION
Allows filtering out archived repositories when include_archived=false. Maintains backward compatibility with default value of true.

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
