### PR TITLE
fix: add MCP initialize handshake to mcpcurl

### DIFF
--- a/cmd/mcpcurl/main.go
+++ b/cmd/mcpcurl/main.go
@@ -503,6 +503,9 @@ func readJSONRPCResponse(scanner *bufio.Scanner) (string, error) {
 			return "", fmt.Errorf("failed to parse JSON-RPC message: %w", err)
 		}
 		if _, hasID := msg["id"]; hasID {
+			if errField, hasErr := msg["error"]; hasErr {
+				return "", fmt.Errorf("server returned error: %s", string(errField))
+			}
 			return line, nil
 		}
 		// No "id" — this is a notification, skip it

--- a/cmd/mcpcurl/main.go
+++ b/cmd/mcpcurl/main.go
@@ -408,11 +408,13 @@ func executeServerCommand(cmdStr, jsonRequest string) (string, error) {
 		return "", fmt.Errorf("failed to start command: %w", err)
 	}
 
-	// Ensure the child process is cleaned up on any error after Start()
-	cleanup := func() {
+	// Ensure the child process is cleaned up on every return path.
+	// stdin must be closed before Wait so the server sees EOF and exits;
+	// its non-zero exit status on EOF is expected, so we ignore the error.
+	defer func() {
 		_ = stdin.Close()
 		_ = cmd.Wait()
-	}
+	}()
 
 	// Use a scanner with a large buffer for reading JSON-RPC responses
 	scanner := bufio.NewScanner(stdoutPipe)
@@ -421,42 +423,32 @@ func executeServerCommand(cmdStr, jsonRequest string) (string, error) {
 	// Step 1: Send MCP initialize request
 	initReq, err := buildInitializeRequest()
 	if err != nil {
-		cleanup()
 		return "", fmt.Errorf("failed to build initialize request: %w", err)
 	}
 	if _, err := io.WriteString(stdin, initReq+"\n"); err != nil {
-		cleanup()
 		return "", fmt.Errorf("failed to write initialize request: %w", err)
 	}
 
 	// Step 2: Read initialize response (skip any server notifications)
 	if _, err := readJSONRPCResponse(scanner); err != nil {
-		cleanup()
 		return "", fmt.Errorf("failed to read initialize response: %w, stderr: %s", err, stderr.String())
 	}
 
 	// Step 3: Send initialized notification
 	if _, err := io.WriteString(stdin, buildInitializedNotification()+"\n"); err != nil {
-		cleanup()
 		return "", fmt.Errorf("failed to write initialized notification: %w", err)
 	}
 
 	// Step 4: Send the actual request
 	if _, err := io.WriteString(stdin, jsonRequest+"\n"); err != nil {
-		cleanup()
 		return "", fmt.Errorf("failed to write request: %w", err)
 	}
 
 	// Step 5: Read the actual response (skip any server notifications)
 	response, err := readJSONRPCResponse(scanner)
 	if err != nil {
-		cleanup()
 		return "", fmt.Errorf("failed to read response: %w, stderr: %s", err, stderr.String())
 	}
-
-	// Close stdin and wait for process to exit. The server will see EOF and
-	// exit with a non-zero status, which is expected — we already have the response.
-	cleanup()
 
 	return response, nil
 }

