### PR TITLE
fix: remove unnecessary type arguments in helper_test.go

### DIFF
--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -216,7 +216,7 @@ func TestOptionalParamOK(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test with string type assertion
 			if _, isString := tc.expectedVal.(string); isString || tc.errorMsg == "parameter myParam is not of type string, is bool" {
-				val, ok, err := OptionalParamOK[string, map[string]any](tc.args, tc.paramName)
+				val, ok, err := OptionalParamOK[string](tc.args, tc.paramName)
 				if tc.expectError {
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), tc.errorMsg)
@@ -231,7 +231,7 @@ func TestOptionalParamOK(t *testing.T) {
 
 			// Test with bool type assertion
 			if _, isBool := tc.expectedVal.(bool); isBool || tc.errorMsg == "parameter myParam is not of type bool, is string" {
-				val, ok, err := OptionalParamOK[bool, map[string]any](tc.args, tc.paramName)
+				val, ok, err := OptionalParamOK[bool](tc.args, tc.paramName)
 				if tc.expectError {
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), tc.errorMsg)
@@ -246,7 +246,7 @@ func TestOptionalParamOK(t *testing.T) {
 
 			// Test with float64 type assertion (for number case)
 			if _, isFloat := tc.expectedVal.(float64); isFloat {
-				val, ok, err := OptionalParamOK[float64, map[string]any](tc.args, tc.paramName)
+				val, ok, err := OptionalParamOK[float64](tc.args, tc.paramName)
 				if tc.expectError {
 					// This case shouldn't happen for float64 in the defined tests
 					require.Fail(t, "Unexpected error case for float64")


### PR DESCRIPTION
Removes unnecessary explicit type arguments from `OptionalParamOK` calls in `helper_test.go`.

Go can infer the second type parameter (`map[string]any`) automatically, so specifying it explicitly triggers the `infertypeargs` lint warning about unnecessary type arguments.

## Changes
- Line 219: `OptionalParamOK[string, map[string]any]` → `OptionalParamOK[string]`
- Line 234: `OptionalParamOK[bool, map[string]any]` → `OptionalParamOK[bool]`  
- Line 249: `OptionalParamOK[float64, map[string]any]` → `OptionalParamOK[float64]`