### PR TITLE
Add go report card to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Go Report Card](https://goreportcard.com/badge/github.com/github/github-mcp-server)](https://goreportcard.com/report/github.com/github/github-mcp-server)
+
 # GitHub MCP Server
 
 The GitHub MCP Server connects AI tools directly to GitHub's platform. This gives AI agents, assistants, and chatbots the ability to read repositories and code files, manage issues and PRs, analyze code, and automate workflows. All through natural language interactions.


### PR DESCRIPTION
Adds a go report score card to the main page in the README:

<img width="2364" height="728" alt="CleanShot 2025-11-21 at 10 41 34@2x" src="https://github.com/user-attachments/assets/d33f72e8-8ec2-422b-b43a-02dcd9605254" />