### PR TITLE
Update docs to state that dynamic mode is not available in Remote Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,7 @@ Possible options:
 
 ## Dynamic Tool Discovery
 
-**Note**: This feature is currently in beta and it is not available in the Remote GitHub MCP Server. Please test it out and let us know if you encounter any issues.
+**Note**: This feature is currently in beta and is not available in the Remote GitHub MCP Server. Please test it out and let us know if you encounter any issues.
 
 Instead of starting with all tools enabled, you can turn on dynamic toolset discovery. Dynamic toolsets allow the MCP host to list and enable toolsets in response to a user prompt. This should help to avoid situations where the model gets confused by the sheer number of tools available.
 


### PR DESCRIPTION
This PR updates the docs to make it clearer that the Dynamic Toolset Discovery is not available in the Remote MCP Server
