### PR TITLE
bug fix: --tools flag not working with feature-flagged tools and deprecation aliases

### DIFF
--- a/pkg/inventory/builder.go
+++ b/pkg/inventory/builder.go
@@ -149,11 +149,14 @@ func (b *Builder) Build() *Inventory {
 	if len(b.additionalTools) > 0 {
 		r.additionalTools = make(map[string]bool, len(b.additionalTools))
 		for _, name := range b.additionalTools {
-			// Resolve deprecated aliases to canonical names
+			// Always include the original name - this handles the case where
+			// the tool exists but is controlled by a feature flag that's OFF.
+			r.additionalTools[name] = true
+			// Also include the canonical name if this is a deprecated alias.
+			// This handles the case where the feature flag is ON and only
+			// the new consolidated tool is available.
 			if canonical, isAlias := b.deprecatedAliases[name]; isAlias {
 				r.additionalTools[canonical] = true
-			} else {
-				r.additionalTools[name] = true
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->
When using `--tools` to request a tool that has a deprecated alias (e.g., `list_workflow_runs` which has been consolidated into `actions_list`), the tool should be found if the consolidation feature flag (`remote_mcp_consolidated_actions`) is off.

For example consider this configuration:
```json
"args": [
	"run",
	"./cmd/github-mcp-server",
	"--tools=list_workflow_runs",
	"stdio"
],

// note: `remote_mcp_consolidated_actions` feature flag here is NOT enabled, so `list_workflow_runs` should be enabled
```

_Expected_: `list_workflow_runs` is available
_Actual_: 0 tools available

With the feature flag on, it worked correctly (resolved to `actions_list` via alias). With `--toolsets=actions` and the feature flag turned off, it also worked correctly:
```json
"args": [
	"run",
	"./cmd/github-mcp-server",
	"--toolsets=actions",
	"stdio"
],

// note: `remote_mcp_consolidated_actions` feature flag here is NOT enabled, and indeed `list_workflow_runs` is enabled
```

In short: with `remote_mcp_consolidated_actions` turned off, "old" (aka pre-consolidation) tools should be configurable both via `--toolsets` and `--tools`, but in this case only `--toolsets` was working.

**Root Cause**
This bug was in the logic that handles the interaction of feature flags and deprecation aliases. The deprecated alias resolution always mapped old names to canonical names (`list_workflow_runs` → `actions_list`), regardless of which tool variant was actually active. When the feature flag was off, only `list_workflow_runs` existed, but we were looking for `actions_list` because we had resolved the `list_workflow_runs` to `actions_list` regardless of the feature flag controlling which tools (pre vs post consolidation) should be enabled.

**Solution**
In this fix we store both the original name and the resolved alias in `additionalTools`. The feature flag filtering ensures only one tool variant is ever active, so there's no risk of enabling both.

I also added tests to avoid future regressions. 

### Demo (Screenshots)
<details>
  <summary>FF is OFF, `list_workflow_runs` can be individually enabled</summary>
  
<img width="888" height="435" alt="Screenshot 2026-01-09 at 11 56 20" src="https://github.com/user-attachments/assets/1aaf85cb-ac35-4b77-b234-b698d1b0cad6" />

</details>

<details>
  <summary>FF is ON, `list_workflow_runs` correctly maps to `actions_list` via the deprecation alias</summary>
  <img width="888" height="899" alt="Screenshot 2026-01-09 at 11 57 21" src="https://github.com/user-attachments/assets/62fd0800-9e44-448c-b6b9-45a3a0872270" />
</details>


<details>
  <summary>Generally, tool-specific config works as intended</summary>
  
<img width="888" height="592" alt="Screenshot 2026-01-09 at 11 57 46" src="https://github.com/user-attachments/assets/1b960d49-19ce-4201-862b-fd06c6a84a7b" />

</details>

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes https://github.com/github/copilot-agent-services/issues/1136

## What changed
<!-- Bullet list of concrete changes. -->
In this fix we store both the original name and the resolved alias in `additionalTools`.

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [X] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [X] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [X] Linted locally with `./script/lint`
- [X] Tested locally with `./script/test`

## Docs

- [X] Not needed
- [ ] Updated (README / docs / examples)
