### PR TITLE
Improve Copilot CLI installation doc

### DIFF
--- a/docs/installation-guides/install-copilot-cli.md
+++ b/docs/installation-guides/install-copilot-cli.md
@@ -31,7 +31,7 @@ copilot --add-github-mcp-tool list_discussions
 copilot --disable-builtin-mcps
 ```
 
-Run `copilot --help` for all available flags. For the list of toolsets and tools, see the [toolsets documentation](../../README.md#available-toolsets).
+Run `copilot --help` for all available flags. For the list of toolsets, see [Available toolsets](../../README.md#available-toolsets); for the list of tools, see [Tools](../../README.md#tools).
 
 ## Custom Configuration
 


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

This PR restructures the Copilot CLI installation guide to reflect that the server comes pre-installed. It also adds CLI flags documentation, server naming behaviour, and fixes the provided remote config.

## Why
<!-- Why is this change needed? Link issues or discussions. -->
- The original doc assumed users needed to configure the server from scratch.
- The provided remote config was missing the `type` field

## What changed
<!-- Bullet list of concrete changes. -->
- 
- 

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [ ] Linted locally with `./script/lint`
- [ ] Tested locally with `./script/test`

Docs only change.

## Docs

- [ ] Not needed
- [x] Updated (README / docs / examples)
