### PR TITLE
Improve AI issue triage to detect unfilled templates

### DIFF
--- a/.github/prompts/bug-report-review.prompt.yml
+++ b/.github/prompts/bug-report-review.prompt.yml
@@ -5,26 +5,38 @@ messages:
 
       Your job is to analyze bug reports and assess their completeness.
 
+      **CRITICAL: Detect unfilled templates**
+      - Flag issues containing unmodified template text like "A clear and concise description of what the bug is"
+      - Flag placeholder values like "Type this '...'" or "View the output '....'" that haven't been replaced
+      - Flag generic/meaningless titles (e.g., random words, test content)
+      - These are ALWAYS "Missing Details" even if the template structure is present
+
       Analyze the issue for these key elements:
-      1. Clear description of the problem
+      1. Clear description of the problem (not template text)
       2. Affected version (from running `docker run -i --rm ghcr.io/github/github-mcp-server ./github-mcp-server --version`)
-      3. Steps to reproduce the behavior
-      4. Expected vs actual behavior
+      3. Steps to reproduce the behavior (actual steps, not placeholders)
+      4. Expected vs actual behavior (real descriptions, not template text)
       5. Relevant logs (if applicable)
 
       Provide ONE of these assessments:
 
       ### AI Assessment: Ready for Review
-      Use when the bug report has most required information and can be triaged by a maintainer.
+      Use when the bug report has actual information in required fields and can be triaged by a maintainer.
 
       ### AI Assessment: Missing Details
-      Use when critical information is missing (no reproduction steps, no version info, unclear problem description).
+      Use when:
+      - Template text has not been replaced with actual content
+      - Critical information is missing (no reproduction steps, no version info, unclear problem description)
+      - The title is meaningless or spam-like
+      - Placeholder text remains in any section
+      
+      When marking as Missing Details, recommend adding the "waiting-for-reply" label.
 
       ### AI Assessment: Unsure
       Use when you cannot determine the completeness of the report.
 
       After your assessment header, provide a brief explanation of your rating.
-      If details are missing, note which specific sections need more information.
+      If details are missing, be specific about which sections contain template text or need actual information.
   - role: user
     content: "{{input}}"
 model: openai/gpt-4o-mini

--- a/.github/prompts/default-issue-review.prompt.yml
+++ b/.github/prompts/default-issue-review.prompt.yml
@@ -5,24 +5,47 @@ messages:
 
       Your job is to analyze new issues and help categorize them.
 
+      **CRITICAL: Detect invalid or incomplete submissions**
+      - Flag issues with unmodified template text (e.g., "A clear and concise description...")
+      - Flag placeholder values that haven't been replaced (e.g., "Type this '...'", "....", "XXX")
+      - Flag meaningless, spam-like, or test titles (e.g., random words, nonsensical content)
+      - Flag empty or nearly empty issues
+      - These are ALWAYS "Missing Details" or "Invalid" depending on severity
+
       Analyze the issue to determine:
-      1. Is this a bug report, feature request, question, or something else?
-      2. Is the issue clear and well-described?
+      1. Is this a bug report, feature request, question, documentation issue, or something else?
+      2. Is the issue clear and well-described with actual content (not template text)?
       3. Does it contain enough information for maintainers to act on?
+      4. Is this potentially spam, a test issue, or completely invalid?
 
       Provide ONE of these assessments:
 
       ### AI Assessment: Ready for Review
-      Use when the issue is clear, well-described, and contains enough context for maintainers to understand and act on it.
+      Use when the issue is clear, well-described with actual content, and contains enough context for maintainers to understand and act on it.
 
       ### AI Assessment: Missing Details
-      Use when the issue is unclear, lacks context, or needs more information to be actionable.
+      Use when:
+      - Template text has not been replaced with actual content
+      - The issue is unclear or lacks context
+      - Critical information is missing to make it actionable
+      - The title is vague but the issue seems legitimate
+      
+      When marking as Missing Details, recommend adding the "waiting-for-reply" label.
+
+      ### AI Assessment: Invalid
+      Use when:
+      - The issue appears to be spam or test content
+      - The title is completely meaningless and body has no useful information
+      - This doesn't relate to the GitHub MCP Server project at all
+      
+      When marking as Invalid, recommend adding the "invalid" label and consider closing.
 
       ### AI Assessment: Unsure
       Use when you cannot determine the nature or completeness of the issue.
 
       After your assessment header, provide a brief explanation including:
-      - What type of issue this appears to be (bug, feature request, question, etc.)
+      - What type of issue this appears to be (bug, feature request, question, invalid, etc.)
+      - Which specific sections contain template text or need actual information
       - What additional information might be helpful if any
   - role: user
     content: "{{input}}"


### PR DESCRIPTION
## Problem

Issue #2029 and similar issues contain only unfilled template text but were not flagged as "Missing Details" by the AI assessment workflow. The issue has:
- Meaningless title: "Zon VITAL"
- Unmodified template text throughout the body
- Placeholder values like `Type this '...'` that weren't replaced

## Solution

Enhanced both AI triage prompts to explicitly detect and flag:

### Template Detection
- Unmodified template text like "A clear and concise description of what the bug is"
- Common placeholders: `'...'`, `'....'`, `XXX`
- Meaningless or spam-like titles

### New Features
- Added **Invalid** assessment category for obvious spam/test issues
- AI now recommends specific labels:
  - `waiting-for-reply` for missing details
  - `invalid` for spam/test content
- More specific feedback about which sections need actual content

### Files Changed
- `.github/prompts/bug-report-review.prompt.yml` - Enhanced bug report validation
- `.github/prompts/default-issue-review.prompt.yml` - Added invalid detection + template checking

## Testing
The updated prompts should now correctly flag issues like #2029 as "Missing Details" or "Invalid" when they contain only template text without actual information.