### PR TITLE
[docs] Update codex installation docs for clarity

### DIFF
--- a/docs/installation-guides/install-codex.md
+++ b/docs/installation-guides/install-codex.md
@@ -23,7 +23,7 @@ You can also add it via the Codex CLI:
 codex mcp add github --url https://api.githubcopilot.com/mcp/  
 ```
 
-###  Storing Your PAT Securely
+### Storing Your PAT Securely
 
 For security, avoid hardcoding your token. One common approach:
 


### PR DESCRIPTION
## Summary

The codex installation docs were slightly confusing when I went through them. We're not actually storing the PAT in the config. As well, storing the PAT as an env var is a requirement so installation shouldn't be collapsed, where it is easily missed.

## What changed

- Updated installation docs

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR


## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [x] Updated (README / docs / examples)
