### PR TITLE
Spike: instruction resolver with most-specificity rule

### DIFF
--- a/pkg/github/instructions_test.go
+++ b/pkg/github/instructions_test.go
@@ -184,3 +184,211 @@ func TestGetToolsetInstructions(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// SPIKE TESTS: InstructionResolver with most-specificity rule
+// =============================================================================
+
+func TestInstructionResolver_BasicMatching(t *testing.T) {
+	resolver := NewInstructionResolver([]InstructionRule{
+		NewInstructionRule("rule-a", "Instruction A", "tool1"),
+		NewInstructionRule("rule-b", "Instruction B", "tool2"),
+		NewInstructionRule("rule-c", "Instruction C", "tool3"),
+	})
+
+	tests := []struct {
+		name         string
+		activeTools  []string
+		expectedIDs  []string
+		expectedInst []string
+	}{
+		{
+			name:         "single tool matches single rule",
+			activeTools:  []string{"tool1"},
+			expectedIDs:  []string{"rule-a"},
+			expectedInst: []string{"Instruction A"},
+		},
+		{
+			name:         "two tools match two rules",
+			activeTools:  []string{"tool1", "tool2"},
+			expectedIDs:  []string{"rule-a", "rule-b"},
+			expectedInst: []string{"Instruction A", "Instruction B"},
+		},
+		{
+			name:         "no matching tools",
+			activeTools:  []string{"tool4"},
+			expectedIDs:  []string{},
+			expectedInst: []string{},
+		},
+		{
+			name:         "all tools match all rules",
+			activeTools:  []string{"tool1", "tool2", "tool3"},
+			expectedIDs:  []string{"rule-a", "rule-b", "rule-c"},
+			expectedInst: []string{"Instruction A", "Instruction B", "Instruction C"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := resolver.MatchingRuleIDs(tt.activeTools)
+			instructions := resolver.ResolveInstructions(tt.activeTools)
+
+			if len(ids) != len(tt.expectedIDs) {
+				t.Errorf("Expected %d rule IDs, got %d: %v", len(tt.expectedIDs), len(ids), ids)
+			}
+			for i, id := range tt.expectedIDs {
+				if i >= len(ids) || ids[i] != id {
+					t.Errorf("Expected rule ID %s at position %d, got %v", id, i, ids)
+				}
+			}
+
+			if len(instructions) != len(tt.expectedInst) {
+				t.Errorf("Expected %d instructions, got %d: %v", len(tt.expectedInst), len(instructions), instructions)
+			}
+		})
+	}
+}
+
+func TestInstructionResolver_SupersetShadowing(t *testing.T) {
+	// Rule with more tools (superset) shadows rules with fewer tools
+	resolver := NewInstructionResolver([]InstructionRule{
+		NewInstructionRule("issues-read", "Read issues instruction", "get_issue", "list_issues"),
+		NewInstructionRule("issues-all", "All issues instruction", "get_issue", "list_issues", "create_issue"),
+		NewInstructionRule("create-only", "Create only instruction", "create_issue"),
+	})
+
+	tests := []struct {
+		name        string
+		activeTools []string
+		expectedIDs []string
+		description string
+	}{
+		{
+			name:        "superset rule shadows subset rules",
+			activeTools: []string{"get_issue", "list_issues", "create_issue"},
+			expectedIDs: []string{"issues-all"},
+			description: "issues-all shadows issues-read (superset) and create-only (superset)",
+		},
+		{
+			name:        "no shadowing when superset rule doesn't match",
+			activeTools: []string{"get_issue", "list_issues"},
+			expectedIDs: []string{"issues-read"},
+			description: "issues-all doesn't match (missing create_issue), so issues-read is not shadowed",
+		},
+		{
+			name:        "single tool rule not shadowed when superset doesn't match",
+			activeTools: []string{"create_issue"},
+			expectedIDs: []string{"create-only"},
+			description: "Only create-only matches",
+		},
+		{
+			name:        "extra active tools don't affect shadowing",
+			activeTools: []string{"get_issue", "list_issues", "create_issue", "get_me", "other_tool"},
+			expectedIDs: []string{"issues-all"},
+			description: "Extra tools in activeTools don't prevent shadowing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := resolver.MatchingRuleIDs(tt.activeTools)
+
+			if len(ids) != len(tt.expectedIDs) {
+				t.Errorf("%s: Expected %d rule IDs %v, got %d: %v",
+					tt.description, len(tt.expectedIDs), tt.expectedIDs, len(ids), ids)
+				return
+			}
+			for i, id := range tt.expectedIDs {
+				if i >= len(ids) || ids[i] != id {
+					t.Errorf("%s: Expected rule ID %s at position %d, got %v",
+						tt.description, id, i, ids)
+				}
+			}
+		})
+	}
+}
+
+func TestInstructionResolver_PartialOverlapNoShadowing(t *testing.T) {
+	// Rules with partial overlap (neither is superset of other) should both apply
+	resolver := NewInstructionResolver([]InstructionRule{
+		NewInstructionRule("rule-ab", "AB instruction", "tool_a", "tool_b"),
+		NewInstructionRule("rule-bc", "BC instruction", "tool_b", "tool_c"),
+	})
+
+	// When all three tools are active, both rules match
+	// Neither is a superset of the other, so neither is shadowed
+	ids := resolver.MatchingRuleIDs([]string{"tool_a", "tool_b", "tool_c"})
+
+	if len(ids) != 2 {
+		t.Errorf("Expected 2 rules (partial overlap, no shadowing), got %d: %v", len(ids), ids)
+	}
+}
+
+func TestInstructionResolver_ComplexHierarchy(t *testing.T) {
+	// Create a hierarchy: rule1 ⊂ rule2 ⊂ rule3
+	resolver := NewInstructionResolver([]InstructionRule{
+		NewInstructionRule("level1", "Level 1 instruction", "t1"),
+		NewInstructionRule("level2", "Level 2 instruction", "t1", "t2"),
+		NewInstructionRule("level3", "Level 3 instruction", "t1", "t2", "t3"),
+	})
+
+	tests := []struct {
+		name        string
+		activeTools []string
+		expectedIDs []string
+	}{
+		{
+			name:        "only level1 active",
+			activeTools: []string{"t1"},
+			expectedIDs: []string{"level1"},
+		},
+		{
+			name:        "level1 and level2 tools active",
+			activeTools: []string{"t1", "t2"},
+			expectedIDs: []string{"level2"}, // shadows level1
+		},
+		{
+			name:        "all three levels active",
+			activeTools: []string{"t1", "t2", "t3"},
+			expectedIDs: []string{"level3"}, // shadows level1 and level2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := resolver.MatchingRuleIDs(tt.activeTools)
+			if len(ids) != len(tt.expectedIDs) {
+				t.Errorf("Expected %v, got %v", tt.expectedIDs, ids)
+			}
+		})
+	}
+}
+
+func TestInstructionResolver_EmptyRules(t *testing.T) {
+	resolver := NewInstructionResolver([]InstructionRule{})
+
+	ids := resolver.MatchingRuleIDs([]string{"tool1", "tool2"})
+	if len(ids) != 0 {
+		t.Errorf("Expected no matches for empty resolver, got %v", ids)
+	}
+
+	instructions := resolver.ResolveInstructions([]string{"tool1"})
+	if len(instructions) != 0 {
+		t.Errorf("Expected no instructions for empty resolver, got %v", instructions)
+	}
+}
+
+func TestInstructionResolver_EmptyActiveTools(t *testing.T) {
+	resolver := NewInstructionResolver([]InstructionRule{
+		NewInstructionRule("rule1", "Instruction 1", "tool1"),
+	})
+
+	ids := resolver.MatchingRuleIDs([]string{})
+	if len(ids) != 0 {
+		t.Errorf("Expected no matches for empty active tools, got %v", ids)
+	}
+}
+
+// =============================================================================
+// END SPIKE TESTS
+// =============================================================================


