### PR TITLE
chore: update local golangci-lint installation

### DIFF
--- a/script/lint
+++ b/script/lint
@@ -11,4 +11,4 @@ if [ ! -f "$BINARY" ]; then
     curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b "$BINDIR" "$GOLANGCI_LINT_VERSION"
 fi
 
-$BINARY run
+"$BINARY" run


### PR DESCRIPTION
## Summary

Updates the installation script URL for golangci-lint in the `script/lint`.

## Why

According to the [official docs](https://golangci-lint.run/docs/welcome/install/local/#binaries), installation commands are as follows:

```sh
# binary will be $(go env GOPATH)/bin/golangci-lint
curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0

# or install it into ./bin/
curl -sSfL https://golangci-lint.run/install.sh | sh -s v2.8.0

# In Alpine Linux (as it does not come with curl by default)
wget -O- -nv https://golangci-lint.run/install.sh | sh -s v2.8.0
```

P.S. I'm one of the Golangci-lint [developers](https://github.com/golangci/golangci-lint/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Aalexandear+is%3Aclosed).

## What changed

- Changed the URL to `install.sh` in `script/lint`.
- Added explicit installation path (`-b "$BINDIR"`).
- Added a newline to the EOF in `script/lint` for consistency.

## MCP impact
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
- N/A

## Security / limits
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR


## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)