### PR TITLE
docs: Add Claude Code OAuth plugin warning and troubleshooting

### DIFF
--- a/docs/installation-guides/install-claude.md
+++ b/docs/installation-guides/install-claude.md
@@ -2,6 +2,8 @@
 
 ## Claude Code CLI
 
+> ⚠️ **Important**: Claude Code includes a built-in `github@claude-plugins-official` plugin that attempts OAuth authentication. This plugin currently fails with "Incompatible auth server: does not support dynamic client registration" due to a compatibility issue between Claude Code's OAuth implementation and GitHub's MCP server ([anthropics/claude-code#3273](https://github.com/anthropics/claude-code/issues/3273)). **Use the PAT-based setup below instead**, which bypasses OAuth entirely and works reliably.
+
 ### Prerequisites
 - Claude Code CLI installed
 - [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new)
@@ -154,6 +156,20 @@ Add this codeblock to your `claude_desktop_config.json`:
 ---
 
 ## Troubleshooting
+
+**Built-in Plugin OAuth Errors:**
+
+If you see "Incompatible auth server: does not support dynamic client registration" when running `/mcp` in Claude Code, the built-in `github@claude-plugins-official` plugin is conflicting with the manual setup. To resolve:
+
+1. Disable the built-in plugin:
+   ```bash
+   claude plugins disable github@claude-plugins-official
+   ```
+   Or in `~/.claude/settings.json`, set `"github@claude-plugins-official": false` under `enabledPlugins`.
+
+2. Use the PAT-based setup described above instead.
+
+3. Verify with `claude mcp list` — you should see `github: ✓ Connected` (the manual config) and the plugin entry should no longer appear.
 
 **Authentication Failed:**
 - Verify PAT has `repo` scope


### PR DESCRIPTION
## Summary

Adds documentation to help Claude Code users who encounter the "Incompatible auth server: does not support dynamic client registration" error when using the built-in `github@claude-plugins-official` plugin.

## Problem

Claude Code ships with a built-in GitHub plugin that attempts OAuth authentication. However, Claude Code's OAuth implementation requires dynamic client registration, which GitHub's MCP server doesn't support. This causes the plugin to fail silently or with confusing errors, while the documented PAT-based setup works perfectly.

Users often don't realize:
1. The built-in plugin exists and is conflicting
2. The PAT-based manual setup bypasses this issue entirely
3. How to disable the broken plugin

Related issues:
- anthropics/claude-code#3273
- anthropics/claude-code#2831
- #1404

## Changes

1. **Added prominent warning** at the top of the Claude Code CLI section explaining the OAuth incompatibility
2. **Added troubleshooting section** with steps to:
   - Disable the conflicting built-in plugin
   - Verify the manual PAT-based setup is working

## Why this helps

Many users hit this issue and spend time debugging. This documentation makes the workaround discoverable and saves users from confusion until the OAuth compatibility is fixed upstream in Claude Code.

---

🤖 Generated with [Claude Code](https://claude.ai/code)