### PR TITLE
Add create_discussion tool to discussions toolset

### DIFF
--- a/pkg/github/__toolsnaps__/create_discussion.snap
+++ b/pkg/github/__toolsnaps__/create_discussion.snap
@@ -1,0 +1,38 @@
+{
+  "annotations": {
+    "title": "Create discussion"
+  },
+  "description": "Create a new discussion in a repository or organisation.",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "Discussion body text in markdown format",
+        "type": "string"
+      },
+      "categoryId": {
+        "description": "Category ID where the discussion should be created (obtainable via list_discussion_categories)",
+        "type": "string"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name. If not provided, the discussion will be created at the organisation level.",
+        "type": "string"
+      },
+      "title": {
+        "description": "Discussion title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "categoryId",
+      "title",
+      "body"
+    ],
+    "type": "object"
+  },
+  "name": "create_discussion"
+}


### PR DESCRIPTION
Closes #1517

This PR adds a new `create_discussion` tool to the discussions toolset, enabling programmatic creation of GitHub Discussions through the MCP server.

## Changes

- Added `CreateDiscussion` function in `pkg/github/discussions.go` using GraphQL mutation
- Implemented comprehensive unit tests covering success and error scenarios
- Updated discussions toolset to include the new write tool
- Generated toolsnap for schema validation

## Testing

- All existing tests pass
- New tests cover:
  - Successful discussion creation
  - Organization-level discussions
  - Missing parameter validation
  - Repository and category not found errors
- Linter passes with no issues
- Documentation generated via `script/generate-docs`

The tool follows existing patterns in the codebase and integrates cleanly with the current discussions toolset structure.