### PR TITLE
Docs: Remove stale Claude Web references from installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 
 ### Install in other MCP hosts
 - **[GitHub Copilot in other IDEs](/docs/installation-guides/install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
-- **[Claude Applications](/docs/installation-guides/install-claude.md)** - Installation guide for Claude Web, Claude Desktop and Claude Code CLI
+- **[Claude Applications](/docs/installation-guides/install-claude.md)** - Installation guide for Claude Desktop and Claude Code CLI
 - **[Cursor](/docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE
 - **[Windsurf](/docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
 

--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -4,7 +4,7 @@ This directory contains detailed installation instructions for the GitHub MCP Se
 
 ## Installation Guides by Host Application
 - **[GitHub Copilot in other IDEs](install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
-- **[Claude Applications](install-claude.md)** - Installation guide for Claude Web, Claude Desktop and Claude Code CLI
+- **[Claude Applications](install-claude.md)** - Installation guide for Claude Desktop and Claude Code CLI
 - **[Cursor](install-cursor.md)** - Installation guide for Cursor IDE
 - **[Google Gemini CLI](install-gemini-cli.md)** - Installation guide for Google Gemini CLI
 - **[OpenAI Codex](install-codex.md)** - Installation guide for OpenAI Codex


### PR DESCRIPTION
The "Claude Web" in "Installation guide for Claude Web, Claude Desktop and Claude Code CLI" is misleading because `install-claude.md` makes no mention of Claude Web at all.

Actually, that file used to mention Claude Web, but only mentions that it doesn’t work due to “known compatibility issues” with the remote GitHub MCP Server. In commit 96a705c that section has been removed. However, the stale references remain.

Since Claude Web only supports remote MCP servers and the remote server doesn't work with it, mentioning it in the installation documentation is misleading and should be removed.

This PR:

- Removed "Claude Web" from the Claude Applications installation guide description in `README.md`
- Removed "Claude Web" from the Claude Applications installation guide description in `docs/installation-guides/README.md`