### PR TITLE
refactor: inject deps via context instead of closures

### DIFF
--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -50,47 +50,45 @@ func ListWorkflows(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo"},
 			}),
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get optional pagination parameters
-				pagination, err := OptionalPaginationParams(args)
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Set up list options
-				opts := &github.ListOptions{
-					PerPage: pagination.PerPage,
-					Page:    pagination.Page,
-				}
-
-				workflows, resp, err := client.Actions.ListWorkflows(ctx, owner, repo, opts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to list workflows: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				r, err := json.Marshal(workflows)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get optional pagination parameters
+			pagination, err := OptionalPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Set up list options
+			opts := &github.ListOptions{
+				PerPage: pagination.PerPage,
+				Page:    pagination.Page,
+			}
+
+			workflows, resp, err := client.Actions.ListWorkflows(ctx, owner, repo, opts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to list workflows: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			r, err := json.Marshal(workflows)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -176,75 +174,73 @@ func ListWorkflowRuns(t translations.TranslationHelperFunc) inventory.ServerTool
 				Required: []string{"owner", "repo", "workflow_id"},
 			}),
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				workflowID, err := RequiredParam[string](args, "workflow_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get optional filtering parameters
-				actor, err := OptionalParam[string](args, "actor")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				branch, err := OptionalParam[string](args, "branch")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				event, err := OptionalParam[string](args, "event")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				status, err := OptionalParam[string](args, "status")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get optional pagination parameters
-				pagination, err := OptionalPaginationParams(args)
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Set up list options
-				opts := &github.ListWorkflowRunsOptions{
-					Actor:  actor,
-					Branch: branch,
-					Event:  event,
-					Status: status,
-					ListOptions: github.ListOptions{
-						PerPage: pagination.PerPage,
-						Page:    pagination.Page,
-					},
-				}
-
-				workflowRuns, resp, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowID, opts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to list workflow runs: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				r, err := json.Marshal(workflowRuns)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			workflowID, err := RequiredParam[string](args, "workflow_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get optional filtering parameters
+			actor, err := OptionalParam[string](args, "actor")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			branch, err := OptionalParam[string](args, "branch")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			event, err := OptionalParam[string](args, "event")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			status, err := OptionalParam[string](args, "status")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get optional pagination parameters
+			pagination, err := OptionalPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Set up list options
+			opts := &github.ListWorkflowRunsOptions{
+				Actor:  actor,
+				Branch: branch,
+				Event:  event,
+				Status: status,
+				ListOptions: github.ListOptions{
+					PerPage: pagination.PerPage,
+					Page:    pagination.Page,
+				},
+			}
+
+			workflowRuns, resp, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowID, opts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to list workflow runs: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			r, err := json.Marshal(workflowRuns)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -287,76 +283,74 @@ func RunWorkflow(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo", "workflow_id", "ref"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				workflowID, err := RequiredParam[string](args, "workflow_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				ref, err := RequiredParam[string](args, "ref")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get optional inputs parameter
-				var inputs map[string]interface{}
-				if requestInputs, ok := args["inputs"]; ok {
-					if inputsMap, ok := requestInputs.(map[string]interface{}); ok {
-						inputs = inputsMap
-					}
-				}
-
-				event := github.CreateWorkflowDispatchEventRequest{
-					Ref:    ref,
-					Inputs: inputs,
-				}
-
-				var resp *github.Response
-				var workflowType string
-
-				if workflowIDInt, parseErr := strconv.ParseInt(workflowID, 10, 64); parseErr == nil {
-					resp, err = client.Actions.CreateWorkflowDispatchEventByID(ctx, owner, repo, workflowIDInt, event)
-					workflowType = "workflow_id"
-				} else {
-					resp, err = client.Actions.CreateWorkflowDispatchEventByFileName(ctx, owner, repo, workflowID, event)
-					workflowType = "workflow_file"
-				}
-
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to run workflow: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				result := map[string]any{
-					"message":       "Workflow run has been queued",
-					"workflow_type": workflowType,
-					"workflow_id":   workflowID,
-					"ref":           ref,
-					"inputs":        inputs,
-					"status":        resp.Status,
-					"status_code":   resp.StatusCode,
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			workflowID, err := RequiredParam[string](args, "workflow_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			ref, err := RequiredParam[string](args, "ref")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get optional inputs parameter
+			var inputs map[string]interface{}
+			if requestInputs, ok := args["inputs"]; ok {
+				if inputsMap, ok := requestInputs.(map[string]interface{}); ok {
+					inputs = inputsMap
+				}
+			}
+
+			event := github.CreateWorkflowDispatchEventRequest{
+				Ref:    ref,
+				Inputs: inputs,
+			}
+
+			var resp *github.Response
+			var workflowType string
+
+			if workflowIDInt, parseErr := strconv.ParseInt(workflowID, 10, 64); parseErr == nil {
+				resp, err = client.Actions.CreateWorkflowDispatchEventByID(ctx, owner, repo, workflowIDInt, event)
+				workflowType = "workflow_id"
+			} else {
+				resp, err = client.Actions.CreateWorkflowDispatchEventByFileName(ctx, owner, repo, workflowID, event)
+				workflowType = "workflow_file"
+			}
+
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to run workflow: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			result := map[string]any{
+				"message":       "Workflow run has been queued",
+				"workflow_type": workflowType,
+				"workflow_id":   workflowID,
+				"ref":           ref,
+				"inputs":        inputs,
+				"status":        resp.Status,
+				"status_code":   resp.StatusCode,
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -391,40 +385,38 @@ func GetWorkflowRun(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo", "run_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				workflowRun, resp, err := client.Actions.GetWorkflowRunByID(ctx, owner, repo, runID)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get workflow run: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				r, err := json.Marshal(workflowRun)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			workflowRun, resp, err := client.Actions.GetWorkflowRunByID(ctx, owner, repo, runID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get workflow run: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			r, err := json.Marshal(workflowRun)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -459,50 +451,48 @@ func GetWorkflowRunLogs(t translations.TranslationHelperFunc) inventory.ServerTo
 				Required: []string{"owner", "repo", "run_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				// Get the download URL for the logs
-				url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, owner, repo, runID, 1)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get workflow run logs: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				// Create response with the logs URL and information
-				result := map[string]any{
-					"logs_url":         url.String(),
-					"message":          "Workflow run logs are available for download",
-					"note":             "The logs_url provides a download link for the complete workflow run logs as a ZIP archive. You can download this archive to extract and examine individual job logs.",
-					"warning":          "This downloads ALL logs as a ZIP file which can be large and expensive. For debugging failed jobs, consider using get_job_logs with failed_only=true and run_id instead.",
-					"optimization_tip": "Use: get_job_logs with parameters {run_id: " + fmt.Sprintf("%d", runID) + ", failed_only: true} for more efficient failed job debugging",
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			// Get the download URL for the logs
+			url, resp, err := client.Actions.GetWorkflowRunLogs(ctx, owner, repo, runID, 1)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get workflow run logs: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			// Create response with the logs URL and information
+			result := map[string]any{
+				"logs_url":         url.String(),
+				"message":          "Workflow run logs are available for download",
+				"note":             "The logs_url provides a download link for the complete workflow run logs as a ZIP archive. You can download this archive to extract and examine individual job logs.",
+				"warning":          "This downloads ALL logs as a ZIP file which can be large and expensive. For debugging failed jobs, consider using get_job_logs with failed_only=true and run_id instead.",
+				"optimization_tip": "Use: get_job_logs with parameters {run_id: " + fmt.Sprintf("%d", runID) + ", failed_only: true} for more efficient failed job debugging",
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -542,67 +532,65 @@ func ListWorkflowJobs(t translations.TranslationHelperFunc) inventory.ServerTool
 				Required: []string{"owner", "repo", "run_id"},
 			}),
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				// Get optional filtering parameters
-				filter, err := OptionalParam[string](args, "filter")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get optional pagination parameters
-				pagination, err := OptionalPaginationParams(args)
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Set up list options
-				opts := &github.ListWorkflowJobsOptions{
-					Filter: filter,
-					ListOptions: github.ListOptions{
-						PerPage: pagination.PerPage,
-						Page:    pagination.Page,
-					},
-				}
-
-				jobs, resp, err := client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to list workflow jobs: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				// Add optimization tip for failed job debugging
-				response := map[string]any{
-					"jobs":             jobs,
-					"optimization_tip": "For debugging failed jobs, consider using get_job_logs with failed_only=true and run_id=" + fmt.Sprintf("%d", runID) + " to get logs directly without needing to list jobs first",
-				}
-
-				r, err := json.Marshal(response)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			// Get optional filtering parameters
+			filter, err := OptionalParam[string](args, "filter")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get optional pagination parameters
+			pagination, err := OptionalPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Set up list options
+			opts := &github.ListWorkflowJobsOptions{
+				Filter: filter,
+				ListOptions: github.ListOptions{
+					PerPage: pagination.PerPage,
+					Page:    pagination.Page,
+				},
+			}
+
+			jobs, resp, err := client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to list workflow jobs: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			// Add optimization tip for failed job debugging
+			response := map[string]any{
+				"jobs":             jobs,
+				"optimization_tip": "For debugging failed jobs, consider using get_job_logs with failed_only=true and run_id=" + fmt.Sprintf("%d", runID) + " to get logs directly without needing to list jobs first",
+			}
+
+			r, err := json.Marshal(response)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -654,66 +642,64 @@ func GetJobLogs(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get optional parameters
-				jobID, err := OptionalIntParam(args, "job_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID, err := OptionalIntParam(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				failedOnly, err := OptionalParam[bool](args, "failed_only")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				returnContent, err := OptionalParam[bool](args, "return_content")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				tailLines, err := OptionalIntParam(args, "tail_lines")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				// Default to 500 lines if not specified
-				if tailLines == 0 {
-					tailLines = 500
-				}
-
-				// Validate parameters
-				if failedOnly && runID == 0 {
-					return utils.NewToolResultError("run_id is required when failed_only is true"), nil, nil
-				}
-				if !failedOnly && jobID == 0 {
-					return utils.NewToolResultError("job_id is required when failed_only is false"), nil, nil
-				}
-
-				if failedOnly && runID > 0 {
-					// Handle failed-only mode: get logs for all failed jobs in the workflow run
-					return handleFailedJobLogs(ctx, client, owner, repo, int64(runID), returnContent, tailLines, deps.GetContentWindowSize())
-				} else if jobID > 0 {
-					// Handle single job mode
-					return handleSingleJobLogs(ctx, client, owner, repo, int64(jobID), returnContent, tailLines, deps.GetContentWindowSize())
-				}
-
-				return utils.NewToolResultError("Either job_id must be provided for single job logs, or run_id with failed_only=true for failed job logs"), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get optional parameters
+			jobID, err := OptionalIntParam(args, "job_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID, err := OptionalIntParam(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			failedOnly, err := OptionalParam[bool](args, "failed_only")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			returnContent, err := OptionalParam[bool](args, "return_content")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			tailLines, err := OptionalIntParam(args, "tail_lines")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			// Default to 500 lines if not specified
+			if tailLines == 0 {
+				tailLines = 500
+			}
+
+			// Validate parameters
+			if failedOnly && runID == 0 {
+				return utils.NewToolResultError("run_id is required when failed_only is true"), nil, nil
+			}
+			if !failedOnly && jobID == 0 {
+				return utils.NewToolResultError("job_id is required when failed_only is false"), nil, nil
+			}
+
+			if failedOnly && runID > 0 {
+				// Handle failed-only mode: get logs for all failed jobs in the workflow run
+				return handleFailedJobLogs(ctx, client, owner, repo, int64(runID), returnContent, tailLines, deps.GetContentWindowSize())
+			} else if jobID > 0 {
+				// Handle single job mode
+				return handleSingleJobLogs(ctx, client, owner, repo, int64(jobID), returnContent, tailLines, deps.GetContentWindowSize())
+			}
+
+			return utils.NewToolResultError("Either job_id must be provided for single job logs, or run_id with failed_only=true for failed job logs"), nil, nil
 		},
 	)
 }
@@ -902,47 +888,45 @@ func RerunWorkflowRun(t translations.TranslationHelperFunc) inventory.ServerTool
 				Required: []string{"owner", "repo", "run_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				resp, err := client.Actions.RerunWorkflowByID(ctx, owner, repo, runID)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to rerun workflow run", resp, err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				result := map[string]any{
-					"message":     "Workflow run has been queued for re-run",
-					"run_id":      runID,
-					"status":      resp.Status,
-					"status_code": resp.StatusCode,
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			resp, err := client.Actions.RerunWorkflowByID(ctx, owner, repo, runID)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to rerun workflow run", resp, err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			result := map[string]any{
+				"message":     "Workflow run has been queued for re-run",
+				"run_id":      runID,
+				"status":      resp.Status,
+				"status_code": resp.StatusCode,
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -977,47 +961,45 @@ func RerunFailedJobs(t translations.TranslationHelperFunc) inventory.ServerTool 
 				Required: []string{"owner", "repo", "run_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				resp, err := client.Actions.RerunFailedJobsByID(ctx, owner, repo, runID)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to rerun failed jobs", resp, err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				result := map[string]any{
-					"message":     "Failed jobs have been queued for re-run",
-					"run_id":      runID,
-					"status":      resp.Status,
-					"status_code": resp.StatusCode,
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			resp, err := client.Actions.RerunFailedJobsByID(ctx, owner, repo, runID)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to rerun failed jobs", resp, err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			result := map[string]any{
+				"message":     "Failed jobs have been queued for re-run",
+				"run_id":      runID,
+				"status":      resp.Status,
+				"status_code": resp.StatusCode,
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -1052,49 +1034,47 @@ func CancelWorkflowRun(t translations.TranslationHelperFunc) inventory.ServerToo
 				Required: []string{"owner", "repo", "run_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				resp, err := client.Actions.CancelWorkflowRunByID(ctx, owner, repo, runID)
-				if err != nil {
-					if _, ok := err.(*github.AcceptedError); !ok {
-						return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to cancel workflow run", resp, err), nil, nil
-					}
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				result := map[string]any{
-					"message":     "Workflow run has been cancelled",
-					"run_id":      runID,
-					"status":      resp.Status,
-					"status_code": resp.StatusCode,
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			resp, err := client.Actions.CancelWorkflowRunByID(ctx, owner, repo, runID)
+			if err != nil {
+				if _, ok := err.(*github.AcceptedError); !ok {
+					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to cancel workflow run", resp, err), nil, nil
+				}
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			result := map[string]any{
+				"message":     "Workflow run has been cancelled",
+				"run_id":      runID,
+				"status":      resp.Status,
+				"status_code": resp.StatusCode,
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -1129,52 +1109,50 @@ func ListWorkflowRunArtifacts(t translations.TranslationHelperFunc) inventory.Se
 				Required: []string{"owner", "repo", "run_id"},
 			}),
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				// Get optional pagination parameters
-				pagination, err := OptionalPaginationParams(args)
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Set up list options
-				opts := &github.ListOptions{
-					PerPage: pagination.PerPage,
-					Page:    pagination.Page,
-				}
-
-				artifacts, resp, err := client.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, runID, opts)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to list workflow run artifacts", resp, err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				r, err := json.Marshal(artifacts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			// Get optional pagination parameters
+			pagination, err := OptionalPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Set up list options
+			opts := &github.ListOptions{
+				PerPage: pagination.PerPage,
+				Page:    pagination.Page,
+			}
+
+			artifacts, resp, err := client.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, runID, opts)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to list workflow run artifacts", resp, err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			r, err := json.Marshal(artifacts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -1209,49 +1187,47 @@ func DownloadWorkflowRunArtifact(t translations.TranslationHelperFunc) inventory
 				Required: []string{"owner", "repo", "artifact_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				artifactIDInt, err := RequiredInt(args, "artifact_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				artifactID := int64(artifactIDInt)
-
-				// Get the download URL for the artifact
-				url, resp, err := client.Actions.DownloadArtifact(ctx, owner, repo, artifactID, 1)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to get artifact download URL", resp, err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				// Create response with the download URL and information
-				result := map[string]any{
-					"download_url": url.String(),
-					"message":      "Artifact is available for download",
-					"note":         "The download_url provides a download link for the artifact as a ZIP archive. The link is temporary and expires after a short time.",
-					"artifact_id":  artifactID,
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			artifactIDInt, err := RequiredInt(args, "artifact_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			artifactID := int64(artifactIDInt)
+
+			// Get the download URL for the artifact
+			url, resp, err := client.Actions.DownloadArtifact(ctx, owner, repo, artifactID, 1)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to get artifact download URL", resp, err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			// Create response with the download URL and information
+			result := map[string]any{
+				"download_url": url.String(),
+				"message":      "Artifact is available for download",
+				"note":         "The download_url provides a download link for the artifact as a ZIP archive. The link is temporary and expires after a short time.",
+				"artifact_id":  artifactID,
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -1287,47 +1263,45 @@ func DeleteWorkflowRunLogs(t translations.TranslationHelperFunc) inventory.Serve
 				Required: []string{"owner", "repo", "run_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				resp, err := client.Actions.DeleteWorkflowRunLogs(ctx, owner, repo, runID)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to delete workflow run logs", resp, err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				result := map[string]any{
-					"message":     "Workflow run logs have been deleted",
-					"run_id":      runID,
-					"status":      resp.Status,
-					"status_code": resp.StatusCode,
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			resp, err := client.Actions.DeleteWorkflowRunLogs(ctx, owner, repo, runID)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to delete workflow run logs", resp, err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			result := map[string]any{
+				"message":     "Workflow run logs have been deleted",
+				"run_id":      runID,
+				"status":      resp.Status,
+				"status_code": resp.StatusCode,
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -1362,40 +1336,38 @@ func GetWorkflowRunUsage(t translations.TranslationHelperFunc) inventory.ServerT
 				Required: []string{"owner", "repo", "run_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runIDInt, err := RequiredInt(args, "run_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				runID := int64(runIDInt)
-
-				usage, resp, err := client.Actions.GetWorkflowRunUsageByID(ctx, owner, repo, runID)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to get workflow run usage", resp, err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				r, err := json.Marshal(usage)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runIDInt, err := RequiredInt(args, "run_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			runID := int64(runIDInt)
+
+			usage, resp, err := client.Actions.GetWorkflowRunUsageByID(ctx, owner, repo, runID)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to get workflow run usage", resp, err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			r, err := json.Marshal(usage)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -114,7 +114,7 @@ func Test_ListWorkflows(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -203,7 +203,7 @@ func Test_RunWorkflow(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -299,7 +299,7 @@ func Test_RunWorkflow_WithFilename(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -407,7 +407,7 @@ func Test_CancelWorkflowRun(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -537,7 +537,7 @@ func Test_ListWorkflowRunArtifacts(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -627,7 +627,7 @@ func Test_DownloadWorkflowRunArtifact(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -713,7 +713,7 @@ func Test_DeleteWorkflowRunLogs(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -817,7 +817,7 @@ func Test_GetWorkflowRunUsage(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -1082,7 +1082,7 @@ func Test_GetJobLogs(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -1149,7 +1149,7 @@ func Test_GetJobLogs_WithContentReturn(t *testing.T) {
 		"return_content": true,
 	})
 
-	result, err := handler(context.Background(), &request)
+	result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 	require.NoError(t, err)
 	require.False(t, result.IsError)
 
@@ -1202,7 +1202,7 @@ func Test_GetJobLogs_WithContentReturnAndTailLines(t *testing.T) {
 		"tail_lines":     float64(1), // Requesting last 1 line
 	})
 
-	result, err := handler(context.Background(), &request)
+	result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 	require.NoError(t, err)
 	require.False(t, result.IsError)
 
@@ -1254,7 +1254,7 @@ func Test_GetJobLogs_WithContentReturnAndLargeTailLines(t *testing.T) {
 		"tail_lines":     float64(100),
 	})
 
-	result, err := handler(context.Background(), &request)
+	result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 	require.NoError(t, err)
 	require.False(t, result.IsError)
 

--- a/pkg/github/code_scanning.go
+++ b/pkg/github/code_scanning.go
@@ -44,51 +44,49 @@ func GetCodeScanningAlert(t translations.TranslationHelperFunc) inventory.Server
 				Required: []string{"owner", "repo", "alertNumber"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				alertNumber, err := RequiredInt(args, "alertNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				alert, resp, err := client.CodeScanning.GetAlert(ctx, owner, repo, int64(alertNumber))
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						"failed to get alert",
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get alert", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(alert)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal alert", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			alertNumber, err := RequiredInt(args, "alertNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+
+			alert, resp, err := client.CodeScanning.GetAlert(ctx, owner, repo, int64(alertNumber))
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to get alert",
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get alert", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(alert)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal alert", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -137,62 +135,60 @@ func ListCodeScanningAlerts(t translations.TranslationHelperFunc) inventory.Serv
 				Required: []string{"owner", "repo"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				ref, err := OptionalParam[string](args, "ref")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				severity, err := OptionalParam[string](args, "severity")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				toolName, err := OptionalParam[string](args, "tool_name")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-				alerts, resp, err := client.CodeScanning.ListAlertsForRepo(ctx, owner, repo, &github.AlertListOptions{Ref: ref, State: state, Severity: severity, ToolName: toolName})
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						"failed to list alerts",
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(alerts)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			ref, err := OptionalParam[string](args, "ref")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			severity, err := OptionalParam[string](args, "severity")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			toolName, err := OptionalParam[string](args, "tool_name")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+			alerts, resp, err := client.CodeScanning.ListAlertsForRepo(ctx, owner, repo, &github.AlertListOptions{Ref: ref, State: state, Severity: severity, ToolName: toolName})
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to list alerts",
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(alerts)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }

--- a/pkg/github/code_scanning_test.go
+++ b/pkg/github/code_scanning_test.go
@@ -90,7 +90,7 @@ func Test_GetCodeScanningAlert(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler with new signature
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -216,7 +216,7 @@ func Test_ListCodeScanningAlerts(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler with new signature
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -113,7 +113,7 @@ func Test_GetMe(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectToolError {
@@ -353,10 +353,11 @@ func Test_GetTeams(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := serverTool.Handler(tc.makeDeps())
+			deps := tc.makeDeps()
+			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectToolError {
@@ -499,7 +500,7 @@ func Test_GetTeamMembers(t *testing.T) {
 			handler := serverTool.Handler(tc.deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), tc.deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectToolError {

--- a/pkg/github/dependabot.go
+++ b/pkg/github/dependabot.go
@@ -45,51 +45,49 @@ func GetDependabotAlert(t translations.TranslationHelperFunc) inventory.ServerTo
 				Required: []string{"owner", "repo", "alertNumber"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				alertNumber, err := RequiredInt(args, "alertNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, err
-				}
-
-				alert, resp, err := client.Dependabot.GetRepoAlert(ctx, owner, repo, alertNumber)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						fmt.Sprintf("failed to get alert with number '%d'", alertNumber),
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, err
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get alert", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(alert)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal alert", err), nil, err
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			alertNumber, err := RequiredInt(args, "alertNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, err
+			}
+
+			alert, resp, err := client.Dependabot.GetRepoAlert(ctx, owner, repo, alertNumber)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					fmt.Sprintf("failed to get alert with number '%d'", alertNumber),
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, err
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get alert", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(alert)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal alert", err), nil, err
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -130,58 +128,56 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 				Required: []string{"owner", "repo"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				severity, err := OptionalParam[string](args, "severity")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, err
-				}
-
-				alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, owner, repo, &github.ListAlertsOptions{
-					State:    ToStringPtr(state),
-					Severity: ToStringPtr(severity),
-				})
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						fmt.Sprintf("failed to list alerts for repository '%s/%s'", owner, repo),
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, err
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(alerts)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, err
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			severity, err := OptionalParam[string](args, "severity")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, err
+			}
+
+			alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, owner, repo, &github.ListAlertsOptions{
+				State:    ToStringPtr(state),
+				Severity: ToStringPtr(severity),
+			})
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					fmt.Sprintf("failed to list alerts for repository '%s/%s'", owner, repo),
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, err
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(alerts)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, err
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }

--- a/pkg/github/dependabot_test.go
+++ b/pkg/github/dependabot_test.go
@@ -88,7 +88,7 @@ func Test_GetDependabotAlert(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -237,7 +237,7 @@ func Test_ListDependabotAlerts(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -451,7 +451,7 @@ func Test_ListDiscussions(t *testing.T) {
 			handler := toolDef.Handler(deps)
 
 			req := createMCPRequest(tc.reqParams)
-			res, err := handler(context.Background(), &req)
+			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {
@@ -564,7 +564,7 @@ func Test_GetDiscussion(t *testing.T) {
 
 			reqParams := map[string]interface{}{"owner": "owner", "repo": "repo", "discussionNumber": int32(1)}
 			req := createMCPRequest(reqParams)
-			res, err := handler(context.Background(), &req)
+			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {
@@ -649,7 +649,7 @@ func Test_GetDiscussionComments(t *testing.T) {
 	}
 	request := createMCPRequest(reqParams)
 
-	result, err := handler(context.Background(), &request)
+	result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 	require.NoError(t, err)
 
 	textContent := getTextResult(t, result)
@@ -795,7 +795,7 @@ func Test_ListDiscussionCategories(t *testing.T) {
 			handler := toolDef.Handler(deps)
 
 			req := createMCPRequest(tc.reqParams)
-			res, err := handler(context.Background(), &req)
+			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {

--- a/pkg/github/dynamic_tools.go
+++ b/pkg/github/dynamic_tools.go
@@ -27,7 +27,10 @@ type DynamicToolDependencies struct {
 }
 
 // NewDynamicTool creates a ServerTool with fully-typed DynamicToolDependencies.
+// Dynamic tools use a different dependency structure (DynamicToolDependencies) than regular
+// tools (ToolDependencies), so they intentionally use the closure pattern.
 func NewDynamicTool(toolset inventory.ToolsetMetadata, tool mcp.Tool, handler func(deps DynamicToolDependencies) mcp.ToolHandlerFor[map[string]any, any]) inventory.ServerTool {
+	//nolint:staticcheck // SA1019: Dynamic tools use a different deps structure, closure pattern is intentional
 	return inventory.NewServerTool(tool, toolset, func(d any) mcp.ToolHandlerFor[map[string]any, any] {
 		return handler(d.(DynamicToolDependencies))
 	})

--- a/pkg/github/gists_test.go
+++ b/pkg/github/gists_test.go
@@ -167,7 +167,7 @@ func Test_ListGists(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results
@@ -284,7 +284,7 @@ func Test_GetGist(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results
@@ -430,7 +430,7 @@ func Test_CreateGist(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results
@@ -589,7 +589,7 @@ func Test_UpdateGist(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results

--- a/pkg/github/git_test.go
+++ b/pkg/github/git_test.go
@@ -134,7 +134,7 @@ func Test_GetRepositoryTree(t *testing.T) {
 			// Create the tool request
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -274,57 +274,55 @@ Options are:
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				method, err := RequiredParam[string](args, "method")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			method, err := RequiredParam[string](args, "method")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				issueNumber, err := RequiredInt(args, "issue_number")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			issueNumber, err := RequiredInt(args, "issue_number")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				pagination, err := OptionalPaginationParams(args)
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+			pagination, err := OptionalPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
 
-				gqlClient, err := deps.GetGQLClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub graphql client", err), nil, nil
-				}
+			gqlClient, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub graphql client", err), nil, nil
+			}
 
-				switch method {
-				case "get":
-					result, err := GetIssue(ctx, client, deps.GetRepoAccessCache(), owner, repo, issueNumber, deps.GetFlags())
-					return result, nil, err
-				case "get_comments":
-					result, err := GetIssueComments(ctx, client, deps.GetRepoAccessCache(), owner, repo, issueNumber, pagination, deps.GetFlags())
-					return result, nil, err
-				case "get_sub_issues":
-					result, err := GetSubIssues(ctx, client, deps.GetRepoAccessCache(), owner, repo, issueNumber, pagination, deps.GetFlags())
-					return result, nil, err
-				case "get_labels":
-					result, err := GetIssueLabels(ctx, gqlClient, owner, repo, issueNumber)
-					return result, nil, err
-				default:
-					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
-				}
+			switch method {
+			case "get":
+				result, err := GetIssue(ctx, client, deps.GetRepoAccessCache(), owner, repo, issueNumber, deps.GetFlags())
+				return result, nil, err
+			case "get_comments":
+				result, err := GetIssueComments(ctx, client, deps.GetRepoAccessCache(), owner, repo, issueNumber, pagination, deps.GetFlags())
+				return result, nil, err
+			case "get_sub_issues":
+				result, err := GetSubIssues(ctx, client, deps.GetRepoAccessCache(), owner, repo, issueNumber, pagination, deps.GetFlags())
+				return result, nil, err
+			case "get_labels":
+				result, err := GetIssueLabels(ctx, gqlClient, owner, repo, issueNumber)
+				return result, nil, err
+			default:
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}
 		})
 }
@@ -567,38 +565,36 @@ func ListIssueTypes(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-				issueTypes, resp, err := client.Organizations.ListIssueTypes(ctx, owner)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to list issue types", err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list issue types", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(issueTypes)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal issue types", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+			issueTypes, resp, err := client.Organizations.ListIssueTypes(ctx, owner)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to list issue types", err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list issue types", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(issueTypes)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal issue types", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		})
 }
 
@@ -636,54 +632,52 @@ func AddIssueComment(t translations.TranslationHelperFunc) inventory.ServerTool 
 				Required: []string{"owner", "repo", "issue_number", "body"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				issueNumber, err := RequiredInt(args, "issue_number")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				body, err := RequiredParam[string](args, "body")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				comment := &github.IssueComment{
-					Body: github.Ptr(body),
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-				createdComment, resp, err := client.Issues.CreateComment(ctx, owner, repo, issueNumber, comment)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to create comment", err), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusCreated {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to create comment", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(createdComment)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			issueNumber, err := RequiredInt(args, "issue_number")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			body, err := RequiredParam[string](args, "body")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			comment := &github.IssueComment{
+				Body: github.Ptr(body),
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+			createdComment, resp, err := client.Issues.CreateComment(ctx, owner, repo, issueNumber, comment)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to create comment", err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusCreated {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to create comment", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(createdComment)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		})
 }
 
@@ -742,62 +736,60 @@ Options are:
 				Required: []string{"method", "owner", "repo", "issue_number", "sub_issue_id"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				method, err := RequiredParam[string](args, "method")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			method, err := RequiredParam[string](args, "method")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				issueNumber, err := RequiredInt(args, "issue_number")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				subIssueID, err := RequiredInt(args, "sub_issue_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				replaceParent, err := OptionalParam[bool](args, "replace_parent")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				afterID, err := OptionalIntParam(args, "after_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				beforeID, err := OptionalIntParam(args, "before_id")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			issueNumber, err := RequiredInt(args, "issue_number")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			subIssueID, err := RequiredInt(args, "sub_issue_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			replaceParent, err := OptionalParam[bool](args, "replace_parent")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			afterID, err := OptionalIntParam(args, "after_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			beforeID, err := OptionalIntParam(args, "before_id")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
 
-				switch strings.ToLower(method) {
-				case "add":
-					result, err := AddSubIssue(ctx, client, owner, repo, issueNumber, subIssueID, replaceParent)
-					return result, nil, err
-				case "remove":
-					// Call the remove sub-issue function
-					result, err := RemoveSubIssue(ctx, client, owner, repo, issueNumber, subIssueID)
-					return result, nil, err
-				case "reprioritize":
-					// Call the reprioritize sub-issue function
-					result, err := ReprioritizeSubIssue(ctx, client, owner, repo, issueNumber, subIssueID, afterID, beforeID)
-					return result, nil, err
-				default:
-					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
-				}
+			switch strings.ToLower(method) {
+			case "add":
+				result, err := AddSubIssue(ctx, client, owner, repo, issueNumber, subIssueID, replaceParent)
+				return result, nil, err
+			case "remove":
+				// Call the remove sub-issue function
+				result, err := RemoveSubIssue(ctx, client, owner, repo, issueNumber, subIssueID)
+				return result, nil, err
+			case "reprioritize":
+				// Call the reprioritize sub-issue function
+				result, err := ReprioritizeSubIssue(ctx, client, owner, repo, issueNumber, subIssueID, afterID, beforeID)
+				return result, nil, err
+			default:
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}
 		})
 }
@@ -971,11 +963,9 @@ func SearchIssues(t translations.TranslationHelperFunc) inventory.ServerTool {
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				result, err := searchHandler(ctx, deps.GetClient, args, "issue", "failed to search issues")
-				return result, nil, err
-			}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			result, err := searchHandler(ctx, deps.GetClient, args, "issue", "failed to search issues")
+			return result, nil, err
 		})
 }
 
@@ -1062,104 +1052,102 @@ Options are:
 				Required: []string{"method", "owner", "repo"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				method, err := RequiredParam[string](args, "method")
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			method, err := RequiredParam[string](args, "method")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			title, err := OptionalParam[string](args, "title")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Optional parameters
+			body, err := OptionalParam[string](args, "body")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get assignees
+			assignees, err := OptionalStringArrayParam(args, "assignees")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get labels
+			labels, err := OptionalStringArrayParam(args, "labels")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Get optional milestone
+			milestone, err := OptionalIntParam(args, "milestone")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			var milestoneNum int
+			if milestone != 0 {
+				milestoneNum = milestone
+			}
+
+			// Get optional type
+			issueType, err := OptionalParam[string](args, "type")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Handle state, state_reason and duplicateOf parameters
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			stateReason, err := OptionalParam[string](args, "state_reason")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			duplicateOf, err := OptionalIntParam(args, "duplicate_of")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			if duplicateOf != 0 && stateReason != "duplicate" {
+				return utils.NewToolResultError("duplicate_of can only be used when state_reason is 'duplicate'"), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+
+			gqlClient, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GraphQL client", err), nil, nil
+			}
+
+			switch method {
+			case "create":
+				result, err := CreateIssue(ctx, client, owner, repo, title, body, assignees, labels, milestoneNum, issueType)
+				return result, nil, err
+			case "update":
+				issueNumber, err := RequiredInt(args, "issue_number")
 				if err != nil {
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
-
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				title, err := OptionalParam[string](args, "title")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Optional parameters
-				body, err := OptionalParam[string](args, "body")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get assignees
-				assignees, err := OptionalStringArrayParam(args, "assignees")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get labels
-				labels, err := OptionalStringArrayParam(args, "labels")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Get optional milestone
-				milestone, err := OptionalIntParam(args, "milestone")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				var milestoneNum int
-				if milestone != 0 {
-					milestoneNum = milestone
-				}
-
-				// Get optional type
-				issueType, err := OptionalParam[string](args, "type")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Handle state, state_reason and duplicateOf parameters
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				stateReason, err := OptionalParam[string](args, "state_reason")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				duplicateOf, err := OptionalIntParam(args, "duplicate_of")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				if duplicateOf != 0 && stateReason != "duplicate" {
-					return utils.NewToolResultError("duplicate_of can only be used when state_reason is 'duplicate'"), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				gqlClient, err := deps.GetGQLClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GraphQL client", err), nil, nil
-				}
-
-				switch method {
-				case "create":
-					result, err := CreateIssue(ctx, client, owner, repo, title, body, assignees, labels, milestoneNum, issueType)
-					return result, nil, err
-				case "update":
-					issueNumber, err := RequiredInt(args, "issue_number")
-					if err != nil {
-						return utils.NewToolResultError(err.Error()), nil, nil
-					}
-					result, err := UpdateIssue(ctx, client, gqlClient, owner, repo, issueNumber, title, body, assignees, labels, milestoneNum, issueType, state, stateReason, duplicateOf)
-					return result, nil, err
-				default:
-					return utils.NewToolResultError("invalid method, must be either 'create' or 'update'"), nil, nil
-				}
+				result, err := UpdateIssue(ctx, client, gqlClient, owner, repo, issueNumber, title, body, assignees, labels, milestoneNum, issueType, state, stateReason, duplicateOf)
+				return result, nil, err
+			default:
+				return utils.NewToolResultError("invalid method, must be either 'create' or 'update'"), nil, nil
 			}
 		})
 }
@@ -1393,187 +1381,185 @@ func ListIssues(t translations.TranslationHelperFunc) inventory.ServerTool {
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Set optional parameters if provided
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Normalize and filter by state
-				state = strings.ToUpper(state)
-				var states []githubv4.IssueState
-
-				switch state {
-				case "OPEN", "CLOSED":
-					states = []githubv4.IssueState{githubv4.IssueState(state)}
-				default:
-					states = []githubv4.IssueState{githubv4.IssueStateOpen, githubv4.IssueStateClosed}
-				}
-
-				// Get labels
-				labels, err := OptionalStringArrayParam(args, "labels")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				orderBy, err := OptionalParam[string](args, "orderBy")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				direction, err := OptionalParam[string](args, "direction")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Normalize and validate orderBy
-				orderBy = strings.ToUpper(orderBy)
-				switch orderBy {
-				case "CREATED_AT", "UPDATED_AT", "COMMENTS":
-					// Valid, keep as is
-				default:
-					orderBy = "CREATED_AT"
-				}
-
-				// Normalize and validate direction
-				direction = strings.ToUpper(direction)
-				switch direction {
-				case "ASC", "DESC":
-					// Valid, keep as is
-				default:
-					direction = "DESC"
-				}
-
-				since, err := OptionalParam[string](args, "since")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// There are two optional parameters: since and labels.
-				var sinceTime time.Time
-				var hasSince bool
-				if since != "" {
-					sinceTime, err = parseISOTimestamp(since)
-					if err != nil {
-						return utils.NewToolResultError(fmt.Sprintf("failed to list issues: %s", err.Error())), nil, nil
-					}
-					hasSince = true
-				}
-				hasLabels := len(labels) > 0
-
-				// Get pagination parameters and convert to GraphQL format
-				pagination, err := OptionalCursorPaginationParams(args)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// Check if someone tried to use page-based pagination instead of cursor-based
-				if _, pageProvided := args["page"]; pageProvided {
-					return utils.NewToolResultError("This tool uses cursor-based pagination. Use the 'after' parameter with the 'endCursor' value from the previous response instead of 'page'."), nil, nil
-				}
-
-				// Check if pagination parameters were explicitly provided
-				_, perPageProvided := args["perPage"]
-				paginationExplicit := perPageProvided
-
-				paginationParams, err := pagination.ToGraphQLParams()
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// Use default of 30 if pagination was not explicitly provided
-				if !paginationExplicit {
-					defaultFirst := int32(DefaultGraphQLPageSize)
-					paginationParams.First = &defaultFirst
-				}
-
-				client, err := deps.GetGQLClient(ctx)
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil, nil
-				}
-
-				vars := map[string]interface{}{
-					"owner":     githubv4.String(owner),
-					"repo":      githubv4.String(repo),
-					"states":    states,
-					"orderBy":   githubv4.IssueOrderField(orderBy),
-					"direction": githubv4.OrderDirection(direction),
-					"first":     githubv4.Int(*paginationParams.First),
-				}
-
-				if paginationParams.After != nil {
-					vars["after"] = githubv4.String(*paginationParams.After)
-				} else {
-					// Used within query, therefore must be set to nil and provided as $after
-					vars["after"] = (*githubv4.String)(nil)
-				}
-
-				// Ensure optional parameters are set
-				if hasLabels {
-					// Use query with labels filtering - convert string labels to githubv4.String slice
-					labelStrings := make([]githubv4.String, len(labels))
-					for i, label := range labels {
-						labelStrings[i] = githubv4.String(label)
-					}
-					vars["labels"] = labelStrings
-				}
-
-				if hasSince {
-					vars["since"] = githubv4.DateTime{Time: sinceTime}
-				}
-
-				issueQuery := getIssueQueryType(hasLabels, hasSince)
-				if err := client.Query(ctx, issueQuery, vars); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				// Extract and convert all issue nodes using the common interface
-				var issues []*github.Issue
-				var pageInfo struct {
-					HasNextPage     githubv4.Boolean
-					HasPreviousPage githubv4.Boolean
-					StartCursor     githubv4.String
-					EndCursor       githubv4.String
-				}
-				var totalCount int
-
-				if queryResult, ok := issueQuery.(IssueQueryResult); ok {
-					fragment := queryResult.GetIssueFragment()
-					for _, issue := range fragment.Nodes {
-						issues = append(issues, fragmentToIssue(issue))
-					}
-					pageInfo = fragment.PageInfo
-					totalCount = fragment.TotalCount
-				}
-
-				// Create response with issues
-				response := map[string]interface{}{
-					"issues": issues,
-					"pageInfo": map[string]interface{}{
-						"hasNextPage":     pageInfo.HasNextPage,
-						"hasPreviousPage": pageInfo.HasPreviousPage,
-						"startCursor":     string(pageInfo.StartCursor),
-						"endCursor":       string(pageInfo.EndCursor),
-					},
-					"totalCount": totalCount,
-				}
-				out, err := json.Marshal(response)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal issues: %w", err)
-				}
-				return utils.NewToolResultText(string(out)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Set optional parameters if provided
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Normalize and filter by state
+			state = strings.ToUpper(state)
+			var states []githubv4.IssueState
+
+			switch state {
+			case "OPEN", "CLOSED":
+				states = []githubv4.IssueState{githubv4.IssueState(state)}
+			default:
+				states = []githubv4.IssueState{githubv4.IssueStateOpen, githubv4.IssueStateClosed}
+			}
+
+			// Get labels
+			labels, err := OptionalStringArrayParam(args, "labels")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			orderBy, err := OptionalParam[string](args, "orderBy")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			direction, err := OptionalParam[string](args, "direction")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Normalize and validate orderBy
+			orderBy = strings.ToUpper(orderBy)
+			switch orderBy {
+			case "CREATED_AT", "UPDATED_AT", "COMMENTS":
+				// Valid, keep as is
+			default:
+				orderBy = "CREATED_AT"
+			}
+
+			// Normalize and validate direction
+			direction = strings.ToUpper(direction)
+			switch direction {
+			case "ASC", "DESC":
+				// Valid, keep as is
+			default:
+				direction = "DESC"
+			}
+
+			since, err := OptionalParam[string](args, "since")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// There are two optional parameters: since and labels.
+			var sinceTime time.Time
+			var hasSince bool
+			if since != "" {
+				sinceTime, err = parseISOTimestamp(since)
+				if err != nil {
+					return utils.NewToolResultError(fmt.Sprintf("failed to list issues: %s", err.Error())), nil, nil
+				}
+				hasSince = true
+			}
+			hasLabels := len(labels) > 0
+
+			// Get pagination parameters and convert to GraphQL format
+			pagination, err := OptionalCursorPaginationParams(args)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// Check if someone tried to use page-based pagination instead of cursor-based
+			if _, pageProvided := args["page"]; pageProvided {
+				return utils.NewToolResultError("This tool uses cursor-based pagination. Use the 'after' parameter with the 'endCursor' value from the previous response instead of 'page'."), nil, nil
+			}
+
+			// Check if pagination parameters were explicitly provided
+			_, perPageProvided := args["perPage"]
+			paginationExplicit := perPageProvided
+
+			paginationParams, err := pagination.ToGraphQLParams()
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// Use default of 30 if pagination was not explicitly provided
+			if !paginationExplicit {
+				defaultFirst := int32(DefaultGraphQLPageSize)
+				paginationParams.First = &defaultFirst
+			}
+
+			client, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil, nil
+			}
+
+			vars := map[string]interface{}{
+				"owner":     githubv4.String(owner),
+				"repo":      githubv4.String(repo),
+				"states":    states,
+				"orderBy":   githubv4.IssueOrderField(orderBy),
+				"direction": githubv4.OrderDirection(direction),
+				"first":     githubv4.Int(*paginationParams.First),
+			}
+
+			if paginationParams.After != nil {
+				vars["after"] = githubv4.String(*paginationParams.After)
+			} else {
+				// Used within query, therefore must be set to nil and provided as $after
+				vars["after"] = (*githubv4.String)(nil)
+			}
+
+			// Ensure optional parameters are set
+			if hasLabels {
+				// Use query with labels filtering - convert string labels to githubv4.String slice
+				labelStrings := make([]githubv4.String, len(labels))
+				for i, label := range labels {
+					labelStrings[i] = githubv4.String(label)
+				}
+				vars["labels"] = labelStrings
+			}
+
+			if hasSince {
+				vars["since"] = githubv4.DateTime{Time: sinceTime}
+			}
+
+			issueQuery := getIssueQueryType(hasLabels, hasSince)
+			if err := client.Query(ctx, issueQuery, vars); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Extract and convert all issue nodes using the common interface
+			var issues []*github.Issue
+			var pageInfo struct {
+				HasNextPage     githubv4.Boolean
+				HasPreviousPage githubv4.Boolean
+				StartCursor     githubv4.String
+				EndCursor       githubv4.String
+			}
+			var totalCount int
+
+			if queryResult, ok := issueQuery.(IssueQueryResult); ok {
+				fragment := queryResult.GetIssueFragment()
+				for _, issue := range fragment.Nodes {
+					issues = append(issues, fragmentToIssue(issue))
+				}
+				pageInfo = fragment.PageInfo
+				totalCount = fragment.TotalCount
+			}
+
+			// Create response with issues
+			response := map[string]interface{}{
+				"issues": issues,
+				"pageInfo": map[string]interface{}{
+					"hasNextPage":     pageInfo.HasNextPage,
+					"hasPreviousPage": pageInfo.HasPreviousPage,
+					"startCursor":     string(pageInfo.StartCursor),
+					"endCursor":       string(pageInfo.EndCursor),
+				},
+				"totalCount": totalCount,
+			}
+			out, err := json.Marshal(response)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal issues: %w", err)
+			}
+			return utils.NewToolResultText(string(out)), nil, nil
 		})
 }
 
@@ -1648,133 +1634,131 @@ func AssignCopilotToIssue(t translations.TranslationHelperFunc) inventory.Server
 				Required: []string{"owner", "repo", "issueNumber"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				var params struct {
-					Owner       string
-					Repo        string
-					IssueNumber int32
-				}
-				if err := mapstructure.Decode(args, &params); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			var params struct {
+				Owner       string
+				Repo        string
+				IssueNumber int32
+			}
+			if err := mapstructure.Decode(args, &params); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				client, err := deps.GetGQLClient(ctx)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
-				}
+			client, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
+			}
 
-				// Firstly, we try to find the copilot bot in the suggested actors for the repository.
-				// Although as I write this, we would expect copilot to be at the top of the list, in future, maybe
-				// it will not be on the first page of responses, thus we will keep paginating until we find it.
-				type botAssignee struct {
-					ID       githubv4.ID
-					Login    string
-					TypeName string `graphql:"__typename"`
-				}
+			// Firstly, we try to find the copilot bot in the suggested actors for the repository.
+			// Although as I write this, we would expect copilot to be at the top of the list, in future, maybe
+			// it will not be on the first page of responses, thus we will keep paginating until we find it.
+			type botAssignee struct {
+				ID       githubv4.ID
+				Login    string
+				TypeName string `graphql:"__typename"`
+			}
 
-				type suggestedActorsQuery struct {
-					Repository struct {
-						SuggestedActors struct {
-							Nodes []struct {
-								Bot botAssignee `graphql:"... on Bot"`
-							}
-							PageInfo struct {
-								HasNextPage bool
-								EndCursor   string
-							}
-						} `graphql:"suggestedActors(first: 100, after: $endCursor, capabilities: CAN_BE_ASSIGNED)"`
-					} `graphql:"repository(owner: $owner, name: $name)"`
-				}
-
-				variables := map[string]any{
-					"owner":     githubv4.String(params.Owner),
-					"name":      githubv4.String(params.Repo),
-					"endCursor": (*githubv4.String)(nil),
-				}
-
-				var copilotAssignee *botAssignee
-				for {
-					var query suggestedActorsQuery
-					err := client.Query(ctx, &query, variables)
-					if err != nil {
-						return nil, nil, err
-					}
-
-					// Iterate all the returned nodes looking for the copilot bot, which is supposed to have the
-					// same name on each host. We need this in order to get the ID for later assignment.
-					for _, node := range query.Repository.SuggestedActors.Nodes {
-						if node.Bot.Login == "copilot-swe-agent" {
-							copilotAssignee = &node.Bot
-							break
+			type suggestedActorsQuery struct {
+				Repository struct {
+					SuggestedActors struct {
+						Nodes []struct {
+							Bot botAssignee `graphql:"... on Bot"`
 						}
-					}
+						PageInfo struct {
+							HasNextPage bool
+							EndCursor   string
+						}
+					} `graphql:"suggestedActors(first: 100, after: $endCursor, capabilities: CAN_BE_ASSIGNED)"`
+				} `graphql:"repository(owner: $owner, name: $name)"`
+			}
 
-					if !query.Repository.SuggestedActors.PageInfo.HasNextPage {
+			variables := map[string]any{
+				"owner":     githubv4.String(params.Owner),
+				"name":      githubv4.String(params.Repo),
+				"endCursor": (*githubv4.String)(nil),
+			}
+
+			var copilotAssignee *botAssignee
+			for {
+				var query suggestedActorsQuery
+				err := client.Query(ctx, &query, variables)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				// Iterate all the returned nodes looking for the copilot bot, which is supposed to have the
+				// same name on each host. We need this in order to get the ID for later assignment.
+				for _, node := range query.Repository.SuggestedActors.Nodes {
+					if node.Bot.Login == "copilot-swe-agent" {
+						copilotAssignee = &node.Bot
 						break
 					}
-					variables["endCursor"] = githubv4.String(query.Repository.SuggestedActors.PageInfo.EndCursor)
 				}
 
-				// If we didn't find the copilot bot, we can't proceed any further.
-				if copilotAssignee == nil {
-					// The e2e tests depend upon this specific message to skip the test.
-					return utils.NewToolResultError("copilot isn't available as an assignee for this issue. Please inform the user to visit https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot for more information."), nil, nil
+				if !query.Repository.SuggestedActors.PageInfo.HasNextPage {
+					break
 				}
-
-				// Next let's get the GQL Node ID and current assignees for this issue because the only way to
-				// assign copilot is to use replaceActorsForAssignable which requires the full list.
-				var getIssueQuery struct {
-					Repository struct {
-						Issue struct {
-							ID        githubv4.ID
-							Assignees struct {
-								Nodes []struct {
-									ID githubv4.ID
-								}
-							} `graphql:"assignees(first: 100)"`
-						} `graphql:"issue(number: $number)"`
-					} `graphql:"repository(owner: $owner, name: $name)"`
-				}
-
-				variables = map[string]any{
-					"owner":  githubv4.String(params.Owner),
-					"name":   githubv4.String(params.Repo),
-					"number": githubv4.Int(params.IssueNumber),
-				}
-
-				if err := client.Query(ctx, &getIssueQuery, variables); err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("failed to get issue ID: %v", err)), nil, nil
-				}
-
-				// Finally, do the assignment. Just for reference, assigning copilot to an issue that it is already
-				// assigned to seems to have no impact (which is a good thing).
-				var assignCopilotMutation struct {
-					ReplaceActorsForAssignable struct {
-						Typename string `graphql:"__typename"` // Not required but we need a selector or GQL errors
-					} `graphql:"replaceActorsForAssignable(input: $input)"`
-				}
-
-				actorIDs := make([]githubv4.ID, len(getIssueQuery.Repository.Issue.Assignees.Nodes)+1)
-				for i, node := range getIssueQuery.Repository.Issue.Assignees.Nodes {
-					actorIDs[i] = node.ID
-				}
-				actorIDs[len(getIssueQuery.Repository.Issue.Assignees.Nodes)] = copilotAssignee.ID
-
-				if err := client.Mutate(
-					ctx,
-					&assignCopilotMutation,
-					ReplaceActorsForAssignableInput{
-						AssignableID: getIssueQuery.Repository.Issue.ID,
-						ActorIDs:     actorIDs,
-					},
-					nil,
-				); err != nil {
-					return nil, nil, fmt.Errorf("failed to replace actors for assignable: %w", err)
-				}
-
-				return utils.NewToolResultText("successfully assigned copilot to issue"), nil, nil
+				variables["endCursor"] = githubv4.String(query.Repository.SuggestedActors.PageInfo.EndCursor)
 			}
+
+			// If we didn't find the copilot bot, we can't proceed any further.
+			if copilotAssignee == nil {
+				// The e2e tests depend upon this specific message to skip the test.
+				return utils.NewToolResultError("copilot isn't available as an assignee for this issue. Please inform the user to visit https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot for more information."), nil, nil
+			}
+
+			// Next let's get the GQL Node ID and current assignees for this issue because the only way to
+			// assign copilot is to use replaceActorsForAssignable which requires the full list.
+			var getIssueQuery struct {
+				Repository struct {
+					Issue struct {
+						ID        githubv4.ID
+						Assignees struct {
+							Nodes []struct {
+								ID githubv4.ID
+							}
+						} `graphql:"assignees(first: 100)"`
+					} `graphql:"issue(number: $number)"`
+				} `graphql:"repository(owner: $owner, name: $name)"`
+			}
+
+			variables = map[string]any{
+				"owner":  githubv4.String(params.Owner),
+				"name":   githubv4.String(params.Repo),
+				"number": githubv4.Int(params.IssueNumber),
+			}
+
+			if err := client.Query(ctx, &getIssueQuery, variables); err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("failed to get issue ID: %v", err)), nil, nil
+			}
+
+			// Finally, do the assignment. Just for reference, assigning copilot to an issue that it is already
+			// assigned to seems to have no impact (which is a good thing).
+			var assignCopilotMutation struct {
+				ReplaceActorsForAssignable struct {
+					Typename string `graphql:"__typename"` // Not required but we need a selector or GQL errors
+				} `graphql:"replaceActorsForAssignable(input: $input)"`
+			}
+
+			actorIDs := make([]githubv4.ID, len(getIssueQuery.Repository.Issue.Assignees.Nodes)+1)
+			for i, node := range getIssueQuery.Repository.Issue.Assignees.Nodes {
+				actorIDs[i] = node.ID
+			}
+			actorIDs[len(getIssueQuery.Repository.Issue.Assignees.Nodes)] = copilotAssignee.ID
+
+			if err := client.Mutate(
+				ctx,
+				&assignCopilotMutation,
+				ReplaceActorsForAssignableInput{
+					AssignableID: getIssueQuery.Repository.Issue.ID,
+					ActorIDs:     actorIDs,
+				},
+				nil,
+			); err != nil {
+				return nil, nil, fmt.Errorf("failed to replace actors for assignable: %w", err)
+			}
+
+			return utils.NewToolResultText("successfully assigned copilot to issue"), nil, nil
 		})
 }
 

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -339,7 +339,7 @@ func Test_GetIssue(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectHandlerError {
 				require.Error(t, err)
@@ -456,7 +456,7 @@ func Test_AddIssueComment(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -790,7 +790,7 @@ func Test_SearchIssues(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -962,7 +962,7 @@ func Test_CreateIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1274,7 +1274,7 @@ func Test_ListIssues(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			req := createMCPRequest(tc.reqParams)
-			res, err := handler(context.Background(), &req)
+			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {
@@ -1779,7 +1779,7 @@ func Test_UpdateIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError || tc.expectedErrMsg != "" {
@@ -2028,7 +2028,7 @@ func Test_GetIssueComments(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2145,7 +2145,7 @@ func Test_GetIssueLabels(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)
@@ -2569,7 +2569,7 @@ func TestAssignCopilotToIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -2800,7 +2800,7 @@ func Test_AddSubIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3047,7 +3047,7 @@ func Test_GetSubIssues(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3284,7 +3284,7 @@ func Test_RemoveSubIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3573,7 +3573,7 @@ func Test_ReprioritizeSubIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3707,7 +3707,7 @@ func Test_ListIssueTypes(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -120,7 +120,7 @@ func TestGetLabel(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)
@@ -218,7 +218,7 @@ func TestListLabels(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)
@@ -469,7 +469,7 @@ func TestWriteLabel(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)

--- a/pkg/github/notifications_test.go
+++ b/pkg/github/notifications_test.go
@@ -130,7 +130,7 @@ func Test_ListNotifications(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -263,7 +263,7 @@ func Test_ManageNotificationSubscription(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -426,7 +426,7 @@ func Test_ManageRepositoryNotificationSubscription(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -568,7 +568,7 @@ func Test_DismissNotification(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -693,7 +693,7 @@ func Test_MarkAllNotificationsRead(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -777,7 +777,7 @@ func Test_GetNotificationDetails(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -146,7 +146,7 @@ func Test_ListProjects(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -285,7 +285,7 @@ func Test_GetProject(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -437,7 +437,7 @@ func Test_ListProjectFields(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -597,7 +597,7 @@ func Test_GetProjectField(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -803,7 +803,7 @@ func Test_ListProjectItems(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -1000,7 +1000,7 @@ func Test_GetProjectItem(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -1230,7 +1230,7 @@ func Test_AddProjectItem(t *testing.T) {
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectError {
@@ -1514,7 +1514,7 @@ func Test_UpdateProjectItem(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -1681,7 +1681,7 @@ func Test_DeleteProjectItem(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -69,68 +69,66 @@ Possible options:
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				method, err := RequiredParam[string](args, "method")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			method, err := RequiredParam[string](args, "method")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				pullNumber, err := RequiredInt(args, "pullNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				pagination, err := OptionalPaginationParams(args)
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pullNumber, err := RequiredInt(args, "pullNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pagination, err := OptionalPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
 
-				switch method {
-				case "get":
-					result, err := GetPullRequest(ctx, client, deps.GetRepoAccessCache(), owner, repo, pullNumber, deps.GetFlags())
-					return result, nil, err
-				case "get_diff":
-					result, err := GetPullRequestDiff(ctx, client, owner, repo, pullNumber)
-					return result, nil, err
-				case "get_status":
-					result, err := GetPullRequestStatus(ctx, client, owner, repo, pullNumber)
-					return result, nil, err
-				case "get_files":
-					result, err := GetPullRequestFiles(ctx, client, owner, repo, pullNumber, pagination)
-					return result, nil, err
-				case "get_review_comments":
-					gqlClient, err := deps.GetGQLClient(ctx)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to get GitHub GQL client", err), nil, nil
-					}
-					cursorPagination, err := OptionalCursorPaginationParams(args)
-					if err != nil {
-						return utils.NewToolResultError(err.Error()), nil, nil
-					}
-					result, err := GetPullRequestReviewComments(ctx, gqlClient, deps.GetRepoAccessCache(), owner, repo, pullNumber, cursorPagination, deps.GetFlags())
-					return result, nil, err
-				case "get_reviews":
-					result, err := GetPullRequestReviews(ctx, client, deps.GetRepoAccessCache(), owner, repo, pullNumber, deps.GetFlags())
-					return result, nil, err
-				case "get_comments":
-					result, err := GetIssueComments(ctx, client, deps.GetRepoAccessCache(), owner, repo, pullNumber, pagination, deps.GetFlags())
-					return result, nil, err
-				default:
-					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+			switch method {
+			case "get":
+				result, err := GetPullRequest(ctx, client, deps.GetRepoAccessCache(), owner, repo, pullNumber, deps.GetFlags())
+				return result, nil, err
+			case "get_diff":
+				result, err := GetPullRequestDiff(ctx, client, owner, repo, pullNumber)
+				return result, nil, err
+			case "get_status":
+				result, err := GetPullRequestStatus(ctx, client, owner, repo, pullNumber)
+				return result, nil, err
+			case "get_files":
+				result, err := GetPullRequestFiles(ctx, client, owner, repo, pullNumber, pagination)
+				return result, nil, err
+			case "get_review_comments":
+				gqlClient, err := deps.GetGQLClient(ctx)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to get GitHub GQL client", err), nil, nil
 				}
+				cursorPagination, err := OptionalCursorPaginationParams(args)
+				if err != nil {
+					return utils.NewToolResultError(err.Error()), nil, nil
+				}
+				result, err := GetPullRequestReviewComments(ctx, gqlClient, deps.GetRepoAccessCache(), owner, repo, pullNumber, cursorPagination, deps.GetFlags())
+				return result, nil, err
+			case "get_reviews":
+				result, err := GetPullRequestReviews(ctx, client, deps.GetRepoAccessCache(), owner, repo, pullNumber, deps.GetFlags())
+				return result, nil, err
+			case "get_comments":
+				result, err := GetIssueComments(ctx, client, deps.GetRepoAccessCache(), owner, repo, pullNumber, pagination, deps.GetFlags())
+				return result, nil, err
+			default:
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}
 		})
 }
@@ -520,92 +518,90 @@ func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				title, err := RequiredParam[string](args, "title")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				head, err := RequiredParam[string](args, "head")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				base, err := RequiredParam[string](args, "base")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				body, err := OptionalParam[string](args, "body")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				draft, err := OptionalParam[bool](args, "draft")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				maintainerCanModify, err := OptionalParam[bool](args, "maintainer_can_modify")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				newPR := &github.NewPullRequest{
-					Title: github.Ptr(title),
-					Head:  github.Ptr(head),
-					Base:  github.Ptr(base),
-				}
-
-				if body != "" {
-					newPR.Body = github.Ptr(body)
-				}
-
-				newPR.Draft = github.Ptr(draft)
-				newPR.MaintainerCanModify = github.Ptr(maintainerCanModify)
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-				pr, resp, err := client.PullRequests.Create(ctx, owner, repo, newPR)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						"failed to create pull request",
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusCreated {
-					bodyBytes, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to create pull request", resp, bodyBytes), nil, nil
-				}
-
-				// Return minimal response with just essential information
-				minimalResponse := MinimalResponse{
-					ID:  fmt.Sprintf("%d", pr.GetID()),
-					URL: pr.GetHTMLURL(),
-				}
-
-				r, err := json.Marshal(minimalResponse)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			title, err := RequiredParam[string](args, "title")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			head, err := RequiredParam[string](args, "head")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			base, err := RequiredParam[string](args, "base")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			body, err := OptionalParam[string](args, "body")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			draft, err := OptionalParam[bool](args, "draft")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			maintainerCanModify, err := OptionalParam[bool](args, "maintainer_can_modify")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			newPR := &github.NewPullRequest{
+				Title: github.Ptr(title),
+				Head:  github.Ptr(head),
+				Base:  github.Ptr(base),
+			}
+
+			if body != "" {
+				newPR.Body = github.Ptr(body)
+			}
+
+			newPR.Draft = github.Ptr(draft)
+			newPR.MaintainerCanModify = github.Ptr(maintainerCanModify)
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+			pr, resp, err := client.PullRequests.Create(ctx, owner, repo, newPR)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to create pull request",
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusCreated {
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to create pull request", resp, bodyBytes), nil, nil
+			}
+
+			// Return minimal response with just essential information
+			minimalResponse := MinimalResponse{
+				ID:  fmt.Sprintf("%d", pr.GetID()),
+				URL: pr.GetHTMLURL(),
+			}
+
+			r, err := json.Marshal(minimalResponse)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		})
 }
 
@@ -673,214 +669,188 @@ func UpdatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pullNumber, err := RequiredInt(args, "pullNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			_, draftProvided := args["draft"]
+			var draftValue bool
+			if draftProvided {
+				draftValue, err = OptionalParam[bool](args, "draft")
 				if err != nil {
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				pullNumber, err := RequiredInt(args, "pullNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+			}
 
-				_, draftProvided := args["draft"]
-				var draftValue bool
-				if draftProvided {
-					draftValue, err = OptionalParam[bool](args, "draft")
-					if err != nil {
-						return utils.NewToolResultError(err.Error()), nil, nil
-					}
-				}
+			update := &github.PullRequest{}
+			restUpdateNeeded := false
 
-				update := &github.PullRequest{}
-				restUpdateNeeded := false
+			if title, ok, err := OptionalParamOK[string](args, "title"); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			} else if ok {
+				update.Title = github.Ptr(title)
+				restUpdateNeeded = true
+			}
 
-				if title, ok, err := OptionalParamOK[string](args, "title"); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				} else if ok {
-					update.Title = github.Ptr(title)
-					restUpdateNeeded = true
-				}
+			if body, ok, err := OptionalParamOK[string](args, "body"); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			} else if ok {
+				update.Body = github.Ptr(body)
+				restUpdateNeeded = true
+			}
 
-				if body, ok, err := OptionalParamOK[string](args, "body"); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				} else if ok {
-					update.Body = github.Ptr(body)
-					restUpdateNeeded = true
-				}
+			if state, ok, err := OptionalParamOK[string](args, "state"); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			} else if ok {
+				update.State = github.Ptr(state)
+				restUpdateNeeded = true
+			}
 
-				if state, ok, err := OptionalParamOK[string](args, "state"); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				} else if ok {
-					update.State = github.Ptr(state)
-					restUpdateNeeded = true
-				}
+			if base, ok, err := OptionalParamOK[string](args, "base"); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			} else if ok {
+				update.Base = &github.PullRequestBranch{Ref: github.Ptr(base)}
+				restUpdateNeeded = true
+			}
 
-				if base, ok, err := OptionalParamOK[string](args, "base"); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				} else if ok {
-					update.Base = &github.PullRequestBranch{Ref: github.Ptr(base)}
-					restUpdateNeeded = true
-				}
+			if maintainerCanModify, ok, err := OptionalParamOK[bool](args, "maintainer_can_modify"); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			} else if ok {
+				update.MaintainerCanModify = github.Ptr(maintainerCanModify)
+				restUpdateNeeded = true
+			}
 
-				if maintainerCanModify, ok, err := OptionalParamOK[bool](args, "maintainer_can_modify"); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				} else if ok {
-					update.MaintainerCanModify = github.Ptr(maintainerCanModify)
-					restUpdateNeeded = true
-				}
+			// Handle reviewers separately
+			reviewers, err := OptionalStringArrayParam(args, "reviewers")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				// Handle reviewers separately
-				reviewers, err := OptionalStringArrayParam(args, "reviewers")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+			// If no updates, no draft change, and no reviewers, return error early
+			if !restUpdateNeeded && !draftProvided && len(reviewers) == 0 {
+				return utils.NewToolResultError("No update parameters provided."), nil, nil
+			}
 
-				// If no updates, no draft change, and no reviewers, return error early
-				if !restUpdateNeeded && !draftProvided && len(reviewers) == 0 {
-					return utils.NewToolResultError("No update parameters provided."), nil, nil
-				}
-
-				// Handle REST API updates (title, body, state, base, maintainer_can_modify)
-				if restUpdateNeeded {
-					client, err := deps.GetClient(ctx)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-					}
-
-					_, resp, err := client.PullRequests.Edit(ctx, owner, repo, pullNumber, update)
-					if err != nil {
-						return ghErrors.NewGitHubAPIErrorResponse(ctx,
-							"failed to update pull request",
-							resp,
-							err,
-						), nil, nil
-					}
-					defer func() { _ = resp.Body.Close() }()
-
-					if resp.StatusCode != http.StatusOK {
-						bodyBytes, err := io.ReadAll(resp.Body)
-						if err != nil {
-							return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-						}
-						return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to update pull request", resp, bodyBytes), nil, nil
-					}
-				}
-
-				// Handle draft status changes using GraphQL
-				if draftProvided {
-					gqlClient, err := deps.GetGQLClient(ctx)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to get GitHub GraphQL client", err), nil, nil
-					}
-
-					var prQuery struct {
-						Repository struct {
-							PullRequest struct {
-								ID      githubv4.ID
-								IsDraft githubv4.Boolean
-							} `graphql:"pullRequest(number: $prNum)"`
-						} `graphql:"repository(owner: $owner, name: $repo)"`
-					}
-
-					err = gqlClient.Query(ctx, &prQuery, map[string]interface{}{
-						"owner": githubv4.String(owner),
-						"repo":  githubv4.String(repo),
-						"prNum": githubv4.Int(pullNumber), // #nosec G115 - pull request numbers are always small positive integers
-					})
-					if err != nil {
-						return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "Failed to find pull request", err), nil, nil
-					}
-
-					currentIsDraft := bool(prQuery.Repository.PullRequest.IsDraft)
-
-					if currentIsDraft != draftValue {
-						if draftValue {
-							// Convert to draft
-							var mutation struct {
-								ConvertPullRequestToDraft struct {
-									PullRequest struct {
-										ID      githubv4.ID
-										IsDraft githubv4.Boolean
-									}
-								} `graphql:"convertPullRequestToDraft(input: $input)"`
-							}
-
-							err = gqlClient.Mutate(ctx, &mutation, githubv4.ConvertPullRequestToDraftInput{
-								PullRequestID: prQuery.Repository.PullRequest.ID,
-							}, nil)
-							if err != nil {
-								return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "Failed to convert pull request to draft", err), nil, nil
-							}
-						} else {
-							// Mark as ready for review
-							var mutation struct {
-								MarkPullRequestReadyForReview struct {
-									PullRequest struct {
-										ID      githubv4.ID
-										IsDraft githubv4.Boolean
-									}
-								} `graphql:"markPullRequestReadyForReview(input: $input)"`
-							}
-
-							err = gqlClient.Mutate(ctx, &mutation, githubv4.MarkPullRequestReadyForReviewInput{
-								PullRequestID: prQuery.Repository.PullRequest.ID,
-							}, nil)
-							if err != nil {
-								return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "Failed to mark pull request ready for review", err), nil, nil
-							}
-						}
-					}
-				}
-
-				// Handle reviewer requests
-				if len(reviewers) > 0 {
-					client, err := deps.GetClient(ctx)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-					}
-
-					reviewersRequest := github.ReviewersRequest{
-						Reviewers: reviewers,
-					}
-
-					_, resp, err := client.PullRequests.RequestReviewers(ctx, owner, repo, pullNumber, reviewersRequest)
-					if err != nil {
-						return ghErrors.NewGitHubAPIErrorResponse(ctx,
-							"failed to request reviewers",
-							resp,
-							err,
-						), nil, nil
-					}
-					defer func() {
-						if resp != nil && resp.Body != nil {
-							_ = resp.Body.Close()
-						}
-					}()
-
-					if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-						bodyBytes, err := io.ReadAll(resp.Body)
-						if err != nil {
-							return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-						}
-						return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to request reviewers", resp, bodyBytes), nil, nil
-					}
-				}
-
-				// Get the final state of the PR to return
+			// Handle REST API updates (title, body, state, base, maintainer_can_modify)
+			if restUpdateNeeded {
 				client, err := deps.GetClient(ctx)
 				if err != nil {
 					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 				}
 
-				finalPR, resp, err := client.PullRequests.Get(ctx, owner, repo, pullNumber)
+				_, resp, err := client.PullRequests.Edit(ctx, owner, repo, pullNumber, update)
 				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx, "Failed to get pull request", resp, err), nil, nil
+					return ghErrors.NewGitHubAPIErrorResponse(ctx,
+						"failed to update pull request",
+						resp,
+						err,
+					), nil, nil
+				}
+				defer func() { _ = resp.Body.Close() }()
+
+				if resp.StatusCode != http.StatusOK {
+					bodyBytes, err := io.ReadAll(resp.Body)
+					if err != nil {
+						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+					}
+					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to update pull request", resp, bodyBytes), nil, nil
+				}
+			}
+
+			// Handle draft status changes using GraphQL
+			if draftProvided {
+				gqlClient, err := deps.GetGQLClient(ctx)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to get GitHub GraphQL client", err), nil, nil
+				}
+
+				var prQuery struct {
+					Repository struct {
+						PullRequest struct {
+							ID      githubv4.ID
+							IsDraft githubv4.Boolean
+						} `graphql:"pullRequest(number: $prNum)"`
+					} `graphql:"repository(owner: $owner, name: $repo)"`
+				}
+
+				err = gqlClient.Query(ctx, &prQuery, map[string]interface{}{
+					"owner": githubv4.String(owner),
+					"repo":  githubv4.String(repo),
+					"prNum": githubv4.Int(pullNumber), // #nosec G115 - pull request numbers are always small positive integers
+				})
+				if err != nil {
+					return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "Failed to find pull request", err), nil, nil
+				}
+
+				currentIsDraft := bool(prQuery.Repository.PullRequest.IsDraft)
+
+				if currentIsDraft != draftValue {
+					if draftValue {
+						// Convert to draft
+						var mutation struct {
+							ConvertPullRequestToDraft struct {
+								PullRequest struct {
+									ID      githubv4.ID
+									IsDraft githubv4.Boolean
+								}
+							} `graphql:"convertPullRequestToDraft(input: $input)"`
+						}
+
+						err = gqlClient.Mutate(ctx, &mutation, githubv4.ConvertPullRequestToDraftInput{
+							PullRequestID: prQuery.Repository.PullRequest.ID,
+						}, nil)
+						if err != nil {
+							return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "Failed to convert pull request to draft", err), nil, nil
+						}
+					} else {
+						// Mark as ready for review
+						var mutation struct {
+							MarkPullRequestReadyForReview struct {
+								PullRequest struct {
+									ID      githubv4.ID
+									IsDraft githubv4.Boolean
+								}
+							} `graphql:"markPullRequestReadyForReview(input: $input)"`
+						}
+
+						err = gqlClient.Mutate(ctx, &mutation, githubv4.MarkPullRequestReadyForReviewInput{
+							PullRequestID: prQuery.Repository.PullRequest.ID,
+						}, nil)
+						if err != nil {
+							return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "Failed to mark pull request ready for review", err), nil, nil
+						}
+					}
+				}
+			}
+
+			// Handle reviewer requests
+			if len(reviewers) > 0 {
+				client, err := deps.GetClient(ctx)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+				}
+
+				reviewersRequest := github.ReviewersRequest{
+					Reviewers: reviewers,
+				}
+
+				_, resp, err := client.PullRequests.RequestReviewers(ctx, owner, repo, pullNumber, reviewersRequest)
+				if err != nil {
+					return ghErrors.NewGitHubAPIErrorResponse(ctx,
+						"failed to request reviewers",
+						resp,
+						err,
+					), nil, nil
 				}
 				defer func() {
 					if resp != nil && resp.Body != nil {
@@ -888,19 +858,43 @@ func UpdatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 					}
 				}()
 
-				// Return minimal response with just essential information
-				minimalResponse := MinimalResponse{
-					ID:  fmt.Sprintf("%d", finalPR.GetID()),
-					URL: finalPR.GetHTMLURL(),
+				if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+					bodyBytes, err := io.ReadAll(resp.Body)
+					if err != nil {
+						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+					}
+					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to request reviewers", resp, bodyBytes), nil, nil
 				}
-
-				r, err := json.Marshal(minimalResponse)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("Failed to marshal response", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
 			}
+
+			// Get the final state of the PR to return
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+
+			finalPR, resp, err := client.PullRequests.Get(ctx, owner, repo, pullNumber)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "Failed to get pull request", resp, err), nil, nil
+			}
+			defer func() {
+				if resp != nil && resp.Body != nil {
+					_ = resp.Body.Close()
+				}
+			}()
+
+			// Return minimal response with just essential information
+			minimalResponse := MinimalResponse{
+				ID:  fmt.Sprintf("%d", finalPR.GetID()),
+				URL: finalPR.GetHTMLURL(),
+			}
+
+			r, err := json.Marshal(minimalResponse)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("Failed to marshal response", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		})
 }
 
@@ -956,95 +950,93 @@ func ListPullRequests(t translations.TranslationHelperFunc) inventory.ServerTool
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				head, err := OptionalParam[string](args, "head")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				base, err := OptionalParam[string](args, "base")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				sort, err := OptionalParam[string](args, "sort")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				direction, err := OptionalParam[string](args, "direction")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				pagination, err := OptionalPaginationParams(args)
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				opts := &github.PullRequestListOptions{
-					State:     state,
-					Head:      head,
-					Base:      base,
-					Sort:      sort,
-					Direction: direction,
-					ListOptions: github.ListOptions{
-						PerPage: pagination.PerPage,
-						Page:    pagination.Page,
-					},
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-				prs, resp, err := client.PullRequests.List(ctx, owner, repo, opts)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						"failed to list pull requests",
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					bodyBytes, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list pull requests", resp, bodyBytes), nil, nil
-				}
-
-				// sanitize title/body on each PR
-				for _, pr := range prs {
-					if pr == nil {
-						continue
-					}
-					if pr.Title != nil {
-						pr.Title = github.Ptr(sanitize.Sanitize(*pr.Title))
-					}
-					if pr.Body != nil {
-						pr.Body = github.Ptr(sanitize.Sanitize(*pr.Body))
-					}
-				}
-
-				r, err := json.Marshal(prs)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			head, err := OptionalParam[string](args, "head")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			base, err := OptionalParam[string](args, "base")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			sort, err := OptionalParam[string](args, "sort")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			direction, err := OptionalParam[string](args, "direction")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pagination, err := OptionalPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			opts := &github.PullRequestListOptions{
+				State:     state,
+				Head:      head,
+				Base:      base,
+				Sort:      sort,
+				Direction: direction,
+				ListOptions: github.ListOptions{
+					PerPage: pagination.PerPage,
+					Page:    pagination.Page,
+				},
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+			prs, resp, err := client.PullRequests.List(ctx, owner, repo, opts)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to list pull requests",
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list pull requests", resp, bodyBytes), nil, nil
+			}
+
+			// sanitize title/body on each PR
+			for _, pr := range prs {
+				if pr == nil {
+					continue
+				}
+				if pr.Title != nil {
+					pr.Title = github.Ptr(sanitize.Sanitize(*pr.Title))
+				}
+				if pr.Body != nil {
+					pr.Body = github.Ptr(sanitize.Sanitize(*pr.Body))
+				}
+			}
+
+			r, err := json.Marshal(prs)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		})
 }
 
@@ -1094,67 +1086,65 @@ func MergePullRequest(t translations.TranslationHelperFunc) inventory.ServerTool
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				pullNumber, err := RequiredInt(args, "pullNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				commitTitle, err := OptionalParam[string](args, "commit_title")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				commitMessage, err := OptionalParam[string](args, "commit_message")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				mergeMethod, err := OptionalParam[string](args, "merge_method")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				options := &github.PullRequestOptions{
-					CommitTitle: commitTitle,
-					MergeMethod: mergeMethod,
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-				result, resp, err := client.PullRequests.Merge(ctx, owner, repo, pullNumber, commitMessage, options)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						"failed to merge pull request",
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					bodyBytes, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to merge pull request", resp, bodyBytes), nil, nil
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pullNumber, err := RequiredInt(args, "pullNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			commitTitle, err := OptionalParam[string](args, "commit_title")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			commitMessage, err := OptionalParam[string](args, "commit_message")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			mergeMethod, err := OptionalParam[string](args, "merge_method")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			options := &github.PullRequestOptions{
+				CommitTitle: commitTitle,
+				MergeMethod: mergeMethod,
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+			result, resp, err := client.PullRequests.Merge(ctx, owner, repo, pullNumber, commitMessage, options)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to merge pull request",
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to merge pull request", resp, bodyBytes), nil, nil
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		})
 }
 
@@ -1213,11 +1203,9 @@ func SearchPullRequests(t translations.TranslationHelperFunc) inventory.ServerTo
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				result, err := searchHandler(ctx, deps.GetClient, args, "pr", "failed to search pull requests")
-				return result, nil, err
-			}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			result, err := searchHandler(ctx, deps.GetClient, args, "pr", "failed to search pull requests")
+			return result, nil, err
 		})
 }
 
@@ -1257,63 +1245,61 @@ func UpdatePullRequestBranch(t translations.TranslationHelperFunc) inventory.Ser
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				pullNumber, err := RequiredInt(args, "pullNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				expectedHeadSHA, err := OptionalParam[string](args, "expectedHeadSha")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				opts := &github.PullRequestBranchUpdateOptions{}
-				if expectedHeadSHA != "" {
-					opts.ExpectedHeadSHA = github.Ptr(expectedHeadSHA)
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-				result, resp, err := client.PullRequests.UpdateBranch(ctx, owner, repo, pullNumber, opts)
-				if err != nil {
-					// Check if it's an acceptedError. An acceptedError indicates that the update is in progress,
-					// and it's not a real error.
-					if resp != nil && resp.StatusCode == http.StatusAccepted && isAcceptedError(err) {
-						return utils.NewToolResultText("Pull request branch update is in progress"), nil, nil
-					}
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						"failed to update pull request branch",
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusAccepted {
-					bodyBytes, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to update pull request branch", resp, bodyBytes), nil, nil
-				}
-
-				r, err := json.Marshal(result)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pullNumber, err := RequiredInt(args, "pullNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			expectedHeadSHA, err := OptionalParam[string](args, "expectedHeadSha")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			opts := &github.PullRequestBranchUpdateOptions{}
+			if expectedHeadSHA != "" {
+				opts.ExpectedHeadSHA = github.Ptr(expectedHeadSHA)
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+			result, resp, err := client.PullRequests.UpdateBranch(ctx, owner, repo, pullNumber, opts)
+			if err != nil {
+				// Check if it's an acceptedError. An acceptedError indicates that the update is in progress,
+				// and it's not a real error.
+				if resp != nil && resp.StatusCode == http.StatusAccepted && isAcceptedError(err) {
+					return utils.NewToolResultText("Pull request branch update is in progress"), nil, nil
+				}
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to update pull request branch",
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusAccepted {
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to update pull request branch", resp, bodyBytes), nil, nil
+			}
+
+			r, err := json.Marshal(result)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		})
 }
 
@@ -1385,32 +1371,30 @@ Available methods:
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				var params PullRequestReviewWriteParams
-				if err := mapstructure.Decode(args, &params); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			var params PullRequestReviewWriteParams
+			if err := mapstructure.Decode(args, &params); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				// Given our owner, repo and PR number, lookup the GQL ID of the PR.
-				client, err := deps.GetGQLClient(ctx)
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil, nil
-				}
+			// Given our owner, repo and PR number, lookup the GQL ID of the PR.
+			client, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("failed to get GitHub GQL client: %v", err)), nil, nil
+			}
 
-				switch params.Method {
-				case "create":
-					result, err := CreatePullRequestReview(ctx, client, params)
-					return result, nil, err
-				case "submit_pending":
-					result, err := SubmitPendingPullRequestReview(ctx, client, params)
-					return result, nil, err
-				case "delete_pending":
-					result, err := DeletePendingPullRequestReview(ctx, client, params)
-					return result, nil, err
-				default:
-					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", params.Method)), nil, nil
-				}
+			switch params.Method {
+			case "create":
+				result, err := CreatePullRequestReview(ctx, client, params)
+				return result, nil, err
+			case "submit_pending":
+				result, err := SubmitPendingPullRequestReview(ctx, client, params)
+				return result, nil, err
+			case "delete_pending":
+				result, err := DeletePendingPullRequestReview(ctx, client, params)
+				return result, nil, err
+			default:
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", params.Method)), nil, nil
 			}
 		})
 }
@@ -1710,122 +1694,120 @@ func AddCommentToPendingReview(t translations.TranslationHelperFunc) inventory.S
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				var params struct {
-					Owner       string
-					Repo        string
-					PullNumber  int32
-					Path        string
-					Body        string
-					SubjectType string
-					Line        *int32
-					Side        *string
-					StartLine   *int32
-					StartSide   *string
-				}
-				if err := mapstructure.Decode(args, &params); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			var params struct {
+				Owner       string
+				Repo        string
+				PullNumber  int32
+				Path        string
+				Body        string
+				SubjectType string
+				Line        *int32
+				Side        *string
+				StartLine   *int32
+				StartSide   *string
+			}
+			if err := mapstructure.Decode(args, &params); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				client, err := deps.GetGQLClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub GQL client", err), nil, nil
-				}
+			client, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub GQL client", err), nil, nil
+			}
 
-				// First we'll get the current user
-				var getViewerQuery struct {
-					Viewer struct {
-						Login githubv4.String
+			// First we'll get the current user
+			var getViewerQuery struct {
+				Viewer struct {
+					Login githubv4.String
+				}
+			}
+
+			if err := client.Query(ctx, &getViewerQuery, nil); err != nil {
+				return ghErrors.NewGitHubGraphQLErrorResponse(ctx,
+					"failed to get current user",
+					err,
+				), nil, nil
+			}
+
+			var getLatestReviewForViewerQuery struct {
+				Repository struct {
+					PullRequest struct {
+						Reviews struct {
+							Nodes []struct {
+								ID    githubv4.ID
+								State githubv4.PullRequestReviewState
+								URL   githubv4.URI
+							}
+						} `graphql:"reviews(first: 1, author: $author)"`
+					} `graphql:"pullRequest(number: $prNum)"`
+				} `graphql:"repository(owner: $owner, name: $name)"`
+			}
+
+			vars := map[string]any{
+				"author": githubv4.String(getViewerQuery.Viewer.Login),
+				"owner":  githubv4.String(params.Owner),
+				"name":   githubv4.String(params.Repo),
+				"prNum":  githubv4.Int(params.PullNumber),
+			}
+
+			if err := client.Query(context.Background(), &getLatestReviewForViewerQuery, vars); err != nil {
+				return ghErrors.NewGitHubGraphQLErrorResponse(ctx,
+					"failed to get latest review for current user",
+					err,
+				), nil, nil
+			}
+
+			// Validate there is one review and the state is pending
+			if len(getLatestReviewForViewerQuery.Repository.PullRequest.Reviews.Nodes) == 0 {
+				return utils.NewToolResultError("No pending review found for the viewer"), nil, nil
+			}
+
+			review := getLatestReviewForViewerQuery.Repository.PullRequest.Reviews.Nodes[0]
+			if review.State != githubv4.PullRequestReviewStatePending {
+				errText := fmt.Sprintf("The latest review, found at %s is not pending", review.URL)
+				return utils.NewToolResultError(errText), nil, nil
+			}
+
+			// Then we can create a new review thread comment on the review.
+			var addPullRequestReviewThreadMutation struct {
+				AddPullRequestReviewThread struct {
+					Thread struct {
+						ID githubv4.ID // We don't need this, but a selector is required or GQL complains.
 					}
-				}
+				} `graphql:"addPullRequestReviewThread(input: $input)"`
+			}
 
-				if err := client.Query(ctx, &getViewerQuery, nil); err != nil {
-					return ghErrors.NewGitHubGraphQLErrorResponse(ctx,
-						"failed to get current user",
-						err,
-					), nil, nil
-				}
+			if err := client.Mutate(
+				ctx,
+				&addPullRequestReviewThreadMutation,
+				githubv4.AddPullRequestReviewThreadInput{
+					Path:                githubv4.String(params.Path),
+					Body:                githubv4.String(params.Body),
+					SubjectType:         newGQLStringlikePtr[githubv4.PullRequestReviewThreadSubjectType](&params.SubjectType),
+					Line:                newGQLIntPtr(params.Line),
+					Side:                newGQLStringlikePtr[githubv4.DiffSide](params.Side),
+					StartLine:           newGQLIntPtr(params.StartLine),
+					StartSide:           newGQLStringlikePtr[githubv4.DiffSide](params.StartSide),
+					PullRequestReviewID: &review.ID,
+				},
+				nil,
+			); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
-				var getLatestReviewForViewerQuery struct {
-					Repository struct {
-						PullRequest struct {
-							Reviews struct {
-								Nodes []struct {
-									ID    githubv4.ID
-									State githubv4.PullRequestReviewState
-									URL   githubv4.URI
-								}
-							} `graphql:"reviews(first: 1, author: $author)"`
-						} `graphql:"pullRequest(number: $prNum)"`
-					} `graphql:"repository(owner: $owner, name: $name)"`
-				}
-
-				vars := map[string]any{
-					"author": githubv4.String(getViewerQuery.Viewer.Login),
-					"owner":  githubv4.String(params.Owner),
-					"name":   githubv4.String(params.Repo),
-					"prNum":  githubv4.Int(params.PullNumber),
-				}
-
-				if err := client.Query(context.Background(), &getLatestReviewForViewerQuery, vars); err != nil {
-					return ghErrors.NewGitHubGraphQLErrorResponse(ctx,
-						"failed to get latest review for current user",
-						err,
-					), nil, nil
-				}
-
-				// Validate there is one review and the state is pending
-				if len(getLatestReviewForViewerQuery.Repository.PullRequest.Reviews.Nodes) == 0 {
-					return utils.NewToolResultError("No pending review found for the viewer"), nil, nil
-				}
-
-				review := getLatestReviewForViewerQuery.Repository.PullRequest.Reviews.Nodes[0]
-				if review.State != githubv4.PullRequestReviewStatePending {
-					errText := fmt.Sprintf("The latest review, found at %s is not pending", review.URL)
-					return utils.NewToolResultError(errText), nil, nil
-				}
-
-				// Then we can create a new review thread comment on the review.
-				var addPullRequestReviewThreadMutation struct {
-					AddPullRequestReviewThread struct {
-						Thread struct {
-							ID githubv4.ID // We don't need this, but a selector is required or GQL complains.
-						}
-					} `graphql:"addPullRequestReviewThread(input: $input)"`
-				}
-
-				if err := client.Mutate(
-					ctx,
-					&addPullRequestReviewThreadMutation,
-					githubv4.AddPullRequestReviewThreadInput{
-						Path:                githubv4.String(params.Path),
-						Body:                githubv4.String(params.Body),
-						SubjectType:         newGQLStringlikePtr[githubv4.PullRequestReviewThreadSubjectType](&params.SubjectType),
-						Line:                newGQLIntPtr(params.Line),
-						Side:                newGQLStringlikePtr[githubv4.DiffSide](params.Side),
-						StartLine:           newGQLIntPtr(params.StartLine),
-						StartSide:           newGQLStringlikePtr[githubv4.DiffSide](params.StartSide),
-						PullRequestReviewID: &review.ID,
-					},
-					nil,
-				); err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				if addPullRequestReviewThreadMutation.AddPullRequestReviewThread.Thread.ID == nil {
-					return utils.NewToolResultError(`Failed to add comment to pending review. Possible reasons:
+			if addPullRequestReviewThreadMutation.AddPullRequestReviewThread.Thread.ID == nil {
+				return utils.NewToolResultError(`Failed to add comment to pending review. Possible reasons:
 	- The line number doesn't exist in the pull request diff
 	- The file path is incorrect
 	- The side (LEFT/RIGHT) is invalid for the specified line
 `), nil, nil
-				}
-
-				// Return nothing interesting, just indicate success for the time being.
-				// In future, we may want to return the review ID, but for the moment, we're not leaking
-				// API implementation details to the LLM.
-				return utils.NewToolResultText("pull request review comment successfully added to pending review"), nil, nil
 			}
+
+			// Return nothing interesting, just indicate success for the time being.
+			// In future, we may want to return the review ID, but for the moment, we're not leaking
+			// API implementation details to the LLM.
+			return utils.NewToolResultText("pull request review comment successfully added to pending review"), nil, nil
 		})
 }
 
@@ -1864,58 +1846,56 @@ func RequestCopilotReview(t translations.TranslationHelperFunc) inventory.Server
 			},
 			InputSchema: schema,
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				pullNumber, err := RequiredInt(args, "pullNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
-				}
-
-				_, resp, err := client.PullRequests.RequestReviewers(
-					ctx,
-					owner,
-					repo,
-					pullNumber,
-					github.ReviewersRequest{
-						// The login name of the copilot reviewer bot
-						Reviewers: []string{"copilot-pull-request-reviewer[bot]"},
-					},
-				)
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						"failed to request copilot review",
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusCreated {
-					bodyBytes, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to request copilot review", resp, bodyBytes), nil, nil
-				}
-
-				// Return nothing on success, as there's not much value in returning the Pull Request itself
-				return utils.NewToolResultText(""), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			pullNumber, err := RequiredInt(args, "pullNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+
+			_, resp, err := client.PullRequests.RequestReviewers(
+				ctx,
+				owner,
+				repo,
+				pullNumber,
+				github.ReviewersRequest{
+					// The login name of the copilot reviewer bot
+					Reviewers: []string{"copilot-pull-request-reviewer[bot]"},
+				},
+			)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					"failed to request copilot review",
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusCreated {
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to request copilot review", resp, bodyBytes), nil, nil
+			}
+
+			// Return nothing on success, as there's not much value in returning the Pull Request itself
+			return utils.NewToolResultText(""), nil, nil
 		})
 }
 

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -118,7 +118,7 @@ func Test_GetPullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -381,7 +381,7 @@ func Test_UpdatePullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError || tc.expectedErrMsg != "" {
@@ -570,7 +570,7 @@ func Test_UpdatePullRequest_Draft(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError || tc.expectedErrMsg != "" {
 				require.NoError(t, err)
@@ -703,7 +703,7 @@ func Test_ListPullRequests(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -827,7 +827,7 @@ func Test_MergePullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1133,7 +1133,7 @@ func Test_SearchPullRequests(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1288,7 +1288,7 @@ func Test_GetPullRequestFiles(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1463,7 +1463,7 @@ func Test_GetPullRequestStatus(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1599,7 +1599,7 @@ func Test_UpdatePullRequestBranch(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1919,7 +1919,7 @@ func Test_GetPullRequestComments(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2097,7 +2097,7 @@ func Test_GetPullRequestReviews(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2259,7 +2259,7 @@ func Test_CreatePullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2475,7 +2475,7 @@ func TestCreateAndSubmitPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -2589,7 +2589,7 @@ func Test_RequestCopilotReview(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)
@@ -2785,7 +2785,7 @@ func TestCreatePendingPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -2968,7 +2968,7 @@ func TestAddPullRequestReviewCommentToPendingReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -3073,7 +3073,7 @@ func TestSubmitPendingPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -3172,7 +3172,7 @@ func TestDeletePendingPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -3265,7 +3265,7 @@ index 5d6e7b2..8a4f5c3 100644
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -341,7 +341,7 @@ func Test_GetFileContents(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -464,7 +464,7 @@ func Test_ForkRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -660,7 +660,7 @@ func Test_CreateBranch(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -792,7 +792,7 @@ func Test_GetCommit(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1018,7 +1018,7 @@ func Test_ListCommits(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1373,7 +1373,7 @@ func Test_CreateOrUpdateFile(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1565,7 +1565,7 @@ func Test_CreateRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1904,7 +1904,7 @@ func Test_PushFiles(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2025,7 +2025,7 @@ func Test_ListBranches(t *testing.T) {
 			request := createMCPRequest(tt.args)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			if tt.wantErr {
 				require.NoError(t, err)
 				if tt.errContains != "" {
@@ -2213,7 +2213,7 @@ func Test_DeleteFile(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2340,7 +2340,7 @@ func Test_ListTags(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2500,7 +2500,7 @@ func Test_GetTag(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2609,7 +2609,7 @@ func Test_ListReleases(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -2700,7 +2700,7 @@ func Test_GetLatestRelease(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -2850,7 +2850,7 @@ func Test_GetReleaseByTag(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -3364,7 +3364,7 @@ func Test_ListStarredRepositories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3465,7 +3465,7 @@ func Test_StarRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3556,7 +3556,7 @@ func Test_UnstarRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -143,7 +143,7 @@ func Test_SearchRepositories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -221,7 +221,7 @@ func Test_SearchRepositories_FullOutput(t *testing.T) {
 
 	request := createMCPRequest(args)
 
-	result, err := handler(context.Background(), &request)
+	result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 	require.NoError(t, err)
 	require.False(t, result.IsError)
@@ -367,7 +367,7 @@ func Test_SearchCode(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -567,7 +567,7 @@ func Test_SearchUsers(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -742,7 +742,7 @@ func Test_SearchOrgs(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/secret_scanning.go
+++ b/pkg/github/secret_scanning.go
@@ -45,51 +45,49 @@ func GetSecretScanningAlert(t translations.TranslationHelperFunc) inventory.Serv
 				Required: []string{"owner", "repo", "alertNumber"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				alertNumber, err := RequiredInt(args, "alertNumber")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
-				}
-
-				alert, resp, err := client.SecretScanning.GetAlert(ctx, owner, repo, int64(alertNumber))
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						fmt.Sprintf("failed to get alert with number '%d'", alertNumber),
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get alert", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(alert)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal alert: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			alertNumber, err := RequiredInt(args, "alertNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
+			}
+
+			alert, resp, err := client.SecretScanning.GetAlert(ctx, owner, repo, int64(alertNumber))
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					fmt.Sprintf("failed to get alert with number '%d'", alertNumber),
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get alert", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(alert)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal alert: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -133,58 +131,56 @@ func ListSecretScanningAlerts(t translations.TranslationHelperFunc) inventory.Se
 				Required: []string{"owner", "repo"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				secretType, err := OptionalParam[string](args, "secret_type")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				resolution, err := OptionalParam[string](args, "resolution")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
-				}
-				alerts, resp, err := client.SecretScanning.ListAlertsForRepo(ctx, owner, repo, &github.SecretScanningAlertListOptions{State: state, SecretType: secretType, Resolution: resolution})
-				if err != nil {
-					return ghErrors.NewGitHubAPIErrorResponse(ctx,
-						fmt.Sprintf("failed to list alerts for repository '%s/%s'", owner, repo),
-						resp,
-						err,
-					), nil, nil
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(alerts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal alerts: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			secretType, err := OptionalParam[string](args, "secret_type")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			resolution, err := OptionalParam[string](args, "resolution")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
+			}
+			alerts, resp, err := client.SecretScanning.ListAlertsForRepo(ctx, owner, repo, &github.SecretScanningAlertListOptions{State: state, SecretType: secretType, Resolution: resolution})
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					fmt.Sprintf("failed to list alerts for repository '%s/%s'", owner, repo),
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(alerts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal alerts: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }

--- a/pkg/github/secret_scanning_test.go
+++ b/pkg/github/secret_scanning_test.go
@@ -96,7 +96,7 @@ func Test_GetSecretScanningAlert(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -235,7 +235,7 @@ func Test_ListSecretScanningAlerts(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)

--- a/pkg/github/security_advisories.go
+++ b/pkg/github/security_advisories.go
@@ -83,127 +83,125 @@ func ListGlobalSecurityAdvisories(t translations.TranslationHelperFunc) inventor
 				},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
-				}
-
-				ghsaID, err := OptionalParam[string](args, "ghsaId")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid ghsaId: %v", err)), nil, nil
-				}
-
-				typ, err := OptionalParam[string](args, "type")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid type: %v", err)), nil, nil
-				}
-
-				cveID, err := OptionalParam[string](args, "cveId")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid cveId: %v", err)), nil, nil
-				}
-
-				eco, err := OptionalParam[string](args, "ecosystem")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid ecosystem: %v", err)), nil, nil
-				}
-
-				sev, err := OptionalParam[string](args, "severity")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid severity: %v", err)), nil, nil
-				}
-
-				cwes, err := OptionalStringArrayParam(args, "cwes")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid cwes: %v", err)), nil, nil
-				}
-
-				isWithdrawn, err := OptionalParam[bool](args, "isWithdrawn")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid isWithdrawn: %v", err)), nil, nil
-				}
-
-				affects, err := OptionalParam[string](args, "affects")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid affects: %v", err)), nil, nil
-				}
-
-				published, err := OptionalParam[string](args, "published")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid published: %v", err)), nil, nil
-				}
-
-				updated, err := OptionalParam[string](args, "updated")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid updated: %v", err)), nil, nil
-				}
-
-				modified, err := OptionalParam[string](args, "modified")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid modified: %v", err)), nil, nil
-				}
-
-				opts := &github.ListGlobalSecurityAdvisoriesOptions{}
-
-				if ghsaID != "" {
-					opts.GHSAID = &ghsaID
-				}
-				if typ != "" {
-					opts.Type = &typ
-				}
-				if cveID != "" {
-					opts.CVEID = &cveID
-				}
-				if eco != "" {
-					opts.Ecosystem = &eco
-				}
-				if sev != "" {
-					opts.Severity = &sev
-				}
-				if len(cwes) > 0 {
-					opts.CWEs = cwes
-				}
-
-				if isWithdrawn {
-					opts.IsWithdrawn = &isWithdrawn
-				}
-
-				if affects != "" {
-					opts.Affects = &affects
-				}
-				if published != "" {
-					opts.Published = &published
-				}
-				if updated != "" {
-					opts.Updated = &updated
-				}
-				if modified != "" {
-					opts.Modified = &modified
-				}
-
-				advisories, resp, err := client.SecurityAdvisories.ListGlobalSecurityAdvisories(ctx, opts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to list global security advisories: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list advisories", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(advisories)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
+
+			ghsaID, err := OptionalParam[string](args, "ghsaId")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid ghsaId: %v", err)), nil, nil
+			}
+
+			typ, err := OptionalParam[string](args, "type")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid type: %v", err)), nil, nil
+			}
+
+			cveID, err := OptionalParam[string](args, "cveId")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid cveId: %v", err)), nil, nil
+			}
+
+			eco, err := OptionalParam[string](args, "ecosystem")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid ecosystem: %v", err)), nil, nil
+			}
+
+			sev, err := OptionalParam[string](args, "severity")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid severity: %v", err)), nil, nil
+			}
+
+			cwes, err := OptionalStringArrayParam(args, "cwes")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid cwes: %v", err)), nil, nil
+			}
+
+			isWithdrawn, err := OptionalParam[bool](args, "isWithdrawn")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid isWithdrawn: %v", err)), nil, nil
+			}
+
+			affects, err := OptionalParam[string](args, "affects")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid affects: %v", err)), nil, nil
+			}
+
+			published, err := OptionalParam[string](args, "published")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid published: %v", err)), nil, nil
+			}
+
+			updated, err := OptionalParam[string](args, "updated")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid updated: %v", err)), nil, nil
+			}
+
+			modified, err := OptionalParam[string](args, "modified")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid modified: %v", err)), nil, nil
+			}
+
+			opts := &github.ListGlobalSecurityAdvisoriesOptions{}
+
+			if ghsaID != "" {
+				opts.GHSAID = &ghsaID
+			}
+			if typ != "" {
+				opts.Type = &typ
+			}
+			if cveID != "" {
+				opts.CVEID = &cveID
+			}
+			if eco != "" {
+				opts.Ecosystem = &eco
+			}
+			if sev != "" {
+				opts.Severity = &sev
+			}
+			if len(cwes) > 0 {
+				opts.CWEs = cwes
+			}
+
+			if isWithdrawn {
+				opts.IsWithdrawn = &isWithdrawn
+			}
+
+			if affects != "" {
+				opts.Affects = &affects
+			}
+			if published != "" {
+				opts.Published = &published
+			}
+			if updated != "" {
+				opts.Updated = &updated
+			}
+			if modified != "" {
+				opts.Modified = &modified
+			}
+
+			advisories, resp, err := client.SecurityAdvisories.ListGlobalSecurityAdvisories(ctx, opts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to list global security advisories: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list advisories", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(advisories)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -248,67 +246,65 @@ func ListRepositorySecurityAdvisories(t translations.TranslationHelperFunc) inve
 				Required: []string{"owner", "repo"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				owner, err := RequiredParam[string](args, "owner")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				repo, err := RequiredParam[string](args, "repo")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				direction, err := OptionalParam[string](args, "direction")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				sortField, err := OptionalParam[string](args, "sort")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
-				}
-
-				opts := &github.ListRepositorySecurityAdvisoriesOptions{}
-				if direction != "" {
-					opts.Direction = direction
-				}
-				if sortField != "" {
-					opts.Sort = sortField
-				}
-				if state != "" {
-					opts.State = state
-				}
-
-				advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, owner, repo, opts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to list repository security advisories: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list repository advisories", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(advisories)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			direction, err := OptionalParam[string](args, "direction")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			sortField, err := OptionalParam[string](args, "sort")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
+			}
+
+			opts := &github.ListRepositorySecurityAdvisoriesOptions{}
+			if direction != "" {
+				opts.Direction = direction
+			}
+			if sortField != "" {
+				opts.Sort = sortField
+			}
+			if state != "" {
+				opts.State = state
+			}
+
+			advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, owner, repo, opts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to list repository security advisories: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list repository advisories", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(advisories)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -334,39 +330,37 @@ func GetGlobalSecurityAdvisory(t translations.TranslationHelperFunc) inventory.S
 				Required: []string{"ghsaId"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
-				}
-
-				ghsaID, err := RequiredParam[string](args, "ghsaId")
-				if err != nil {
-					return utils.NewToolResultError(fmt.Sprintf("invalid ghsaId: %v", err)), nil, nil
-				}
-
-				advisory, resp, err := client.SecurityAdvisories.GetGlobalSecurityAdvisories(ctx, ghsaID)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get advisory: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get advisory", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(advisory)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal advisory: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
+
+			ghsaID, err := RequiredParam[string](args, "ghsaId")
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("invalid ghsaId: %v", err)), nil, nil
+			}
+
+			advisory, resp, err := client.SecurityAdvisories.GetGlobalSecurityAdvisories(ctx, ghsaID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get advisory: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get advisory", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(advisory)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal advisory: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }
@@ -407,62 +401,60 @@ func ListOrgRepositorySecurityAdvisories(t translations.TranslationHelperFunc) i
 				Required: []string{"org"},
 			},
 		},
-		func(deps ToolDependencies) mcp.ToolHandlerFor[map[string]any, any] {
-			return func(ctx context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-				org, err := RequiredParam[string](args, "org")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				direction, err := OptionalParam[string](args, "direction")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				sortField, err := OptionalParam[string](args, "sort")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-				state, err := OptionalParam[string](args, "state")
-				if err != nil {
-					return utils.NewToolResultError(err.Error()), nil, nil
-				}
-
-				client, err := deps.GetClient(ctx)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
-				}
-
-				opts := &github.ListRepositorySecurityAdvisoriesOptions{}
-				if direction != "" {
-					opts.Direction = direction
-				}
-				if sortField != "" {
-					opts.Sort = sortField
-				}
-				if state != "" {
-					opts.State = state
-				}
-
-				advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, org, opts)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to list organization repository security advisories: %w", err)
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list organization repository advisories", resp, body), nil, nil
-				}
-
-				r, err := json.Marshal(advisories)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
-				}
-
-				return utils.NewToolResultText(string(r)), nil, nil
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			org, err := RequiredParam[string](args, "org")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			direction, err := OptionalParam[string](args, "direction")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			sortField, err := OptionalParam[string](args, "sort")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
+			}
+
+			opts := &github.ListRepositorySecurityAdvisoriesOptions{}
+			if direction != "" {
+				opts.Direction = direction
+			}
+			if sortField != "" {
+				opts.Sort = sortField
+			}
+			if state != "" {
+				opts.State = state
+			}
+
+			advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, org, opts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to list organization repository security advisories: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list organization repository advisories", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(advisories)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
 		},
 	)
 }

--- a/pkg/github/security_advisories_test.go
+++ b/pkg/github/security_advisories_test.go
@@ -110,7 +110,7 @@ func Test_ListGlobalSecurityAdvisories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -231,7 +231,7 @@ func Test_GetGlobalSecurityAdvisory(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -378,7 +378,7 @@ func Test_ListRepositorySecurityAdvisories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -523,7 +523,7 @@ func Test_ListOrgRepositorySecurityAdvisories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(context.Background(), &request)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)


### PR DESCRIPTION
## Summary

This refactor changes how dependencies are passed to tool handlers from a closure-based pattern to a context-based pattern. This eliminates the need to create new closures for every tool on each request, which is critical for the remote server where one server instance is created per request.

## Problem

In the closure-based pattern, `NewTool` stored a function that took `deps` and returned a handler:

```go
// Old pattern - creates closure on every call to Handler(deps)
func NewTool(..., handler func(deps) handlerFn) {
    return ServerTool{
        Handler: func(deps any) handlerFn {
            return handler(deps.(ToolDependencies))  // Creates new closure each time
        }
    }
}
```

For the remote server with ~89 tools, this meant **178 allocations per request** just for tool handler setup.

## Solution

The new pattern injects dependencies into the context once, and handlers extract them:

```go
// New pattern - no closure creation at request time
func NewTool(..., handler func(ctx, deps, req, args) result) {
    return ServerTool{
        Handler: func(ctx any) handlerFn {
            return func(ctx, req) result {
                deps := MustDepsFromContext(ctx)  // Extract from context
                return handler(ctx, deps, req, args)
            }
        }
    }
}
```

## Benchmark Results

### Throughput (89 tools, 5s benchmark, 3 runs)

| Benchmark | main (old) | new | Speedup |
|-----------|------------|-----|---------|
| Sequential | 9,345 ns/op | 4,250 ns/op | **2.2x faster** |
| Parallel | 2,751 ns/op | 779 ns/op | **3.5x faster** |

### Memory

| Metric | main | new | Reduction |
|--------|------|-----|-----------|
| Bytes/op | 7,832 B | 2,136 B | **73% less** |
| Allocs/op | 178 | 89 | **50% fewer** |

### Scaling (tools from 13 to 1,300)

| Tools | main | new | Speedup | Memory Saved |
|------:|-----:|----:|--------:|-------------:|
| 13 | 1,261 ns | 811 ns | 1.6x | 54% |
| 65 | 6,420 ns | 3,771 ns | 1.7x | 54% |
| 130 | 14,653 ns | 7,797 ns | 1.9x | 54% |
| 650 | 68,722 ns | 38,872 ns | 1.8x | 54% |
| 1,300 | 145,135 ns | 67,292 ns | 2.2x | 54% |

## Changes

### New APIs in `pkg/github/dependencies.go`
- `ContextWithDeps(ctx, deps)` - inject dependencies into context
- `DepsFromContext(ctx)` - extract dependencies (returns nil if not present)
- `MustDepsFromContext(ctx)` - extract dependencies (panics if not present)

### Updated in `pkg/inventory/server_tool.go`
- `NewServerToolWithContextHandler` - new constructor for context-based handlers
- `NewServerToolWithRawContextHandler` - new constructor for raw handlers
- Old constructors marked as deprecated

### Converted (89 tool handlers across 15 files)
All tool handlers converted from closure pattern to direct context-based pattern.

### Test updates (17 test files)
All tests updated to use `ContextWithDeps(context.Background(), deps)`.

## Backwards Compatibility

- Old `NewServerTool` and `NewServerToolFromHandler` are deprecated but still work
- `dynamic_tools.go` intentionally uses the old pattern (with nolint comment) since it wraps user-provided handlers

## Testing

- All existing tests pass
- `script/lint` passes
- `script/test` passes