### PR TITLE
Fix mcp-diff workflow triggers for push events and tags

### DIFF
--- a/.github/workflows/mcp-diff.yml
+++ b/.github/workflows/mcp-diff.yml
@@ -2,6 +2,9 @@ name: MCP Server Diff
 
 on:
   pull_request:
+  push:
+    branches: [main]
+    tags: ['v*']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Fixes the MCP Server Diff workflow to trigger correctly in all expected scenarios.

## Problem

The workflow was only triggered on `pull_request` events, which doesn't run when:
- Commits are pushed/merged to a PR branch
- Tags are pushed for releases

## Solution

Added `push` triggers for:
- **`branches: [main]`** - Runs when PRs are merged to main
- **`tags: ['v*']`** - Runs on tag pushes, enabling automatic comparison against the previous tag (e.g., `v1.2.0` compares against `v1.1.0`)

This follows the recommended setup from [mcp-server-diff documentation](https://github.com/SamMorrowDrums/mcp-server-diff#quick-start).

## Testing

The workflow will now run on this PR via the existing `pull_request` trigger, and will also run when merged to main or when releasing with tags.