### PR TITLE
Fix nil pointer dereference in completion handler

### DIFF
--- a/pkg/github/repository_resource_completions.go
+++ b/pkg/github/repository_resource_completions.go
@@ -33,8 +33,10 @@ func RepositoryResourceCompletionHandler(getClient GetClientFn) func(ctx context
 
 		argName := req.Params.Argument.Name
 		argValue := req.Params.Argument.Value
-		resolved := req.Params.Context.Arguments
-		if resolved == nil {
+		var resolved map[string]string
+		if req.Params.Context != nil && req.Params.Context.Arguments != nil {
+			resolved = req.Params.Context.Arguments
+		} else {
 			resolved = map[string]string{}
 		}
 


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic in `RepositoryResourceCompletionHandler` when the `Context` field is not provided in the completion request.

## Problem

The `CompleteParams.Context` field in the MCP protocol is optional (marked as `omitempty` and is a pointer type `*CompleteContext`). When clients don't include it in their requests, the code was panicking because it directly accessed `req.Params.Context.Arguments` without first checking if `Context` was nil.

```go
// Before (panic when Context is nil)
resolved := req.Params.Context.Arguments
if resolved == nil {
    resolved = map[string]string{}
}
```

## Solution

Added a nil check for `Context` before accessing `Arguments`:

```go
// After (safe)
var resolved map[string]string
if req.Params.Context != nil && req.Params.Context.Arguments != nil {
    resolved = req.Params.Context.Arguments
} else {
    resolved = map[string]string{}
}
```

## Testing

- All existing completion tests pass
- `TestRepositoryResourceCompletionHandler_NilContext` specifically covers this scenario