### PR TITLE
feat: Add exported ToolScopeMap for library use

### DIFF
--- a/pkg/scopes/tool_scope_map.go
+++ b/pkg/scopes/tool_scope_map.go
@@ -1,0 +1,210 @@
+package scopes
+
+// ToolScopeMap represents the scope lookup data for fast access in production.
+// Keys are tool names, values contain required and accepted scopes as maps for O(1) lookup.
+type ToolScopeMap map[string]*ToolScopeInfo
+
+// AllRequiredScopes returns all unique required scopes across all tools.
+func (m ToolScopeMap) AllRequiredScopes() ScopeSet {
+	result := make(ScopeSet)
+	for _, info := range m {
+		for scope := range info.RequiredScopes {
+			result[scope] = true
+		}
+	}
+	return result
+}
+
+// AllAcceptedScopes returns all unique accepted scopes across all tools.
+func (m ToolScopeMap) AllAcceptedScopes() ScopeSet {
+	result := make(ScopeSet)
+	for _, info := range m {
+		for scope := range info.AcceptedScopes {
+			result[scope] = true
+		}
+	}
+	return result
+}
+
+// ToolsRequiringScope returns all tool names that require the given scope.
+func (m ToolScopeMap) ToolsRequiringScope(scope string) []string {
+	var tools []string
+	for name, info := range m {
+		if info.RequiredScopes.Contains(scope) {
+			tools = append(tools, name)
+		}
+	}
+	return tools
+}
+
+// ToolsAcceptingScope returns all tool names that accept the given scope.
+func (m ToolScopeMap) ToolsAcceptingScope(scope string) []string {
+	var tools []string
+	for name, info := range m {
+		if info.AcceptedScopes.Contains(scope) {
+			tools = append(tools, name)
+		}
+	}
+	return tools
+}
+
+// ToolScopeInfo contains scope information for a single tool optimized for fast lookup.
+type ToolScopeInfo struct {
+	// RequiredScopes contains the scopes that are directly required by this tool.
+	// Map values are always true for O(1) lookup.
+	RequiredScopes ScopeSet `json:"required_scopes"`
+
+	// AcceptedScopes contains all scopes that satisfy the requirements (including required scopes).
+	// This includes parent scopes that implicitly grant access through the hierarchy.
+	// Map values are always true for O(1) lookup.
+	AcceptedScopes ScopeSet `json:"accepted_scopes"`
+}
+
+// ScopeSet is a set of scopes for fast O(1) lookup.
+// All values are true.
+type ScopeSet map[string]bool
+
+// Contains checks if the scope set contains the given scope.
+func (s ScopeSet) Contains(scope string) bool {
+	return s[scope]
+}
+
+// ContainsAny checks if the scope set contains any of the given scopes.
+func (s ScopeSet) ContainsAny(scopes ...string) bool {
+	for _, scope := range scopes {
+		if s[scope] {
+			return true
+		}
+	}
+	return false
+}
+
+// ToSlice converts the scope set to a slice of scope strings.
+func (s ScopeSet) ToSlice() []string {
+	result := make([]string, 0, len(s))
+	for scope := range s {
+		result = append(result, scope)
+	}
+	return result
+}
+
+// NewScopeSet creates a new ScopeSet from a slice of strings.
+func NewScopeSet(scopes []string) ScopeSet {
+	set := make(ScopeSet, len(scopes))
+	for _, s := range scopes {
+		set[s] = true
+	}
+	return set
+}
+
+// NewToolScopeInfo creates a ToolScopeInfo from required scopes.
+// It automatically calculates accepted scopes based on the scope hierarchy.
+func NewToolScopeInfo(required []Scope) *ToolScopeInfo {
+	// Build required scopes set
+	requiredSet := make(ScopeSet, len(required))
+	for _, s := range required {
+		requiredSet[s.String()] = true
+	}
+
+	// Build accepted scopes set (includes required + parent scopes from hierarchy)
+	acceptedSet := make(ScopeSet)
+	for _, reqScope := range required {
+		// Add the required scope itself
+		acceptedSet[reqScope.String()] = true
+		// Add all parent scopes that satisfy this requirement
+		accepted := GetAcceptedScopes(reqScope)
+		for _, accScope := range accepted {
+			acceptedSet[accScope.String()] = true
+		}
+	}
+
+	return &ToolScopeInfo{
+		RequiredScopes: requiredSet,
+		AcceptedScopes: acceptedSet,
+	}
+}
+
+// HasAcceptedScope checks if any of the provided scopes satisfy this tool's requirements.
+// This is the primary method for checking if a user's token has sufficient permissions.
+func (t *ToolScopeInfo) HasAcceptedScope(userScopes ...string) bool {
+	// If the tool requires no scopes, any token is acceptable
+	if len(t.RequiredScopes) == 0 {
+		return true
+	}
+
+	// Check if any of the user's scopes are in the accepted set
+	for _, scope := range userScopes {
+		if t.AcceptedScopes[scope] {
+			return true
+		}
+	}
+	return false
+}
+
+// MissingScopes returns the required scopes that are not satisfied by the given user scopes.
+// Returns nil if all requirements are satisfied.
+func (t *ToolScopeInfo) MissingScopes(userScopes ...string) []string {
+	if len(t.RequiredScopes) == 0 {
+		return nil
+	}
+
+	// Build a set of user scopes for fast lookup
+	userSet := NewScopeSet(userScopes)
+
+	// Check each required scope
+	var missing []string
+	for requiredScope := range t.RequiredScopes {
+		// Check if any accepted scope for this requirement is present
+		found := false
+		accepted := GetAcceptedScopes(Scope(requiredScope))
+		for _, accScope := range accepted {
+			if userSet[accScope.String()] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, requiredScope)
+		}
+	}
+
+	return missing
+}
+
+// BuildToolScopeMap builds a ToolScopeMap from a slice of tool definitions.
+// This is the primary function for library users to build the scope lookup map.
+//
+// Example usage:
+//
+//	// Get tools from your toolset group
+//	tools := []struct{ Name string; Meta map[string]any }{...}
+//
+//	// Build the map
+//	scopeMap := scopes.BuildToolScopeMapFromMeta(tools)
+//
+//	// Check if a user's token has access to a tool
+//	if info, ok := scopeMap["create_issue"]; ok {
+//	    if info.HasAcceptedScope(userScopes...) {
+//	        // User can use this tool
+//	    }
+//	}
+func BuildToolScopeMapFromMeta(tools []ToolMeta) ToolScopeMap {
+	result := make(ToolScopeMap, len(tools))
+	for _, tool := range tools {
+		required := GetScopesFromMeta(tool.Meta)
+		result[tool.Name] = NewToolScopeInfo(required)
+	}
+	return result
+}
+
+// ToolMeta is a minimal interface for tools that have scope metadata.
+type ToolMeta struct {
+	Name string
+	Meta map[string]any
+}
+
+// GetToolScopeInfo creates a ToolScopeInfo directly from a tool's Meta map.
+func GetToolScopeInfo(meta map[string]any) *ToolScopeInfo {
+	required := GetScopesFromMeta(meta)
+	return NewToolScopeInfo(required)
+}

