### PR TITLE
Add Gemini CLI extension

### DIFF
--- a/docs/installation-guides/install-gemini-cli.md
+++ b/docs/installation-guides/install-gemini-cli.md
@@ -30,7 +30,7 @@ After securely storing your PAT, you can add the GitHub MCP server configuration
 
 > **Note:** For the most up-to-date configuration options, see the [main README.md](../../README.md).
 
-### Method 1: Remote Server (Recommended)
+### Method 1: Gemini Extension (Recommended)
 
 The simplest way is to use GitHub's hosted MCP server via our gemini extension.
 
@@ -39,7 +39,7 @@ The simplest way is to use GitHub's hosted MCP server via our gemini extension.
 > [!NOTE]
 > You will still need to have a personal access token with the appropriate scopes called `GITHUB_MCP_PAT` in your environment.
 
-### Method 2: Manual Remote Server
+### Method 2: Remote Server
 
 You can also connect to the hosted MCP server directly. After securely storing your PAT, configure Gemini CLI with:
 

--- a/docs/installation-guides/install-gemini-cli.md
+++ b/docs/installation-guides/install-gemini-cli.md
@@ -14,7 +14,7 @@ For security, avoid hardcoding your token. Create or update `~/.gemini/.env` (wh
 
 ```bash
 # ~/.gemini/.env
-GITHUB_PAT=your_token_here
+GITHUB_MCP_PAT=your_token_here
 ```
 
 </details>
@@ -32,21 +32,13 @@ After securely storing your PAT, you can add the GitHub MCP server configuration
 
 ### Method 1: Remote Server (Recommended)
 
-The simplest way is to use GitHub's hosted MCP server:
+The simplest way is to use GitHub's hosted MCP server via our gemini extension.
 
-```json
-// ~/.gemini/settings.json
-{
-    "mcpServers": {
-        "github": {
-            "httpUrl": "https://api.githubcopilot.com/mcp/",
-            "headers": {
-                "Authorization": "Bearer $GITHUB_PAT"
-            }
-        }
-    }
-}
-```
+`gemini extensions install https://github.com/github/github-mcp-server`
+
+> [!NOTE]
+> You will still need to have a personal access token with the appropriate scopes called `GITHUB_MCP_PAT` in your environment.
+
 
 ### Method 2: Local Docker
 
@@ -88,7 +80,7 @@ Then, replacing `/path/to/binary` with the actual path to your binary, configure
             "command": "/path/to/binary",
             "args": ["stdio"],
             "env": {
-                "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_PAT"
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_MCP_PAT"
             }
         }
     }

--- a/docs/installation-guides/install-gemini-cli.md
+++ b/docs/installation-guides/install-gemini-cli.md
@@ -39,8 +39,25 @@ The simplest way is to use GitHub's hosted MCP server via our gemini extension.
 > [!NOTE]
 > You will still need to have a personal access token with the appropriate scopes called `GITHUB_MCP_PAT` in your environment.
 
+### Method 2: Manual Remote Server
 
-### Method 2: Local Docker
+You can also connect to the hosted MCP server directly. After securely storing your PAT, configure Gemini CLI with:
+
+```json
+// ~/.gemini/settings.json
+{
+    "mcpServers": {
+        "github": {
+            "httpUrl": "https://api.githubcopilot.com/mcp/",
+            "headers": {
+                "Authorization": "Bearer $GITHUB_MCP_PAT"
+            }
+        }
+    }
+}
+```
+
+### Method 3: Local Docker
 
 With docker running, you can run the GitHub MCP server in a container:
 
@@ -66,7 +83,7 @@ With docker running, you can run the GitHub MCP server in a container:
 }
 ```
 
-### Method 3: Binary
+### Method 4: Binary
 
 You can download the latest binary release from the [GitHub releases page](https://github.com/github/github-mcp-server/releases) or build it from source by running `go build -o github-mcp-server ./cmd/github-mcp-server`.
 

--- a/docs/installation-guides/install-gemini-cli.md
+++ b/docs/installation-guides/install-gemini-cli.md
@@ -59,7 +59,7 @@ With docker running, you can run the GitHub MCP server in a container:
                 "ghcr.io/github/github-mcp-server"
             ],
             "env": {
-                "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_PAT"
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_MCP_PAT"
             }
         }
     }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,12 @@
+{
+	"name": "github",
+	"version": "1.0.0",
+	"mcpServers": {
+		"github": {
+			"httpUrl": "https://api.githubcopilot.com/mcp",
+			"headers": {
+				"Authorization": "Bearer $GITHUB_MCP_PAT"
+			}
+		}
+	}
+}

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"mcpServers": {
 		"github": {
-			"httpUrl": "https://api.githubcopilot.com/mcp",
+			"httpUrl": "https://api.githubcopilot.com/mcp/",
 			"headers": {
 				"Authorization": "Bearer $GITHUB_MCP_PAT"
 			}

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"mcpServers": {
 		"github": {
+			"description": "Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language.",
 			"httpUrl": "https://api.githubcopilot.com/mcp/",
 			"headers": {
 				"Authorization": "Bearer $GITHUB_MCP_PAT"


### PR DESCRIPTION
Adds a `gemini-extension.json` manifest file so that the remote MCP server can be installed with the `gemini extensions install https://github.com/github/github-mcp-server` command.

Also updates the env var name for the PAT in all Gemini CLI cases to be `GITHUB_MCP_PAT`. Gemini CLI uses environment variables plus those found in the `.env` file, so I caution using a more explicitly named variable to prevent a user accidentally using a PAT they have in their environment that contains permissions that they may not want their MCP instance to have access to.