--- a/cmd/mcpcurl/main_test.go
+++ b/cmd/mcpcurl/main_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestReadJSONRPCResponse_DirectResponse(t *testing.T) {
+	t.Parallel()
+	input := `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}` + "\n"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	got, err := readJSONRPCResponse(scanner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}` {
+		t.Fatalf("unexpected response: %s", got)
+	}
+}
+
+func TestReadJSONRPCResponse_SkipsNotifications(t *testing.T) {
+	t.Parallel()
+	input := strings.Join([]string{
+		`{"jsonrpc":"2.0","method":"notifications/resources/list_changed","params":{}}`,
+		`{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`,
+		`{"jsonrpc":"2.0","id":42,"result":{"content":[{"type":"text","text":"hello"}]}}`,
+	}, "\n") + "\n"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	got, err := readJSONRPCResponse(scanner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var msg map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got), &msg); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	// Verify we got the response with id:42, not a notification
+	var id int
+	if err := json.Unmarshal(msg["id"], &id); err != nil {
+		t.Fatalf("failed to parse id: %v", err)
+	}
+	if id != 42 {
+		t.Fatalf("expected id 42, got %d", id)
+	}
+}
+
+func TestReadJSONRPCResponse_NoResponse(t *testing.T) {
+	t.Parallel()
+	// Only notifications, no response
+	input := `{"jsonrpc":"2.0","method":"notifications/resources/list_changed","params":{}}` + "\n"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	_, err := readJSONRPCResponse(scanner)
+	if err == nil {
+		t.Fatal("expected error for missing response, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected end of output") {
+		t.Fatalf("expected 'unexpected end of output' error, got: %v", err)
+	}
+}
+
+func TestReadJSONRPCResponse_EmptyInput(t *testing.T) {
+	t.Parallel()
+	scanner := bufio.NewScanner(strings.NewReader(""))
+
+	_, err := readJSONRPCResponse(scanner)
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestReadJSONRPCResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	input := "not valid json\n"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	_, err := readJSONRPCResponse(scanner)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse JSON-RPC message") {
+		t.Fatalf("expected parse error, got: %v", err)
+	}
+}
+
+func TestBuildInitializeRequest(t *testing.T) {
+	t.Parallel()
+	got, err := buildInitializeRequest()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var msg map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got), &msg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	// Verify required fields
+	for _, field := range []string{"jsonrpc", "id", "method", "params"} {
+		if _, ok := msg[field]; !ok {
+			t.Errorf("missing required field %q", field)
+		}
+	}
+
+	// Verify method
+	var method string
+	if err := json.Unmarshal(msg["method"], &method); err != nil {
+		t.Fatalf("failed to parse method: %v", err)
+	}
+	if method != "initialize" {
+		t.Errorf("expected method 'initialize', got %q", method)
+	}
+
+	// Verify params contain protocolVersion and clientInfo
+	var params map[string]json.RawMessage
+	if err := json.Unmarshal(msg["params"], &params); err != nil {
+		t.Fatalf("failed to parse params: %v", err)
+	}
+	for _, field := range []string{"protocolVersion", "capabilities", "clientInfo"} {
+		if _, ok := params[field]; !ok {
+			t.Errorf("missing params field %q", field)
+		}
+	}
+
+	var version string
+	if err := json.Unmarshal(params["protocolVersion"], &version); err != nil {
+		t.Fatalf("failed to parse protocolVersion: %v", err)
+	}
+	if version != "2024-11-05" {
+		t.Errorf("expected protocolVersion '2024-11-05', got %q", version)
+	}
+}
+
+func TestBuildInitializedNotification(t *testing.T) {
+	t.Parallel()
+	got := buildInitializedNotification()
+
+	var msg map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got), &msg); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	// Must have jsonrpc and method
+	var method string
+	if err := json.Unmarshal(msg["method"], &method); err != nil {
+		t.Fatalf("failed to parse method: %v", err)
+	}
+	if method != "notifications/initialized" {
+		t.Errorf("expected method 'notifications/initialized', got %q", method)
+	}
+
+	// Must NOT have an id (it's a notification)
+	if _, hasID := msg["id"]; hasID {
+		t.Error("notification should not have an 'id' field")
+	}
+}

--- a/cmd/mcpcurl/main_test.go
+++ b/cmd/mcpcurl/main_test.go
@@ -88,6 +88,23 @@ func TestReadJSONRPCResponse_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestReadJSONRPCResponse_ServerError(t *testing.T) {
+	t.Parallel()
+	input := `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}` + "\n"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	_, err := readJSONRPCResponse(scanner)
+	if err == nil {
+		t.Fatal("expected error for server error response, got nil")
+	}
+	if !strings.Contains(err.Error(), "server returned error") {
+		t.Fatalf("expected 'server returned error', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "method not found") {
+		t.Fatalf("expected error to contain server message, got: %v", err)
+	}
+}
+
 func TestBuildInitializeRequest(t *testing.T) {
 	t.Parallel()
 	got, err := buildInitializeRequest()


### PR DESCRIPTION
mcpcurl was sending tools/list and tools/call requests without first performing the MCP initialize handshake, causing the server to silently reject all requests and discover zero tools.

Before:
```
$ mcpcurl --stdio-server-cmd "github-mcp-server stdio" tools --help
(no tools listed)
```

After:
```
$ mcpcurl --stdio-server-cmd "github-mcp-server stdio" tools --help
Available Commands:
  add_comment_to_pending_review ...
  add_issue_comment ...
  create_branch ...
```

## Summary

- Added MCP `initialize` handshake (initialize → read response → notifications/initialized) before sending actual requests
- Switched from buffered stdout to line-by-line scanning via `bufio.Scanner` for proper JSON-RPC message handling
- Added `readJSONRPCResponse` to skip server-initiated notifications interleaved with responses
- Ignore server exit code after stdin close (expected EOF)
- Added 7 unit tests in `cmd/mcpcurl/main_test.go`

## Why

`mcpcurl` has never worked — it silently discovers zero tools because the MCP protocol requires an initialization handshake before any requests. The server rejects pre-handshake requests but mcpcurl swallowed the error.

## What changed

- `cmd/mcpcurl/main.go`: Rewrote `executeServerCommand()` to perform MCP handshake; added `buildInitializeRequest()`, `buildInitializedNotification()`, `readJSONRPCResponse()`
- `cmd/mcpcurl/main_test.go`: New file with 7 unit tests

## MCP impact

- [x] No tool or API changes

## Security / limits

- [x] No security or limits impact

## Tool renaming

- [x] I am not renaming tools as part of this PR

## Lint & tests

- `go test -v ./cmd/mcpcurl/` — 7/7 passing
- `go vet ./cmd/mcpcurl/` — clean