### PR DESCRIPTION
## Summary

Exploratory spike to evaluate finer-grained instruction control by associating instructions with specific sets of tools rather than whole toolsets.

## Design

### Core Types

- `InstructionRule` - Associates an instruction with a set of tool names
- `InstructionResolver` - Resolves which instructions apply using the most-specificity rule

### Specificity Algorithm

1. A rule **matches** when ALL its tools are present in active tools
2. When Rule A's tools are a **proper superset** of Rule B's tools (A ⊃ B), A **shadows** B
3. Partial overlaps (neither is superset) → both rules apply
4. Output is sorted for determinism

### Example

```go
rules := []InstructionRule{
    NewInstructionRule("issues-all", "All issues instruction", "get_issue", "list_issues", "create_issue"),
    NewInstructionRule("issues-read", "Read issues instruction", "get_issue", "list_issues"),
    NewInstructionRule("create-only", "Create only instruction", "create_issue"),
}

// Active tools: {get_issue, list_issues, create_issue}
// Result: Only "issues-all" applies (shadows the other two)

// Active tools: {get_issue, list_issues}  
// Result: Only "issues-read" applies
```

## Testing

All tests pass:
- `TestInstructionResolver_BasicMatching`
- `TestInstructionResolver_SupersetShadowing`
- `TestInstructionResolver_PartialOverlapNoShadowing`
- `TestInstructionResolver_ComplexHierarchy`
- `TestInstructionResolver_EmptyRules`
- `TestInstructionResolver_EmptyActiveTools`

## Next Steps (if we proceed)

- Integrate with existing `GenerateInstructions()` or create a V2
- Define actual instruction rules based on tool combinations
- Consider adding priority/weight for equal-size rule conflicts
