### PR TITLE
fix: include empty properties in get_me schema for OpenAI compatibility

### DIFF
--- a/pkg/github/__toolsnaps__/get_me.snap
+++ b/pkg/github/__toolsnaps__/get_me.snap
@@ -5,7 +5,8 @@
   },
   "description": "Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.",
   "inputSchema": {
-    "type": "object"
+    "type": "object",
+    "properties": {}
   },
   "name": "get_me"
 }

--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
@@ -43,9 +44,9 @@ func GetMe(getClient GetClientFn, t translations.TranslationHelperFunc) (mcp.Too
 				Title:        t("TOOL_GET_ME_USER_TITLE", "Get my user profile"),
 				ReadOnlyHint: true,
 			},
-			InputSchema: &jsonschema.Schema{
-				Type: "object",
-			},
+			// Use json.RawMessage to ensure "properties" is included even when empty.
+			// OpenAI strict mode requires the properties field to be present.
+			InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
 		},
 		mcp.ToolHandlerFor[map[string]any, any](func(ctx context.Context, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
 			client, err := getClient(ctx)


### PR DESCRIPTION
Closes https://github.com/github/github-mcp-server/pull/1553

## Summary

OpenAI strict mode requires the `properties` field to be present in object schemas, even when empty. The `get_me` tool has no input parameters, so its schema was `{"type": "object"}` without a `properties` field.

## Problem

The `jsonschema` library's `Schema` struct uses `omitempty` JSON tags, causing empty maps to be omitted during JSON serialization. Even when setting `Properties: map[string]*jsonschema.Schema{}`, the output remains `{"type": "object"}`.

Error from OpenAI:
```
Error code: 400 - {'error': {'message': "Invalid schema for function 'get_me': In context=(), object schema missing properties.", 'type': 'invalid_request_error', 'param': 'tools[13].function.parameters', 'code': 'invalid_function_parameters'}}
```

## Solution

Use `json.RawMessage` to bypass the library's serialization and explicitly include `"properties": {}` in the output:

```go
InputSchema: json.RawMessage(`{"type":"object","properties":{}}`)
```

This ensures OpenAI strict mode compatibility while maintaining the same logical schema.

## Testing

- ✅ `script/lint` - 0 issues
- ✅ `script/test` - all tests pass
- ✅ Toolsnap updated to reflect new schema with `"properties": {}`

Fixes #1548