### PR TITLE
docs: add Copilot CLI installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 
 ### Install in other MCP hosts
 
+- **[Copilot CLI](/docs/installation-guides/install-copilot-cli.md)** - Installation guide for GitHub Copilot CLI
 - **[GitHub Copilot in other IDEs](/docs/installation-guides/install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
 - **[Claude Applications](/docs/installation-guides/install-claude.md)** - Installation guide for Claude Desktop and Claude Code CLI
 - **[Codex](/docs/installation-guides/install-codex.md)** - Installation guide for OpenAI Codex
@@ -350,6 +351,7 @@ Optionally, you can add a similar example (i.e. without the mcp key) to a file c
 
 For other MCP host applications, please refer to our installation guides:
 
+- **[Copilot CLI](docs/installation-guides/install-copilot-cli.md)** - Installation guide for GitHub Copilot CLI
 - **[GitHub Copilot in other IDEs](/docs/installation-guides/install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
 - **[Claude Code & Claude Desktop](docs/installation-guides/install-claude.md)** - Installation guide for Claude Code and Claude Desktop
 - **[Cursor](docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE

--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -3,6 +3,7 @@
 This directory contains detailed installation instructions for the GitHub MCP Server across different host applications and IDEs. Choose the guide that matches your development environment.
 
 ## Installation Guides by Host Application
+- **[Copilot CLI](install-copilot-cli.md)** - Installation guide for GitHub Copilot CLI
 - **[GitHub Copilot in other IDEs](install-other-copilot-ides.md)** - Installation for JetBrains, Visual Studio, Eclipse, and Xcode with GitHub Copilot
 - **[Antigravity](install-antigravity.md)** - Installation for Google Antigravity IDE
 - **[Claude Applications](install-claude.md)** - Installation guide for Claude Web, Claude Desktop and Claude Code CLI
@@ -15,6 +16,7 @@ This directory contains detailed installation instructions for the GitHub MCP Se
 
 | Host Application | Local GitHub MCP Support | Remote GitHub MCP Support | Prerequisites | Difficulty |
 |-----------------|---------------|----------------|---------------|------------|
+| Copilot CLI | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Copilot in VS Code | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: VS Code 1.101+ | Easy |
 | Copilot Coding Agent | ✅ | ✅ Full (on by default; no auth needed) | Any _paid_ copilot license | Default on |
 | Copilot in Visual Studio | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: Visual Studio 17.14+ | Easy |

--- a/docs/installation-guides/install-copilot-cli.md
+++ b/docs/installation-guides/install-copilot-cli.md
@@ -10,7 +10,7 @@
 <summary><b>Storing Your PAT Securely</b></summary>
 <br>
 
-For security, avoid hardcoding your token. Set your PAT as an environment variable:
+To set your PAT as an environment variable:
 
 ```bash
 # Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)

--- a/docs/installation-guides/install-copilot-cli.md
+++ b/docs/installation-guides/install-copilot-cli.md
@@ -1,0 +1,136 @@
+# Install GitHub MCP Server in Copilot CLI
+
+## Prerequisites
+
+1. Copilot CLI installed (see [official Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli))
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new) with appropriate scopes
+3. For local installation: [Docker](https://www.docker.com/) installed and running
+
+<details>
+<summary><b>Storing Your PAT Securely</b></summary>
+<br>
+
+For security, avoid hardcoding your token. Set your PAT as an environment variable:
+
+```bash
+# Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+export GITHUB_PERSONAL_ACCESS_TOKEN=your_token_here
+```
+
+</details>
+
+## GitHub MCP Server Configuration
+
+You can configure the GitHub MCP server in Copilot CLI using either the interactive command or by manually editing the configuration file.
+
+### Method 1: Interactive Setup (Recommended)
+
+Use the Copilot CLI to interactively add the MCP server:
+
+```
+/mcp add
+```
+
+Follow the prompts to configure the GitHub MCP server.
+
+### Method 2: Manual Configuration
+
+Create or edit the configuration file `~/.copilot/mcp-config.json` and add one of the following configurations:
+
+#### Remote Server
+
+Connect to the hosted MCP server:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+#### Local Docker
+
+With Docker running, you can run the GitHub MCP server in a container:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+#### Binary
+
+You can download the latest binary release from the [GitHub releases page](https://github.com/github/github-mcp-server/releases) or build it from source by running `go build -o github-mcp-server ./cmd/github-mcp-server`.
+
+Then, replacing `/path/to/binary` with the actual path to your binary, configure Copilot CLI with:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "/path/to/binary",
+      "args": ["stdio"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+## Verification
+
+To verify that the GitHub MCP server has been configured:
+
+1. Start or restart Copilot CLI
+2. The GitHub tools should be available for use in your conversations
+
+## Troubleshooting
+
+### Local Server Issues
+
+- **Docker errors**: Ensure Docker Desktop is running
+    ```bash
+    docker --version
+    ```
+- **Image pull failures**: Try `docker logout ghcr.io` then retry
+- **Docker not found**: Install Docker Desktop and ensure it's running
+
+### Authentication Issues
+
+- **Invalid PAT**: Verify your GitHub PAT has correct scopes:
+    - `repo` - Repository operations
+    - `read:packages` - Docker image access (if using Docker)
+- **Token expired**: Generate a new GitHub PAT
+
+### Configuration Issues
+
+- **Invalid JSON**: Validate your configuration:
+    ```bash
+    cat ~/.copilot/mcp-config.json | jq .
+    ```
+
+## References
+
+- [Copilot CLI Documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)

--- a/docs/installation-guides/install-copilot-cli.md
+++ b/docs/installation-guides/install-copilot-cli.md
@@ -27,7 +27,7 @@ You can configure the GitHub MCP server in Copilot CLI using either the interact
 
 Use the Copilot CLI to interactively add the MCP server:
 
-```
+```bash
 /mcp add
 ```
 


### PR DESCRIPTION
## Summary
Adds installation instructions for the GitHub MCP Server in Copilot CLI.

## Why
Users need documentation on how to configure the GitHub MCP Server with Copilot CLI, similar to existing guides for other MCP hosts like Gemini CLI, Claude, and Cursor.

## What changed
- Added `docs/installation-guides/install-copilot-cli.md` with complete setup instructions
- Updated `README.md` to include Copilot CLI in both installation guide lists
- Updated `docs/installation-guides/README.md` to include Copilot CLI in guides list and support table

## MCP impact
- [x] No tool or API changes

## Prompts tested (tool changes only)
N/A - documentation only

## Security / limits
- [x] No security or limits impact

## Tool renaming
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [ ] Linted locally with `./script/lint` - N/A for docs-only changes
- [ ] Tested locally with `./script/test` - N/A for docs-only changes

## Docs
- [x] Updated (README / docs / examples)