### PR TITLE
experiment with fake cursor pagination approach

### DIFF
--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -831,7 +831,7 @@ func SearchIssues(getClient GetClientFn, t translations.TranslationHelperFunc) (
 				mcp.Description("Sort order"),
 				mcp.Enum("asc", "desc"),
 			),
-			WithPagination(),
+			WithFixedCursorPagination(),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return searchHandler(ctx, getClient, request, "issue", "failed to search issues")

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -968,7 +968,7 @@ func SearchPullRequests(getClient GetClientFn, t translations.TranslationHelperF
 				mcp.Description("Sort order"),
 				mcp.Enum("asc", "desc"),
 			),
-			WithPagination(),
+			WithFixedCursorPagination(),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return searchHandler(ctx, getClient, request, "pr", "failed to search pull requests")

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -227,6 +227,15 @@ func WithUnifiedPagination() mcp.ToolOption {
 	}
 }
 
+// WithFixedCursorPagination adds only cursor-based pagination parameters to a tool (no page parameter).
+func WithFixedCursorPagination() mcp.ToolOption {
+	return func(tool *mcp.Tool) {
+		mcp.WithString("cursor",
+			mcp.Description("Cursor for pagination. Use the endCursor from the previous page's PageInfo."),
+		)(tool)
+	}
+}
+
 // WithCursorPagination adds only cursor-based pagination parameters to a tool (no page parameter).
 func WithCursorPagination() mcp.ToolOption {
 	return func(tool *mcp.Tool) {
@@ -270,6 +279,19 @@ func OptionalPaginationParams(r mcp.CallToolRequest) (PaginationParams, error) {
 		Page:    page,
 		PerPage: perPage,
 		After:   after,
+	}, nil
+}
+
+// OptionalFixedCursorPaginationParams returns the "perPage" and "after" parameters from the request,
+// without the "page" parameter, suitable for cursor-based pagination only.
+func OptionalFixedCursorPaginationParams(r mcp.CallToolRequest) (CursorPaginationParams, error) {
+	cursor, err := OptionalParam[string](r, "cursor")
+	if err != nil {
+		return CursorPaginationParams{}, err
+	}
+	return CursorPaginationParams{
+		PerPage: 10,
+		After:   cursor,
 	}, nil
 }
 


### PR DESCRIPTION
Looking at whether making pagination behave more like a cursor would be beneficial or not, in terms of getting agents to natively understand how to get more data, and not naively just get a large result set.

Pinning the number of results, and always providing the next cursor value are key parts of this.

Part of https://github.com/github/github-mcp-server/issues/1362