### PR TITLE
Add -t option to docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,7 @@ If you don't have Docker, you can use `go build` to build the binary in the
 The `github-mcp-server` binary includes a few CLI subcommands that are helpful for debugging and exploring the server.
 
 - `github-mcp-server tool-search "<query>"` searches tools by name, description, and input parameter names. Use `--max-results` to return more matches.
-Example:
-
-> **Note:** Color output requires a TTY. Use `docker run -t` (or `-it`) when running in Docker.
-
+Example (color output requires a TTY; use `docker run -t` (or `-it`) when running in Docker):
 ```bash
 docker run -it --rm ghcr.io/github/github-mcp-server tool-search "issue" --max-results 5
 github-mcp-server tool-search "issue" --max-results 5


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

## Why
To enable colours we need to send docker output to TTY.

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [ ] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [x] Updated (README / docs / examples)
