### PR TITLE
Consider workflow scope or user-escalation pattern for merging PRs that modify workflow files

### DIFF
--- a/pkg/scopes/scopes.go
+++ b/pkg/scopes/scopes.go
@@ -55,6 +55,9 @@ const (
 
 	// WritePackages grants write access to packages
 	WritePackages Scope = "write:packages"
+
+	// Workflow grants read and write access to GitHub Actions workflow files
+	Workflow Scope = "workflow"
 )
 
 // ScopeHierarchy defines parent-child relationships between scopes.


### PR DESCRIPTION
## Summary
Add pre-flight file inspection to `MergePullRequest` to detect workflow files and return a clear error message before attempting merge operations that would fail due to missing workflow OAuth scope.

## Why
Fixes #1815 

## What changed

- Added `Workflow` scope constant to `pkg/scopes/scopes.go`
- Added `containsWorkflowFiles `helper function to detect files in `.github/workflows/` or .`github/workflows-lab/`
- Modified `MergePullRequest` handler to check for workflow files before merge and return a descriptive error
- Added test cases for workflow file detection scenarios

## MCP impact
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [x] ` merge_pull_request` now returns an error message when the PR contains workflow files, explaining the workflow scope requirement and suggesting alternatives.
- [ ] New tool added

## Prompts tested (tool changes only)

- "Merge PR # 123 in owner/repo" (with workflow files - returns clear error)
- "Merge pull request 456" (without workflow files - succeeds as before)

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [x] Auth / permissions considered
The change proactively detects when the workflow scope would be required and provides guidance, rather than failing with a cryptic 403 error.
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR


## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
