### PR TITLE
improve response/feedback loop with better error messages

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -560,7 +560,7 @@ func GetFileContents(getClient GetClientFn, getRawClient raw.GetRawClientFn, t t
 					), nil
 				}
 				if fileContent == nil || fileContent.SHA == nil {
-					return mcp.NewToolResultError("file content SHA is nil"), nil
+					return mcp.NewToolResultError("file content SHA is nil, if a directory was requested, path parameters should end with a trailing slash '/'"), nil
 				}
 				fileSHA = *fileContent.SHA
 


### PR DESCRIPTION
GTP-5.1-Codex experienced a problem with `get_file_contents`. It ignored the instruction to add trailing slashes to directories. It looped multiple times before it recovered and added the trailing slashes.

The follow up error: `file content SHA is nil` usually means we are using the logic to look for a file but provided a path in reality. This improved error message should improve the feedback loop drastically for llms.

Closes:
