### PR TITLE
Add issue dependency support (blocked by/blocking relationships) - Fixes #950

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,18 @@ The following sets of tools are available:
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
 
+- **dependency_write** - Manage issue dependencies
+  - **Required OAuth Scopes**: `repo`
+  - `dependency_issue_number`: The number of the issue that blocks this issue (for 'add') or the dependency ID (for 'remove') (number, required)
+  - `issue_number`: The number of the issue (number, required)
+  - `method`: The action to perform on issue dependencies.
+    Options are:
+    - 'add' - add a dependency relationship (mark an issue as blocked by another issue).
+    - 'remove' - remove a dependency relationship.
+    				 (string, required)
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+
 - **get_label** - Get a specific label from a repository.
   - **Required OAuth Scopes**: `repo`
   - `name`: Label name. (string, required)
@@ -817,6 +829,7 @@ The following sets of tools are available:
     2. get_comments - Get issue comments.
     3. get_sub_issues - Get sub-issues of the issue.
     4. get_labels - Get labels assigned to the issue.
+    5. get_dependencies - Get issue dependencies (blocked by/blocking relationships).
      (string, required)
   - `owner`: The owner of the repository (string, required)
   - `page`: Page number for pagination (min 1) (number, optional)

--- a/pkg/github/__toolsnaps__/issue_read.snap
+++ b/pkg/github/__toolsnaps__/issue_read.snap
@@ -11,12 +11,13 @@
         "type": "number"
       },
       "method": {
-        "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues of the issue.\n4. get_labels - Get labels assigned to the issue.\n",
+        "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues of the issue.\n4. get_labels - Get labels assigned to the issue.\n5. get_dependencies - Get issue dependencies (blocked by/blocking relationships).\n",
         "enum": [
           "get",
           "get_comments",
           "get_sub_issues",
-          "get_labels"
+          "get_labels",
+          "get_dependencies"
         ],
         "type": "string"
       },

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -325,7 +325,7 @@ Options are:
 				result, err := GetIssueLabels(ctx, gqlClient, owner, repo, issueNumber)
 				return result, nil, err
 			case "get_dependencies":
-				result, err := GetIssueDependencies(ctx, client, deps.GetRepoAccessCache(), owner, repo, issueNumber)
+				result, err := GetIssueDependencies(ctx, client, owner, repo, issueNumber)
 				return result, nil, err
 			default:
 				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
@@ -2142,7 +2142,7 @@ type IssueDependencies struct {
 
 // GetIssueDependencies retrieves dependency information for an issue.
 // Returns both "depends_on" (issues blocking this issue) and "blocking" (issues blocked by this issue).
-func GetIssueDependencies(ctx context.Context, client *github.Client, cache *lockdown.RepoAccessCache, owner string, repo string, issueNumber int) (*mcp.CallToolResult, error) {
+func GetIssueDependencies(ctx context.Context, client *github.Client, owner string, repo string, issueNumber int) (*mcp.CallToolResult, error) {
 	url := fmt.Sprintf("repos/%s/%s/issues/%d/dependencies", owner, repo, issueNumber)
 	req, err := client.NewRequest("GET", url, nil)
 	if err != nil {
@@ -2269,11 +2269,11 @@ Options are:
 // The issue specified by issueNumber will be blocked by the issue specified by dependencyIssueNumber.
 func AddIssueDependency(ctx context.Context, client *github.Client, owner string, repo string, issueNumber int, dependencyIssueNumber int) (*mcp.CallToolResult, error) {
 	url := fmt.Sprintf("repos/%s/%s/issues/%d/dependencies", owner, repo, issueNumber)
-	
+
 	body := map[string]interface{}{
 		"dependency_issue_id": dependencyIssueNumber,
 	}
-	
+
 	req, err := client.NewRequest("POST", url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -2300,8 +2300,8 @@ func AddIssueDependency(ctx context.Context, client *github.Client, owner string
 	}
 
 	r, err := json.Marshal(map[string]interface{}{
-		"success": true,
-		"message": fmt.Sprintf("Issue #%d is now blocked by issue #%d", issueNumber, dependencyIssueNumber),
+		"success":    true,
+		"message":    fmt.Sprintf("Issue #%d is now blocked by issue #%d", issueNumber, dependencyIssueNumber),
 		"dependency": dependency,
 	})
 	if err != nil {
@@ -2314,7 +2314,7 @@ func AddIssueDependency(ctx context.Context, client *github.Client, owner string
 // RemoveIssueDependency removes a dependency relationship between two issues.
 func RemoveIssueDependency(ctx context.Context, client *github.Client, owner string, repo string, issueNumber int, dependencyID int) (*mcp.CallToolResult, error) {
 	url := fmt.Sprintf("repos/%s/%s/issues/%d/dependencies/%d", owner, repo, issueNumber, dependencyID)
-	
+
 	req, err := client.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -195,6 +195,7 @@ func AllTools(t translations.TranslationHelperFunc) []inventory.ServerTool {
 		AddIssueComment(t),
 		AssignCopilotToIssue(t),
 		SubIssueWrite(t),
+		DependencyWrite(t),
 
 		// User tools
 		SearchUsers(t),


### PR DESCRIPTION
## Summary
  This PR implements issue dependency support requested in #950, adding the ability to read and write "blocked by" and "blocking" relationships between GitHub issues.

  ## Changes
  ### Read Functionality
  - Added `get_dependencies` method to `IssueRead` tool
  - Implemented `GetIssueDependencies()` function to fetch issue dependencies
  - Added `IssueDependency` and `IssueDependencies` data structures

  ### Write Functionality
  - Implemented `DependencyWrite` tool with `add` and `remove` methods
  - Implemented `AddIssueDependency()` function to create dependency relationships
  - Implemented `RemoveIssueDependency()` function to delete dependency relationships
  - Registered `DependencyWrite` in the AllTools list

  ## Implementation Details
  The implementation uses custom API requests via `client.NewRequest()` and `client.Do()` since the go-github library doesn't have built-in support for the issue dependencies endpoints:
  - `GET /repos/{owner}/{repo}/issues/{number}/dependencies` - List dependencies
  - `POST /repos/{owner}/{repo}/issues/{number}/dependencies` - Add dependency
  - `DELETE /repos/{owner}/{repo}/issues/{number}/dependencies/{id}` - Remove dependency

  ## Quality Assurance
  ✅ All tests passing
  ✅ Linter passing (0 issues)
  ✅ Documentation generated
  ✅ Tool snapshots updated

  ## Related Issues
  Closes #950

  ## Checklist
  - [x] Implementation follows existing code patterns (similar to `SubIssueWrite`)
  - [x] Added comprehensive error handling
  - [x] Used appropriate data structures
  - [x] Registered tool in AllTools list
  - [x] Tests passing
  - [x] Linter passing
  - [x] Documentation generated
