### PR TITLE
Add shared SchemaCache for streamable-http server

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/go-chi/chi/v5"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // knownFeatureFlags are the feature flags that can be enabled via X-MCP-Features header.
@@ -135,12 +134,8 @@ func RunHTTPServer(cfg ServerConfig) error {
 		serverOptions = append(serverOptions, WithScopeFetcher(scopeFetcher))
 	}
 
-	// Create a shared schema cache to avoid repeated JSON schema reflection
-	// when a new MCP Server is created per request in stateless mode.
-	schemaCache := mcp.NewSchemaCache()
-
 	r := chi.NewRouter()
-	handler := NewHTTPMcpHandler(ctx, &cfg, deps, t, logger, apiHost, append(serverOptions, WithFeatureChecker(featureChecker), WithOAuthConfig(oauthCfg), WithSchemaCache(schemaCache))...)
+	handler := NewHTTPMcpHandler(ctx, &cfg, deps, t, logger, apiHost, append(serverOptions, WithFeatureChecker(featureChecker), WithOAuthConfig(oauthCfg))...)
 	oauthHandler, err := oauth.NewAuthHandler(oauthCfg)
 	if err != nil {
 		return fmt.Errorf("failed to create OAuth handler: %w", err)


### PR DESCRIPTION
## Summary

Creates a shared `mcp.SchemaCache` in `RunHTTPServer` and passes it through to each per-request MCP Server via `ServerOptions.SchemaCache`.

## Motivation

In streamable-http (stateless) mode, a new `mcp.Server` is created for every request. Without a shared cache, JSON schema reflection and resolution is repeated on every request for every tool. The go-sdk's `SchemaCache` (`sync.Map`-backed, goroutine-safe) caches these schemas across server instances, matching the pattern already used by the remote server.

## Changes

- **`pkg/http/server.go`**: Create `mcp.NewSchemaCache()` once at startup, pass via `WithSchemaCache` option
- **`pkg/http/handler.go`**: Add `SchemaCache` field to `Handler`/`HandlerOptions`, `WithSchemaCache` option func, and set `so.SchemaCache` on per-request `ServerOptions`