### PR TITLE
Add multi-tool workflow server instructions specific to local GitHub MCP

### DIFF
--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -67,10 +67,6 @@ func getGeneralInstructions(enabledToolsets []string) string {
 	}
 
 	scenarios := map[string]scenarioDefinition{
-		"Reviewing Pull Requests": {
-			instruction:      "Use get_pull_request to fetch PR details and get_pull_request_files to see changes. Use create_pending_pull_request_review to start a review, add_comment_to_pending_review for line-specific feedback, then submit_pending_pull_request_review to publish. Check get_pull_request_status to verify CI/CD checks before approving.",
-			requiredToolsets: []string{"pull_requests"},
-		},
 		"Triaging Security Alerts": {
 			instruction:      "Use list_dependabot_alerts, list_code_scanning_alerts, or list_secret_scanning_alerts with state='open' to find active security issues. Use get_*_alert for detailed information about specific alerts. For broader context, search list_global_security_advisories or get_global_security_advisory for known CVEs affecting your dependencies.",
 			requiredToolsets: []string{},


### PR DESCRIPTION
This pull request adds new server instructions by introducing scenario-based instructions for common development tasks. These improvements help users understand which GitHub toolsets and API endpoints to use for typical workflows, making the instructions more actionable and context-aware.

An example of this is as follows, using the **Triaging Security Alerts** scenario with the following instruction:

> Use list_dependabot_alerts, list_code_scanning_alerts, or list_secret_scanning_alerts with state='open' to find active security issues. Use get_*_alert for detailed information about specific alerts. For broader context, search list_global_security_advisories or get_global_security_advisory for known CVEs affecting your dependencies.


<img width="789" height="680" alt="Screenshot 2025-10-13 at 16 29 01" src="https://github.com/user-attachments/assets/5575b602-499e-447e-9ab7-5a80ab37b688" />

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
