### PR TITLE
Fix handling of multi path resources

### DIFF
--- a/pkg/github/repository_resource.go
+++ b/pkg/github/repository_resource.go
@@ -99,7 +99,15 @@ func RepositoryResourceContentsHandler(getClient GetClientFn, getRawClient raw.G
 			return nil, errors.New("repo is required")
 		}
 
-		path := uriValues.Get("path").String()
+		pathValue := uriValues.Get("path")
+		pathComponents := pathValue.List()
+		var path string
+
+		if len(pathComponents) == 0 {
+			path = pathValue.String()
+		} else {
+			path = strings.Join(pathComponents, "/")
+		}
 
 		opts := &github.RepositoryContentGetOptions{}
 		rawOpts := &raw.ContentOpts{}


### PR DESCRIPTION
Follow up to https://github.com/github/github-mcp-server/pull/1457, as I missed that `uritemplate.Value` separates the capture group and `String()` doesn't work.