### PR TITLE
Delete package configuration from server.json (temporarily)

### DIFF
--- a/server.json
+++ b/server.json
@@ -9,59 +9,6 @@
     "source": "github"
   },
   "version": "${VERSION}",
-  "packages": [
-    {
-      "registryType": "oci",
-      "identifier": "ghcr.io/github/github-mcp-server:${VERSION}",
-      "transport": {
-        "type": "stdio"
-      },
-      "runtimeArguments": [
-        {
-          "type": "positional",
-          "value": "run",
-          "description": "The runtime command to execute",
-          "isRequired": true
-        },
-        {
-          "type": "named",
-          "name": "-i",
-          "value": "true",
-          "description": "Run container in interactive mode",
-          "format": "boolean",
-          "isRequired": true
-        },
-        {
-          "type": "named",
-          "name": "--rm",
-          "value": "true",
-          "description": "Automatically remove the container when it exits",
-          "format": "boolean"
-        },
-        {
-          "type": "named",
-          "name": "-e",
-          "description": "Set an environment variable in the runtime",
-          "value": "GITHUB_PERSONAL_ACCESS_TOKEN={token}",
-          "isRequired": true,
-          "variables": {
-            "token": {
-              "isRequired": true,
-              "isSecret": true,
-              "format": "string"
-            }
-          }
-        },
-        {
-          "type": "positional",
-          "valueHint": "image_name",
-          "value": "ghcr.io/github/github-mcp-server",
-          "description": "The container image to run",
-          "isRequired": true
-        }
-      ]
-    }
-  ],
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Temporarily removing package configuration for the GitHub MCP server because certain hosts incorrectly generate docker arguments based on it which results in a broken server configuration when installed via registry.

Will bring it back when the issue is resolved by MCP host.