--- a/pkg/scopes/tool_scope_map_test.go
+++ b/pkg/scopes/tool_scope_map_test.go
@@ -1,0 +1,326 @@
+package scopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeSetContains(t *testing.T) {
+	set := NewScopeSet([]string{"repo", "user", "gist"})
+
+	assert.True(t, set.Contains("repo"))
+	assert.True(t, set.Contains("user"))
+	assert.True(t, set.Contains("gist"))
+	assert.False(t, set.Contains("admin"))
+	assert.False(t, set.Contains(""))
+}
+
+func TestScopeSetContainsAny(t *testing.T) {
+	set := NewScopeSet([]string{"repo", "user"})
+
+	assert.True(t, set.ContainsAny("repo"))
+	assert.True(t, set.ContainsAny("admin", "repo"))
+	assert.True(t, set.ContainsAny("user", "gist"))
+	assert.False(t, set.ContainsAny("admin", "gist"))
+	assert.False(t, set.ContainsAny())
+}
+
+func TestScopeSetToSlice(t *testing.T) {
+	set := NewScopeSet([]string{"repo", "user"})
+	slice := set.ToSlice()
+
+	assert.Len(t, slice, 2)
+	assert.Contains(t, slice, "repo")
+	assert.Contains(t, slice, "user")
+}
+
+func TestNewToolScopeInfo(t *testing.T) {
+	tests := []struct {
+		name            string
+		required        []Scope
+		wantRequired    []string
+		wantAccepted    []string
+		wantNotAccepted []string
+	}{
+		{
+			name:         "no scopes required",
+			required:     []Scope{},
+			wantRequired: []string{},
+			wantAccepted: []string{},
+		},
+		{
+			name:         "single scope - repo",
+			required:     []Scope{Repo},
+			wantRequired: []string{"repo"},
+			wantAccepted: []string{"repo"},
+			// repo has no parent scopes
+		},
+		{
+			name:         "scope with parent - public_repo",
+			required:     []Scope{PublicRepo},
+			wantRequired: []string{"public_repo"},
+			wantAccepted: []string{"public_repo", "repo"}, // repo includes public_repo
+		},
+		{
+			name:         "scope with parent - read:org",
+			required:     []Scope{ReadOrg},
+			wantRequired: []string{"read:org"},
+			wantAccepted: []string{"read:org", "write:org", "admin:org"},
+		},
+		{
+			name:         "multiple scopes",
+			required:     []Scope{Repo, Notifications},
+			wantRequired: []string{"repo", "notifications"},
+			wantAccepted: []string{"repo", "notifications"},
+		},
+		{
+			name:         "scope with deep hierarchy - read:repo_hook",
+			required:     []Scope{ReadRepoHook},
+			wantRequired: []string{"read:repo_hook"},
+			wantAccepted: []string{"read:repo_hook", "write:repo_hook", "admin:repo_hook"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := NewToolScopeInfo(tt.required)
+
+			// Check required scopes
+			for _, scope := range tt.wantRequired {
+				assert.True(t, info.RequiredScopes.Contains(scope),
+					"expected required scope %s to be present", scope)
+			}
+			assert.Equal(t, len(tt.wantRequired), len(info.RequiredScopes),
+				"unexpected number of required scopes")
+
+			// Check accepted scopes
+			for _, scope := range tt.wantAccepted {
+				assert.True(t, info.AcceptedScopes.Contains(scope),
+					"expected accepted scope %s to be present", scope)
+			}
+
+			// Check not accepted scopes
+			for _, scope := range tt.wantNotAccepted {
+				assert.False(t, info.AcceptedScopes.Contains(scope),
+					"expected scope %s to NOT be accepted", scope)
+			}
+		})
+	}
+}
+
+func TestToolScopeInfoHasAcceptedScope(t *testing.T) {
+	tests := []struct {
+		name       string
+		required   []Scope
+		userScopes []string
+		want       bool
+	}{
+		{
+			name:       "no requirements - always passes",
+			required:   []Scope{},
+			userScopes: []string{},
+			want:       true,
+		},
+		{
+			name:       "has exact required scope",
+			required:   []Scope{Repo},
+			userScopes: []string{"repo"},
+			want:       true,
+		},
+		{
+			name:       "missing required scope",
+			required:   []Scope{Repo},
+			userScopes: []string{"gist"},
+			want:       false,
+		},
+		{
+			name:       "has parent scope - repo satisfies public_repo",
+			required:   []Scope{PublicRepo},
+			userScopes: []string{"repo"},
+			want:       true,
+		},
+		{
+			name:       "has parent scope - admin:org satisfies read:org",
+			required:   []Scope{ReadOrg},
+			userScopes: []string{"admin:org"},
+			want:       true,
+		},
+		{
+			name:       "has one of multiple user scopes",
+			required:   []Scope{Repo},
+			userScopes: []string{"gist", "repo", "user"},
+			want:       true,
+		},
+		{
+			name:       "empty user scopes - fails",
+			required:   []Scope{Repo},
+			userScopes: []string{},
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := NewToolScopeInfo(tt.required)
+			got := info.HasAcceptedScope(tt.userScopes...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToolScopeInfoMissingScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		required   []Scope
+		userScopes []string
+		want       []string
+	}{
+		{
+			name:       "no requirements",
+			required:   []Scope{},
+			userScopes: []string{},
+			want:       nil,
+		},
+		{
+			name:       "all satisfied",
+			required:   []Scope{Repo},
+			userScopes: []string{"repo"},
+			want:       nil,
+		},
+		{
+			name:       "missing repo",
+			required:   []Scope{Repo},
+			userScopes: []string{"gist"},
+			want:       []string{"repo"},
+		},
+		{
+			name:       "satisfied by parent scope",
+			required:   []Scope{ReadOrg},
+			userScopes: []string{"admin:org"},
+			want:       nil,
+		},
+		{
+			name:       "multiple missing",
+			required:   []Scope{Repo, Notifications},
+			userScopes: []string{"gist"},
+			want:       []string{"repo", "notifications"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := NewToolScopeInfo(tt.required)
+			got := info.MissingScopes(tt.userScopes...)
+
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.ElementsMatch(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBuildToolScopeMapFromMeta(t *testing.T) {
+	tools := []ToolMeta{
+		{
+			Name: "get_repo",
+			Meta: WithScopes(Repo),
+		},
+		{
+			Name: "create_gist",
+			Meta: WithScopes(Gist),
+		},
+		{
+			Name: "get_user",
+			Meta: nil, // no scopes
+		},
+	}
+
+	scopeMap := BuildToolScopeMapFromMeta(tools)
+
+	require.Len(t, scopeMap, 3)
+
+	// Check get_repo
+	repoInfo, ok := scopeMap["get_repo"]
+	require.True(t, ok)
+	assert.True(t, repoInfo.RequiredScopes.Contains("repo"))
+	assert.True(t, repoInfo.HasAcceptedScope("repo"))
+
+	// Check create_gist
+	gistInfo, ok := scopeMap["create_gist"]
+	require.True(t, ok)
+	assert.True(t, gistInfo.RequiredScopes.Contains("gist"))
+	assert.True(t, gistInfo.HasAcceptedScope("gist"))
+	assert.False(t, gistInfo.HasAcceptedScope("repo"))
+
+	// Check get_user (no scopes)
+	userInfo, ok := scopeMap["get_user"]
+	require.True(t, ok)
+	assert.Empty(t, userInfo.RequiredScopes)
+	assert.True(t, userInfo.HasAcceptedScope()) // no requirements always passes
+}
+
+func TestGetToolScopeInfo(t *testing.T) {
+	meta := WithScopes(Repo, Notifications)
+	info := GetToolScopeInfo(meta)
+
+	assert.True(t, info.RequiredScopes.Contains("repo"))
+	assert.True(t, info.RequiredScopes.Contains("notifications"))
+	assert.True(t, info.HasAcceptedScope("repo", "notifications"))
+}
+
+func TestToolScopeMapAllRequiredScopes(t *testing.T) {
+	tools := []ToolMeta{
+		{Name: "tool1", Meta: WithScopes(Repo)},
+		{Name: "tool2", Meta: WithScopes(Gist)},
+		{Name: "tool3", Meta: WithScopes(Repo, Notifications)},
+		{Name: "tool4", Meta: nil}, // no scopes
+	}
+
+	scopeMap := BuildToolScopeMapFromMeta(tools)
+	allRequired := scopeMap.AllRequiredScopes()
+
+	assert.True(t, allRequired.Contains("repo"))
+	assert.True(t, allRequired.Contains("gist"))
+	assert.True(t, allRequired.Contains("notifications"))
+	assert.False(t, allRequired.Contains("user"))
+}
+
+func TestToolScopeMapToolsRequiringScope(t *testing.T) {
+	tools := []ToolMeta{
+		{Name: "tool1", Meta: WithScopes(Repo)},
+		{Name: "tool2", Meta: WithScopes(Gist)},
+		{Name: "tool3", Meta: WithScopes(Repo, Notifications)},
+	}
+
+	scopeMap := BuildToolScopeMapFromMeta(tools)
+
+	repoTools := scopeMap.ToolsRequiringScope("repo")
+	assert.ElementsMatch(t, []string{"tool1", "tool3"}, repoTools)
+
+	gistTools := scopeMap.ToolsRequiringScope("gist")
+	assert.ElementsMatch(t, []string{"tool2"}, gistTools)
+
+	userTools := scopeMap.ToolsRequiringScope("user")
+	assert.Empty(t, userTools)
+}
+
+func TestToolScopeMapToolsAcceptingScope(t *testing.T) {
+	tools := []ToolMeta{
+		{Name: "tool1", Meta: WithScopes(PublicRepo)}, // accepts repo too
+		{Name: "tool2", Meta: WithScopes(ReadOrg)},    // accepts write:org and admin:org too
+	}
+
+	scopeMap := BuildToolScopeMapFromMeta(tools)
+
+	// public_repo is required but repo is also accepted
+	repoAccepting := scopeMap.ToolsAcceptingScope("repo")
+	assert.Contains(t, repoAccepting, "tool1")
+
+	// read:org is required but admin:org is also accepted
+	adminOrgAccepting := scopeMap.ToolsAcceptingScope("admin:org")
+	assert.Contains(t, adminOrgAccepting, "tool2")
+}


### PR DESCRIPTION
## Summary
Adds exported types and functions in `pkg/scopes` for library users who need fast OAuth scope lookups at runtime.

Part 4 (final) of the OAuth scopes work:
- PR #1485: Phase 1 - OAuth scopes on tool metadata
- PR #1486: Phase 2 - Fine-grained permissions documentation  
- PR #1487: Phase 3 - list-scopes command
- **This PR: Phase 4 - Exported ToolScopeMap for library use**

## Changes
- Add `pkg/scopes/tool_scope_map.go` - exported types and functions
- Add `pkg/scopes/tool_scope_map_test.go` - comprehensive tests

## Exported Types

### `ToolScopeMap` 
`map[string]*ToolScopeInfo` for tool name -> scopes lookup

### `ToolScopeInfo`
Contains `RequiredScopes` and `AcceptedScopes` as `ScopeSet`

### `ScopeSet`
`map[string]bool` for O(1) scope lookup performance

## Key Functions

- `BuildToolScopeMapFromMeta(tools []ToolMeta)` - builds map from tool definitions
- `NewToolScopeInfo(required []Scope)` - creates info from required scopes, auto-calculates accepted scopes
- `GetToolScopeInfo(meta map[string]any)` - creates info from tool Meta field

## Key Methods

- `ToolScopeInfo.HasAcceptedScope(userScopes ...string)` - checks if token has access
- `ToolScopeInfo.MissingScopes(userScopes ...string)` - returns missing required scopes
- `ToolScopeMap.AllRequiredScopes()` - returns all unique required scopes
- `ToolScopeMap.ToolsRequiringScope(scope)` - returns tools that require a scope
- `ToolScopeMap.ToolsAcceptingScope(scope)` - returns tools that accept a scope

## Usage Example

```go
import "github.com/github/github-mcp-server/pkg/scopes"

// Build scope map from tool definitions
tools := []scopes.ToolMeta{
    {Name: "get_repo", Meta: someToolMeta},
    {Name: "create_issue", Meta: anotherToolMeta},
}
scopeMap := scopes.BuildToolScopeMapFromMeta(tools)

// Check if user's token can use a tool
if info, ok := scopeMap["create_issue"]; ok {
    userScopes := []string{"repo", "user"}
    if info.HasAcceptedScope(userScopes...) {
        // User can use this tool
    } else {
        missing := info.MissingScopes(userScopes...)
        fmt.Printf("Missing scopes: %v\n", missing)
    }
}

// Get all required scopes
allRequired := scopeMap.AllRequiredScopes()
fmt.Printf("All required: %v\n", allRequired.ToSlice())
```

## Design Decisions

- **ScopeSet uses `map[string]bool`** - O(1) lookup performance for production environments
- **AcceptedScopes includes parent scopes** - If a tool requires `public_repo`, `repo` is also accepted due to hierarchy
- **Functions work with minimal interfaces** - `ToolMeta` struct only requires `Name` and `Meta` fields

## Testing
- `script/lint` - 0 issues
- `script/test` - All tests pass