### PR TITLE
Fix add_comment_to_pending_review for fork PRs

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1743,6 +1743,7 @@ func AddCommentToPendingReview(t translations.TranslationHelperFunc) inventory.S
 			var getLatestReviewForViewerQuery struct {
 				Repository struct {
 					PullRequest struct {
+						ID      githubv4.ID
 						Reviews struct {
 							Nodes []struct {
 								ID    githubv4.ID
@@ -1788,6 +1789,7 @@ func AddCommentToPendingReview(t translations.TranslationHelperFunc) inventory.S
 				} `graphql:"addPullRequestReviewThread(input: $input)"`
 			}
 
+			pullRequestID := getLatestReviewForViewerQuery.Repository.PullRequest.ID
 			if err := client.Mutate(
 				ctx,
 				&addPullRequestReviewThreadMutation,
@@ -1799,6 +1801,7 @@ func AddCommentToPendingReview(t translations.TranslationHelperFunc) inventory.S
 					Side:                newGQLStringlikePtr[githubv4.DiffSide](params.Side),
 					StartLine:           newGQLIntPtr(params.StartLine),
 					StartSide:           newGQLStringlikePtr[githubv4.DiffSide](params.StartSide),
+					PullRequestID:       &pullRequestID,
 					PullRequestReviewID: &review.ID,
 				},
 				nil,


### PR DESCRIPTION
## Summary

Fixes #1748

The `add_comment_to_pending_review` tool was failing for pull requests from forks because the `addPullRequestReviewThread` GraphQL mutation requires the `PullRequestID` field to correctly identify the pull request context.

## Problem

When adding review comments to PRs from forks, the API was returning `null` for the thread ID with the error:
```
Failed to add comment to pending review. Possible reasons:
  - The line number doesn't exist in the pull request diff
  - The file path is incorrect
  - The side (LEFT/RIGHT) is invalid for the specified line
```

This happened even when all parameters were correct, and worked fine for PRs from the same repo.

## Root Cause

The `AddPullRequestReviewThreadInput` GraphQL input has two optional ID fields:
- `PullRequestID` - The node ID of the pull request
- `PullRequestReviewID` - The Node ID of the review

The code was only providing `PullRequestReviewID`. For fork PRs, GitHub's API needs `PullRequestID` to correctly resolve the context.

This appears to be a pre-existing bug rather than a regression from the consolidation work in #1192. The `add_comment_to_pending_review` tool was not modified during that consolidation. The issue likely became more visible due to stricter API validation on GitHub's side.

Related: https://github.com/orgs/community/discussions/182548

## Fix

1. Modified the GraphQL query to also fetch `PullRequest.ID`
2. Added `PullRequestID` to the mutation input

## Testing

- All existing tests pass
- Updated test helper to support the new query structure
- Lint passes