### PR TITLE
chore: Add description to Gemini CLI extension

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "github",
 	"version": "1.0.0",
-	"description": "Connect Gemini CLI to GitHub - manage repos, issues, PRs, and workflows through natural language.",
+	"description": "Manage GitHub repos, issues, PRs, and workflows through natural language.",
 	"mcpServers": {
 		"github": {
 			"description": "Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language.",


### PR DESCRIPTION
The `description` field within a Gemini CLI extension JSON file (`gemini-extension.json`) is what gets populated on the extensions gallery page https://geminicli.com/extensions/.

If no description is found, the GitHub repo's description is used as a fallback (current case with GitHub extension)

## Current
<img width="400" height="337" alt="image" src="https://github.com/user-attachments/assets/b249d50f-27da-4bc3-9e4e-d63c35f56570" />

Updating the description to be more descriptive to users of what the extension provides them with.

## New
<img width="400" height="339" alt="image" src="https://github.com/user-attachments/assets/6bf80908-9ad7-463e-b93e-b517e1137b06" />

