### PR TITLE
Add repos toolset instructions

### DIFF
--- a/pkg/github/instructions.go
+++ b/pkg/github/instructions.go
@@ -50,6 +50,11 @@ Tool usage guidance:
 // getToolsetInstructions returns specific instructions for individual toolsets
 func getToolsetInstructions(toolset string, enabledToolsets []string) string {
 	switch toolset {
+	case "repos":
+		return `## Repositories
+
+Before updating an existing file, always call 'get_file_contents' to retrieve the SHA of the file blob. Use this SHA as the "sha" parameter in create_or_update_file tool call to avoid conflicts.
+		`
 	case "pull_requests":
 		pullRequestInstructions := `## Pull Requests
 


### PR DESCRIPTION
Adds server instructions for `repos` toolset that tells a model to retrieve file sha before updating it. This should help decrease the amount of `"sha" wasn't supplied.` errors.