### PR TITLE
Check if the tool is _NOT_ read only before skipping it in read-only mode

### DIFF
--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -325,7 +325,7 @@ func (tg *ToolsetGroup) RegisterSpecificTools(s *mcp.Server, toolNames []string,
 			return fmt.Errorf("tool %s not found: %w", toolName, err)
 		}
 
-		if tool.Tool.Annotations.ReadOnlyHint && readOnly {
+		if !tool.Tool.Annotations.ReadOnlyHint && readOnly {
 			// Skip write tools in read-only mode
 			skippedTools = append(skippedTools, toolName)
 			continue


### PR DESCRIPTION
Previously these were pointers to a Bool, now they are concrete types and this was incorrectly ported in the Go SDK move.

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
