### PR TITLE
Update Go version requirement in mcpcurl to 1.24

### DIFF
--- a/cmd/mcpcurl/README.md
+++ b/cmd/mcpcurl/README.md
@@ -16,7 +16,7 @@ be executed against the configured MCP server.
 ## Installation
 
 ### Prerequisites
-- Go 1.21 or later
+- Go 1.24 or later
 - Access to the GitHub MCP Server from either Docker or local build
 
 ### Build from Source


### PR DESCRIPTION
## Summary

Updates the Go version requirement in mcpcurl documentation from 1.21 to 1.24 to align with the project's actual requirement specified in `go.mod`.

## Why

The mcpcurl documentation stated Go 1.21 as a prerequisite, but the project requires Go 1.24.0+ according to `go.mod`. This fixes the documentation inconsistency.

## What changed

- Updated mcpcurl README to require Go 1.24 instead of 1.21

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
Documentation-only change, no impact on MCP tools or server behavior.

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
N/A - documentation change only

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
Documentation-only change.

## Tool renaming
- [x] I am not renaming tools as part of this PR

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [ ] Linted locally with `./script/lint`
- [ ] Tested locally with `./script/test`

## Docs

- [x] Updated (README / docs / examples)
Updated mcpcurl README.md with correct Go version requirement.