### PR TITLE
projects: add server instructions

### DIFF
--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -121,7 +121,7 @@ Syntax Essentials (items):
    Quote multi-word values. (status:"In Review" team-name:"Backend Team").
    Ranges: points:1..3, updated:<@today-30d.
    Wildcards: title:*crash*, label:bug*.
-	 Assigned to User: assignee:@me | assignee:username | no:assignee
+   Assigned to User: assignee:@me | assignee:username | no:assignee
 
 Common Qualifier Glossary (items):
    is:issue | is:pr | state:open|closed|merged | assignee:@me|username | label:NAME | status:VALUE |


### PR DESCRIPTION
This pull request adds comprehensive instructions for handling GitHub Projects to the `pkg/github/instructions.go` file. The new guidance covers best practices for listing, filtering, paginating, and summarizing project items, ensuring correct field usage and query construction. The changes are focused on improving clarity and accuracy when interacting with project-related APIs.

Stacked on top of: https://github.com/github/github-mcp-server/pull/1390

----

These instructions help improve the quality of usage for projects related tools. Most specifically, those calls for listing project items. Some example query improvements below.

### Example 1

> Show me the last week's activity in https://github.com/orgs/test-rg/projects/1234/views/14 for all p2 or higher issues.

**Before:**

`updated:>2025-11-04`

**After:**

`is:issue updated:>@today-7d priority:P0,P1,P2`

### Example 2

> Show me all issues that riley is assigned to in https://github.com/orgs/test-org/projects/123456/views/16, please show me the progress of the sub-issues as well.

**Before:**

`assignee:riley`

Ultimately, no results were ever returned.

**After:** 

Attempt 1:

`is:issue assignee:riley`

Attempt 2 (self-corrected):

`is:issue assignee:*riley*`

### Example 3

> Show me all open p1 issues that I've worked on in https://github.com/orgs/test-org/projects/123456/views/5

**Before:**

`assignee:@me is:open`

**After:**

`is:issue state:open priority:p1 assignee:@me`