### PR TITLE
Token extraction middleware 401

### DIFF
--- a/pkg/http/middleware/token.go
+++ b/pkg/http/middleware/token.go
@@ -50,7 +50,13 @@ func ExtractUserToken(oauthCfg *oauth.Config) func(next http.Handler) http.Handl
 					sendAuthChallenge(w, r, oauthCfg)
 					return
 				}
-				// For other auth errors (bad format, unsupported), return 400
+				// For invalid token format, behavior depends on ValidateTokenFormat config:
+				// - When true: return 401 with WWW-Authenticate header (local server validates)
+				// - When false: return 400 Bad Request (CAPI/remote validates)
+				if oauthCfg != nil && oauthCfg.ValidateTokenFormat {
+					sendAuthChallenge(w, r, oauthCfg)
+					return
+				}
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}

--- a/pkg/http/middleware/token_test.go
+++ b/pkg/http/middleware/token_test.go
@@ -1,0 +1,223 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/http/oauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractUserToken(t *testing.T) {
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name                string
+		authHeader          string
+		validateTokenFormat bool
+		expectedStatus      int
+		expectWWWAuth       bool
+	}{
+		{
+			name:                "valid PAT token passes through",
+			authHeader:          "Bearer ghp_test1234567890123456789012345678901234",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusOK,
+			expectWWWAuth:       false,
+		},
+		{
+			name:                "valid fine-grained PAT passes through",
+			authHeader:          "Bearer github_pat_test1234567890123456789012345678901234",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusOK,
+			expectWWWAuth:       false,
+		},
+		{
+			name:                "valid OAuth token passes through",
+			authHeader:          "Bearer gho_test1234567890123456789012345678901234",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusOK,
+			expectWWWAuth:       false,
+		},
+		{
+			name:                "valid old-style token passes through",
+			authHeader:          "Bearer 1234567890abcdef1234567890abcdef12345678",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusOK,
+			expectWWWAuth:       false,
+		},
+		{
+			name:                "IDE token passes through",
+			authHeader:          "Bearer tid=1;exp=25145314523;chat=1:hmac",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusOK,
+			expectWWWAuth:       false,
+		},
+		{
+			name:                "missing auth header returns 401 with WWW-Authenticate",
+			authHeader:          "",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusUnauthorized,
+			expectWWWAuth:       true,
+		},
+		{
+			name:                "invalid token format returns 400 when ValidateTokenFormat is false",
+			authHeader:          "Bearer invalid_token",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusBadRequest,
+			expectWWWAuth:       false,
+		},
+		{
+			name:                "invalid token format returns 401 with WWW-Authenticate when ValidateTokenFormat is true",
+			authHeader:          "Bearer invalid_token",
+			validateTokenFormat: true,
+			expectedStatus:      http.StatusUnauthorized,
+			expectWWWAuth:       true,
+		},
+		{
+			name:                "GitHub-Bearer prefix returns 400 when ValidateTokenFormat is false",
+			authHeader:          "GitHub-Bearer some_token",
+			validateTokenFormat: false,
+			expectedStatus:      http.StatusBadRequest,
+			expectWWWAuth:       false,
+		},
+		{
+			name:                "GitHub-Bearer prefix returns 401 when ValidateTokenFormat is true",
+			authHeader:          "GitHub-Bearer some_token",
+			validateTokenFormat: true,
+			expectedStatus:      http.StatusUnauthorized,
+			expectWWWAuth:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oauthCfg := &oauth.Config{
+				BaseURL:             "https://api.github.com",
+				ValidateTokenFormat: tc.validateTokenFormat,
+			}
+
+			middleware := ExtractUserToken(oauthCfg)
+			handler := middleware(dummyHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.expectedStatus, rr.Code)
+
+			if tc.expectWWWAuth {
+				wwwAuth := rr.Header().Get("WWW-Authenticate")
+				require.NotEmpty(t, wwwAuth, "expected WWW-Authenticate header to be set")
+				assert.True(t, strings.HasPrefix(wwwAuth, "Bearer resource_metadata="),
+					"WWW-Authenticate header should have Bearer resource_metadata format")
+			} else {
+				assert.Empty(t, rr.Header().Get("WWW-Authenticate"),
+					"WWW-Authenticate header should not be set")
+			}
+		})
+	}
+}
+
+func TestParseAuthorizationHeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		authHeader   string
+		expectedAuth authType
+		expectError  bool
+	}{
+		{
+			name:         "classic PAT",
+			authHeader:   "Bearer ghp_abcdef1234567890",
+			expectedAuth: authTypeGhToken,
+			expectError:  false,
+		},
+		{
+			name:         "fine-grained PAT",
+			authHeader:   "Bearer github_pat_abcdef1234567890",
+			expectedAuth: authTypeGhToken,
+			expectError:  false,
+		},
+		{
+			name:         "OAuth token",
+			authHeader:   "Bearer gho_abcdef1234567890",
+			expectedAuth: authTypeGhToken,
+			expectError:  false,
+		},
+		{
+			name:         "user access token",
+			authHeader:   "Bearer ghu_abcdef1234567890",
+			expectedAuth: authTypeGhToken,
+			expectError:  false,
+		},
+		{
+			name:         "installation token",
+			authHeader:   "Bearer ghs_abcdef1234567890",
+			expectedAuth: authTypeGhToken,
+			expectError:  false,
+		},
+		{
+			name:         "old-style 40 char hex token",
+			authHeader:   "Bearer 1234567890abcdef1234567890abcdef12345678",
+			expectedAuth: authTypeGhToken,
+			expectError:  false,
+		},
+		{
+			name:         "IDE token with colon",
+			authHeader:   "Bearer tid=1;exp=25145314523;chat=1:hmac",
+			expectedAuth: authTypeIDE,
+			expectError:  false,
+		},
+		{
+			name:         "lowercase bearer",
+			authHeader:   "bearer ghp_abcdef1234567890",
+			expectedAuth: authTypeGhToken,
+			expectError:  false,
+		},
+		{
+			name:         "missing header",
+			authHeader:   "",
+			expectedAuth: 0,
+			expectError:  true,
+		},
+		{
+			name:         "unsupported prefix",
+			authHeader:   "GitHub-Bearer token",
+			expectedAuth: 0,
+			expectError:  true,
+		},
+		{
+			name:         "invalid token format",
+			authHeader:   "Bearer invalid",
+			expectedAuth: 0,
+			expectError:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+
+			authType, _, err := parseAuthorizationHeader(req)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedAuth, authType)
+			}
+		})
+	}
+}

--- a/pkg/http/oauth/oauth.go
+++ b/pkg/http/oauth/oauth.go
@@ -51,6 +51,12 @@ type Config struct {
 	// This is used to restore the original path when a proxy strips a base path before forwarding.
 	// If empty, requests are treated as already using the external path.
 	ResourcePath string
+
+	// ValidateTokenFormat controls whether the token extraction middleware validates
+	// the token format and returns a 401 with WWW-Authenticate header for invalid tokens.
+	// When false (default), invalid tokens pass through for validation elsewhere (e.g., CAPI).
+	// When true, invalid tokens receive a 401 response with OAuth challenge headers.
+	ValidateTokenFormat bool
 }
 
 // AuthHandler handles OAuth-related HTTP endpoints.


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

This pull request updates the token extraction middleware to support configurable handling of invalid token formats, and introduces comprehensive unit tests for its behavior. The main change is the addition of a `ValidateTokenFormat` option in the OAuth config, which determines whether the middleware returns a 401 Unauthorized (with a WWW-Authenticate header) or a 400 Bad Request for invalid token formats. This makes the authentication flow more flexible and testable.

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes #

## What changed
<!-- Bullet list of concrete changes. -->
- 
- 

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [x] Auth / permissions considered
- [x] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [ ] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
