### PR TITLE
Fix for -1 in `tailLines`

### DIFF
--- a/pkg/buffer/buffer.go
+++ b/pkg/buffer/buffer.go
@@ -32,6 +32,9 @@ const maxLineSize = 10 * 1024 * 1024
 // If the response contains more lines than maxJobLogLines, only the most recent lines are kept.
 // Lines exceeding maxLineSize are truncated with a marker.
 func ProcessResponseAsRingBufferToEnd(httpResp *http.Response, maxJobLogLines int) (string, int, *http.Response, error) {
+	if maxJobLogLines <= 0 {
+		maxJobLogLines = 500
+	}
 	if maxJobLogLines > 100000 {
 		maxJobLogLines = 100000
 	}

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -702,8 +702,8 @@ For single job logs, provide job_id. For all failed jobs in a run, provide run_i
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
-			// Default to 500 lines if not specified
-			if tailLines == 0 {
+			// Default to 500 lines if not specified or invalid
+			if tailLines <= 0 {
 				tailLines = 500
 			}
 


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

This pull request introduces a small but important improvement to how the default number of log lines is handled when processing job logs. The main change ensures that if an invalid or non-positive value is provided for the number of log lines to display, a sensible default of 500 lines is used.

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes this exception:
```
makeslice: len out of range
```

## What changed
<!-- Bullet list of concrete changes. -->

**Log handling improvements:**

* In `pkg/buffer/buffer.go`, updated `ProcessResponseAsRingBufferToEnd` to default `maxJobLogLines` to 500 if a non-positive value is provided, and to cap it at 100,000 if it exceeds that value.
* In `pkg/github/actions.go`, changed the logic to set `tailLines` to 500 if it is not specified or set to a non-positive value, instead of only when it is zero.

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
