### PR TITLE
Trim leading slash in path parameter

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -402,6 +402,8 @@ func CreateOrUpdateFile(getClient GetClientFn, t translations.TranslationHelperF
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
 		}
+
+		path = strings.TrimPrefix(path, "/")
 		fileContent, resp, err := client.Repositories.CreateFile(ctx, owner, repo, path, opts)
 		if err != nil {
 			return ghErrors.NewGitHubAPIErrorResponse(ctx,


### PR DESCRIPTION
Sometimes path is passed with leading slash. We can auto-correct to make sure we do not get unnecessary tool call failures.
