### PR TITLE
fix: pin Docker base images to SHA256 digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS ui-build
+FROM node:20-alpine@sha256:09e2b3d9726018aecf269bd35325f46bf75046a643a66d28360ec71132750ec8 AS ui-build
 WORKDIR /app
 COPY ui/package*.json ./ui/
 RUN cd ui && npm ci
@@ -7,7 +7,7 @@ COPY ui/ ./ui/
 RUN mkdir -p ./pkg/github/ui_dist && \
     cd ui && npm run build
 
-FROM golang:1.25.7-alpine AS build
+FROM golang:1.25.7-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS build
 ARG VERSION="dev"
 
 # Set the working directory
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o /bin/github-mcp-server ./cmd/github-mcp-server
 
 # Make a stage to run the app
-FROM gcr.io/distroless/base-debian12
+FROM gcr.io/distroless/base-debian12@sha256:937c7eaaf6f3f2d38a1f8c4aeff326f0c56e4593ea152e9e8f74d976dde52f56
 
 # Add required MCP server annotation
 LABEL io.modelcontextprotocol.server.name="io.github.github/github-mcp-server"


### PR DESCRIPTION
## Summary

Pin all three Dockerfile base images to their SHA256 digests to resolve code scanning alerts [#14](https://github.com/github/github-mcp-server/security/code-scanning/14) and [#15](https://github.com/github/github-mcp-server/security/code-scanning/15) for unpinned Docker images.

## Changes

- `node:20-alpine` → pinned to digest (alert `#14`)
- `golang:1.25.7-alpine` → pinned to digest (alert `#15`)
- `gcr.io/distroless/base-debian12` → pinned to digest (proactive)

Dependabot `docker` ecosystem is already configured in `.github/dependabot.yml` and will automatically create PRs to update these digests.