### PR TITLE
chore: simplify tests with usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - ineffassign
     - intrange
     - unused
+    - usetesting
   exclusions:
     generated: lax
     presets:
@@ -40,6 +41,14 @@ linters:
         - "all"
         - -QF1008
         - -ST1000
+    usetesting:
+      context-background: true
+      context-todo: true
+      os-chdir: true
+      os-mkdir-temp: true
+      os-setenv: true
+      os-create-temp: true
+      os-temp-dir: true
 formatters:
   exclusions:
     generated: lax

--- a/internal/toolsnaps/toolsnaps_test.go
+++ b/internal/toolsnaps/toolsnaps_test.go
@@ -17,11 +17,8 @@ type dummyTool struct {
 
 // withIsolatedWorkingDir creates a temp dir, changes to it, and restores the original working dir after the test.
 func withIsolatedWorkingDir(t *testing.T) {
-	dir := t.TempDir()
-	origDir, err := os.Getwd()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.Chdir(origDir)) })
-	require.NoError(t, os.Chdir(dir))
+	t.Helper()
+	t.Chdir(t.TempDir())
 }
 
 func TestSnapshotDoesNotExistNotInCI(t *testing.T) {

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -14,7 +14,7 @@ import (
 func TestGitHubErrorContext(t *testing.T) {
 	t.Run("API errors can be added to context and retrieved", func(t *testing.T) {
 		// Given a context with GitHub error tracking enabled
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		// Create a mock GitHub response
 		resp := &github.Response{
@@ -43,7 +43,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("GraphQL errors can be added to context and retrieved", func(t *testing.T) {
 		// Given a context with GitHub error tracking enabled
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		originalErr := fmt.Errorf("GraphQL query failed")
 
@@ -65,7 +65,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("Raw API errors can be added to context and retrieved", func(t *testing.T) {
 		// Given a context with GitHub error tracking enabled
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		// Create a mock HTTP response
 		resp := &http.Response{
@@ -92,7 +92,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("multiple errors can be accumulated in context", func(t *testing.T) {
 		// Given a context with GitHub error tracking enabled
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		// When we add multiple API errors
 		resp1 := &github.Response{Response: &http.Response{StatusCode: 404}}
@@ -140,7 +140,7 @@ func TestGitHubErrorContext(t *testing.T) {
 		// is shared, allowing middleware to inspect errors that were added later.
 
 		// Given a context with GitHub error tracking enabled
-		originalCtx := ContextWithGitHubErrors(context.Background())
+		originalCtx := ContextWithGitHubErrors(t.Context())
 
 		// Simulate a middleware that captures the context early
 		var middlewareCtx context.Context
@@ -182,7 +182,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("context without GitHub errors returns error", func(t *testing.T) {
 		// Given a regular context without GitHub error tracking
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// When we try to retrieve errors
 		apiErrors, err := GetGitHubAPIErrors(ctx)
@@ -207,7 +207,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("ContextWithGitHubErrors resets existing errors", func(t *testing.T) {
 		// Given a context with existing errors
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 		resp := &github.Response{Response: &http.Response{StatusCode: 404}}
 		ctx, err := NewGitHubAPIErrorToCtx(ctx, "existing error", resp, fmt.Errorf("error"))
 		require.NoError(t, err)
@@ -241,7 +241,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("NewGitHubAPIErrorResponse creates MCP error result and stores context error", func(t *testing.T) {
 		// Given a context with GitHub error tracking enabled
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		resp := &github.Response{Response: &http.Response{StatusCode: 422}}
 		originalErr := fmt.Errorf("validation failed")
@@ -266,7 +266,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("NewGitHubGraphQLErrorResponse creates MCP error result and stores context error", func(t *testing.T) {
 		// Given a context with GitHub error tracking enabled
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		originalErr := fmt.Errorf("mutation failed")
 
@@ -289,7 +289,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("NewGitHubAPIStatusErrorResponse creates MCP error result from status code", func(t *testing.T) {
 		// Given a context with GitHub error tracking enabled
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		resp := &github.Response{Response: &http.Response{StatusCode: 422}}
 		body := []byte(`{"message": "Validation Failed"}`)
@@ -316,7 +316,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 	t.Run("NewGitHubAPIErrorToCtx with uninitialized context does not error", func(t *testing.T) {
 		// Given a regular context without GitHub error tracking initialized
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create a mock GitHub response
 		resp := &github.Response{
@@ -392,7 +392,7 @@ func TestMiddlewareScenario(t *testing.T) {
 		// Simulate a realistic HTTP middleware scenario
 
 		// 1. Request comes in, middleware sets up error tracking
-		ctx := ContextWithGitHubErrors(context.Background())
+		ctx := ContextWithGitHubErrors(t.Context())
 
 		// 2. Middleware stores reference to context for later inspection
 		var middlewareCtx context.Context

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -93,7 +92,7 @@ func Test_ActionsList_ListWorkflows(t *testing.T) {
 			handler := toolDef.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -148,7 +147,7 @@ func Test_ActionsList_ListWorkflowRuns(t *testing.T) {
 			"repo":        "repo",
 			"resource_id": "ci.yml",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -196,7 +195,7 @@ func Test_ActionsList_ListWorkflowRuns(t *testing.T) {
 			"owner":  "owner",
 			"repo":   "repo",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -253,7 +252,7 @@ func Test_ActionsGet_GetWorkflow(t *testing.T) {
 			"repo":        "repo",
 			"resource_id": "ci.yml",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -296,7 +295,7 @@ func Test_ActionsGet_GetWorkflowRun(t *testing.T) {
 			"repo":        "repo",
 			"resource_id": "12345",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -388,7 +387,7 @@ func Test_ActionsRunTrigger_RunWorkflow(t *testing.T) {
 			handler := toolDef.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -430,7 +429,7 @@ func Test_ActionsRunTrigger_CancelWorkflowRun(t *testing.T) {
 			"repo":   "repo",
 			"run_id": float64(12345),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -461,7 +460,7 @@ func Test_ActionsRunTrigger_CancelWorkflowRun(t *testing.T) {
 			"repo":   "repo",
 			"run_id": float64(12345),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -484,7 +483,7 @@ func Test_ActionsRunTrigger_CancelWorkflowRun(t *testing.T) {
 			"owner":  "owner",
 			"repo":   "repo",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -537,7 +536,7 @@ func Test_ActionsGetJobLogs_SingleJob(t *testing.T) {
 			"repo":   "repo",
 			"job_id": float64(123),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -600,7 +599,7 @@ func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 			"run_id":      float64(456),
 			"failed_only": true,
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -650,7 +649,7 @@ func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 			"run_id":      float64(456),
 			"failed_only": true,
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)

--- a/pkg/github/code_scanning_test.go
+++ b/pkg/github/code_scanning_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -90,7 +89,7 @@ func Test_GetCodeScanningAlert(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler with new signature
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -216,7 +215,7 @@ func Test_ListCodeScanningAlerts(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler with new signature
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -103,7 +102,7 @@ func Test_GetMe(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectToolError {
@@ -341,7 +340,7 @@ func Test_GetTeams(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectToolError {
@@ -484,7 +483,7 @@ func Test_GetTeamMembers(t *testing.T) {
 			handler := serverTool.Handler(tc.deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), tc.deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), tc.deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectToolError {

--- a/pkg/github/copilot_test.go
+++ b/pkg/github/copilot_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -698,7 +697,6 @@ func TestAssignCopilotToIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			t.Parallel()
 			// Setup client with mock
 			client := githubv4.NewClient(tc.mockedClient)
@@ -711,7 +709,7 @@ func TestAssignCopilotToIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Disable polling in tests to avoid timeouts
-			ctx := ContextWithPollConfig(context.Background(), PollConfig{MaxAttempts: 0})
+			ctx := ContextWithPollConfig(t.Context(), PollConfig{MaxAttempts: 0})
 			ctx = ContextWithDeps(ctx, deps)
 
 			// Call handler
@@ -832,7 +830,7 @@ func Test_RequestCopilotReview(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)

--- a/pkg/github/dependabot_test.go
+++ b/pkg/github/dependabot_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -81,7 +80,7 @@ func Test_GetDependabotAlert(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -218,7 +217,7 @@ func Test_ListDependabotAlerts(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)

--- a/pkg/github/dependencies_test.go
+++ b/pkg/github/dependencies_test.go
@@ -31,11 +31,11 @@ func TestIsFeatureEnabled_WithEnabledFlag(t *testing.T) {
 	)
 
 	// Test enabled flag
-	result := deps.IsFeatureEnabled(context.Background(), "test_flag")
+	result := deps.IsFeatureEnabled(t.Context(), "test_flag")
 	assert.True(t, result, "Expected test_flag to be enabled")
 
 	// Test disabled flag
-	result = deps.IsFeatureEnabled(context.Background(), "other_flag")
+	result = deps.IsFeatureEnabled(t.Context(), "other_flag")
 	assert.False(t, result, "Expected other_flag to be disabled")
 }
 
@@ -55,7 +55,7 @@ func TestIsFeatureEnabled_WithoutChecker(t *testing.T) {
 	)
 
 	// Should return false when checker is nil
-	result := deps.IsFeatureEnabled(context.Background(), "any_flag")
+	result := deps.IsFeatureEnabled(t.Context(), "any_flag")
 	assert.False(t, result, "Expected false when checker is nil")
 }
 
@@ -79,7 +79,7 @@ func TestIsFeatureEnabled_EmptyFlagName(t *testing.T) {
 	)
 
 	// Should return false for empty flag name
-	result := deps.IsFeatureEnabled(context.Background(), "")
+	result := deps.IsFeatureEnabled(t.Context(), "")
 	assert.False(t, result, "Expected false for empty flag name")
 }
 
@@ -103,6 +103,6 @@ func TestIsFeatureEnabled_CheckerError(t *testing.T) {
 	)
 
 	// Should return false and log error (not crash)
-	result := deps.IsFeatureEnabled(context.Background(), "error_flag")
+	result := deps.IsFeatureEnabled(t.Context(), "error_flag")
 	assert.False(t, result, "Expected false when checker returns error")
 }

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -451,7 +450,7 @@ func Test_ListDiscussions(t *testing.T) {
 			handler := toolDef.Handler(deps)
 
 			req := createMCPRequest(tc.reqParams)
-			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
+			res, err := handler(ContextWithDeps(t.Context(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {
@@ -564,7 +563,7 @@ func Test_GetDiscussion(t *testing.T) {
 
 			reqParams := map[string]any{"owner": "owner", "repo": "repo", "discussionNumber": int32(1)}
 			req := createMCPRequest(reqParams)
-			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
+			res, err := handler(ContextWithDeps(t.Context(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {
@@ -649,7 +648,7 @@ func Test_GetDiscussionComments(t *testing.T) {
 	}
 	request := createMCPRequest(reqParams)
 
-	result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+	result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 	require.NoError(t, err)
 
 	textContent := getTextResult(t, result)
@@ -795,7 +794,7 @@ func Test_ListDiscussionCategories(t *testing.T) {
 			handler := toolDef.Handler(deps)
 
 			req := createMCPRequest(tc.reqParams)
-			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
+			res, err := handler(ContextWithDeps(t.Context(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {

--- a/pkg/github/dynamic_tools_test.go
+++ b/pkg/github/dynamic_tools_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -46,7 +45,7 @@ func TestDynamicTools_ListAvailableToolsets(t *testing.T) {
 	handler := tool.Handler(deps)
 
 	// Call the handler
-	result, err := handler(context.Background(), createDynamicRequest(map[string]any{}))
+	result, err := handler(t.Context(), createDynamicRequest(map[string]any{}))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Content, 1)
@@ -95,7 +94,7 @@ func TestDynamicTools_GetToolsetTools(t *testing.T) {
 	handler := tool.Handler(deps)
 
 	// Call the handler for repos toolset
-	result, err := handler(context.Background(), createDynamicRequest(map[string]any{
+	result, err := handler(t.Context(), createDynamicRequest(map[string]any{
 		"toolset": "repos",
 	}))
 	require.NoError(t, err)
@@ -148,7 +147,7 @@ func TestDynamicTools_EnableToolset(t *testing.T) {
 	handler := tool.Handler(deps)
 
 	// Enable the repos toolset
-	result, err := handler(context.Background(), createDynamicRequest(map[string]any{
+	result, err := handler(t.Context(), createDynamicRequest(map[string]any{
 		"toolset": "repos",
 	}))
 	require.NoError(t, err)
@@ -163,7 +162,7 @@ func TestDynamicTools_EnableToolset(t *testing.T) {
 	assert.Contains(t, textContent.Text, "enabled")
 
 	// Try enabling again - should say already enabled
-	result2, err := handler(context.Background(), createDynamicRequest(map[string]any{
+	result2, err := handler(t.Context(), createDynamicRequest(map[string]any{
 		"toolset": "repos",
 	}))
 	require.NoError(t, err)
@@ -194,7 +193,7 @@ func TestDynamicTools_EnableToolset_InvalidToolset(t *testing.T) {
 	handler := tool.Handler(deps)
 
 	// Try to enable a non-existent toolset
-	result, err := handler(context.Background(), createDynamicRequest(map[string]any{
+	result, err := handler(t.Context(), createDynamicRequest(map[string]any{
 		"toolset": "nonexistent",
 	}))
 	require.NoError(t, err)

--- a/pkg/github/feature_flags_test.go
+++ b/pkg/github/feature_flags_test.go
@@ -111,7 +111,7 @@ func TestHelloWorld_ConditionalBehavior_Featureflag(t *testing.T) {
 			handler := tool.Handler(deps)
 
 			// Call the handler with deps in context
-			ctx := ContextWithDeps(context.Background(), deps)
+			ctx := ContextWithDeps(t.Context(), deps)
 			result, err := handler(ctx, &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
 					Arguments: json.RawMessage(`{}`),
@@ -173,7 +173,7 @@ func TestHelloWorld_ConditionalBehavior_Config(t *testing.T) {
 			handler := tool.Handler(deps)
 
 			// Call the handler with deps in context
-			ctx := ContextWithDeps(context.Background(), deps)
+			ctx := ContextWithDeps(t.Context(), deps)
 			result, err := handler(ctx, &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
 					Arguments: json.RawMessage(`{}`),

--- a/pkg/github/gists_test.go
+++ b/pkg/github/gists_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -151,7 +150,7 @@ func Test_ListGists(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results
@@ -262,7 +261,7 @@ func Test_GetGist(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results
@@ -402,7 +401,7 @@ func Test_CreateGist(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results
@@ -555,7 +554,7 @@ func Test_UpdateGist(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			// Verify results

--- a/pkg/github/git_test.go
+++ b/pkg/github/git_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -134,7 +133,7 @@ func Test_GetRepositoryTree(t *testing.T) {
 			// Create the tool request
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)

--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -307,7 +306,7 @@ func createMCPRequestWithSession(t *testing.T, clientName string, args any) mcp.
 	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
 
 	st, _ := mcp.NewInMemoryTransports()
-	session, err := srv.Connect(context.Background(), st, &mcp.ServerSessionOptions{
+	session, err := srv.Connect(t.Context(), st, &mcp.ServerSessionOptions{
 		State: &mcp.ServerSessionState{
 			InitializeParams: &mcp.InitializeParams{
 				ClientInfo: &mcp.Implementation{Name: clientName},

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -326,7 +325,7 @@ func Test_GetIssue(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectHandlerError {
 				require.Error(t, err)
@@ -437,7 +436,7 @@ func Test_AddIssueComment(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -465,7 +464,6 @@ func Test_AddIssueComment(t *testing.T) {
 			assert.Equal(t, *tc.expectedComment.ID, *returnedComment.ID)
 			assert.Equal(t, *tc.expectedComment.Body, *returnedComment.Body)
 			assert.Equal(t, *tc.expectedComment.User.Login, *returnedComment.User.Login)
-
 		})
 	}
 }
@@ -741,7 +739,7 @@ func Test_SearchIssues(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -904,7 +902,7 @@ func Test_CreateIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -964,7 +962,7 @@ func Test_IssueWrite_InsidersMode_UIGate(t *testing.T) {
 			"repo":   "repo",
 			"title":  "Test",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 		require.NoError(t, err)
 
 		textContent := getTextResult(t, result)
@@ -979,7 +977,7 @@ func Test_IssueWrite_InsidersMode_UIGate(t *testing.T) {
 			"title":         "Test",
 			"_ui_submitted": true,
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 		require.NoError(t, err)
 
 		textContent := getTextResult(t, result)
@@ -994,7 +992,7 @@ func Test_IssueWrite_InsidersMode_UIGate(t *testing.T) {
 			"repo":   "repo",
 			"title":  "Test",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 		require.NoError(t, err)
 
 		textContent := getTextResult(t, result)
@@ -1286,7 +1284,7 @@ func Test_ListIssues(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			req := createMCPRequest(tc.reqParams)
-			res, err := handler(ContextWithDeps(context.Background(), deps), &req)
+			res, err := handler(ContextWithDeps(t.Context(), deps), &req)
 			text := getTextResult(t, res).Text
 
 			if tc.expectError {
@@ -1770,7 +1768,7 @@ func Test_UpdateIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError || tc.expectedErrMsg != "" {
@@ -2007,7 +2005,7 @@ func Test_GetIssueComments(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2124,7 +2122,7 @@ func Test_GetIssueLabels(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)
@@ -2331,7 +2329,7 @@ func Test_AddSubIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2556,7 +2554,7 @@ func Test_GetSubIssues(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2771,7 +2769,7 @@ func Test_RemoveSubIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3031,7 +3029,7 @@ func Test_ReprioritizeSubIssue(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3147,7 +3145,7 @@ func Test_ListIssueTypes(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -120,7 +119,7 @@ func TestGetLabel(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)
@@ -218,7 +217,7 @@ func TestListLabels(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)
@@ -469,7 +468,7 @@ func TestWriteLabel(t *testing.T) {
 			handler := serverTool.Handler(deps)
 
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)

--- a/pkg/github/notifications_test.go
+++ b/pkg/github/notifications_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -114,7 +113,7 @@ func Test_ListNotifications(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -238,7 +237,7 @@ func Test_ManageNotificationSubscription(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -392,7 +391,7 @@ func Test_ManageRepositoryNotificationSubscription(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -540,7 +539,7 @@ func Test_DismissNotification(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -653,7 +652,7 @@ func Test_MarkAllNotificationsRead(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {
@@ -731,7 +730,7 @@ func Test_GetNotificationDetails(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			if tc.expectError {

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -106,7 +105,7 @@ func Test_ProjectsList_ListProjects(t *testing.T) {
 			}
 			handler := toolDef.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expectError, result.IsError)
@@ -151,7 +150,7 @@ func Test_ProjectsList_ListProjectFields(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -177,7 +176,7 @@ func Test_ProjectsList_ListProjectFields(t *testing.T) {
 			"owner":      "octo-org",
 			"owner_type": "org",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -207,7 +206,7 @@ func Test_ProjectsList_ListProjectItems(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -260,7 +259,7 @@ func Test_ProjectsGet_GetProject(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -285,7 +284,7 @@ func Test_ProjectsGet_GetProject(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -316,7 +315,7 @@ func Test_ProjectsGet_GetProjectField(t *testing.T) {
 			"project_number": float64(1),
 			"field_id":       float64(101),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -341,7 +340,7 @@ func Test_ProjectsGet_GetProjectField(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -372,7 +371,7 @@ func Test_ProjectsGet_GetProjectItem(t *testing.T) {
 			"project_number": float64(1),
 			"item_id":        float64(1001),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -397,7 +396,7 @@ func Test_ProjectsGet_GetProjectItem(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -520,7 +519,7 @@ func Test_ProjectsWrite_AddProjectItem(t *testing.T) {
 			"issue_number":   float64(123),
 			"item_type":      "issue",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -617,7 +616,7 @@ func Test_ProjectsWrite_AddProjectItem(t *testing.T) {
 			"pull_request_number": float64(456),
 			"item_type":           "pull_request",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -646,7 +645,7 @@ func Test_ProjectsWrite_AddProjectItem(t *testing.T) {
 			"item_repo":      "item-repo",
 			"issue_number":   float64(123),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -671,7 +670,7 @@ func Test_ProjectsWrite_AddProjectItem(t *testing.T) {
 			"issue_number":   float64(123),
 			"item_type":      "invalid_type",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -692,7 +691,7 @@ func Test_ProjectsWrite_AddProjectItem(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -727,7 +726,7 @@ func Test_ProjectsWrite_UpdateProjectItem(t *testing.T) {
 				"value": "In Progress",
 			},
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -753,7 +752,7 @@ func Test_ProjectsWrite_UpdateProjectItem(t *testing.T) {
 			"project_number": float64(1),
 			"item_id":        float64(1001),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -784,7 +783,7 @@ func Test_ProjectsWrite_DeleteProjectItem(t *testing.T) {
 			"project_number": float64(1),
 			"item_id":        float64(1001),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -806,7 +805,7 @@ func Test_ProjectsWrite_DeleteProjectItem(t *testing.T) {
 			"owner_type":     "org",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
@@ -873,7 +872,7 @@ func Test_ProjectsList_ListProjectStatusUpdates(t *testing.T) {
 			"owner":          "octocat",
 			"project_number": float64(1),
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -923,7 +922,7 @@ func Test_ProjectsGet_GetProjectStatusUpdate(t *testing.T) {
 			"project_number":   float64(1),
 			"status_update_id": "SU_abc123",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)
@@ -1006,7 +1005,7 @@ func Test_ProjectsWrite_CreateProjectStatusUpdate(t *testing.T) {
 			"body":           "Consolidated test",
 			"status":         "AT_RISK",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 		require.NoError(t, err)
 		require.False(t, result.IsError)

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -110,7 +109,7 @@ func Test_GetPullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -340,7 +339,7 @@ func Test_UpdatePullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError || tc.expectedErrMsg != "" {
@@ -526,7 +525,7 @@ func Test_UpdatePullRequest_Draft(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError || tc.expectedErrMsg != "" {
 				require.NoError(t, err)
@@ -653,7 +652,7 @@ func Test_ListPullRequests(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -771,7 +770,7 @@ func Test_MergePullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1050,7 +1049,7 @@ func Test_SearchPullRequests(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1083,7 +1082,6 @@ func Test_SearchPullRequests(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_GetPullRequestFiles(t *testing.T) {
@@ -1211,7 +1209,7 @@ func Test_GetPullRequestFiles(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1371,7 +1369,7 @@ func Test_GetPullRequestStatus(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1498,7 +1496,7 @@ func Test_UpdatePullRequestBranch(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1818,7 +1816,7 @@ func Test_GetPullRequestComments(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1987,7 +1985,7 @@ func Test_GetPullRequestReviews(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2143,7 +2141,7 @@ func Test_CreatePullRequest(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2207,7 +2205,7 @@ func Test_CreatePullRequest_InsidersMode_UIGate(t *testing.T) {
 			"head":  "feature",
 			"base":  "main",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 		require.NoError(t, err)
 
 		textContent := getTextResult(t, result)
@@ -2223,7 +2221,7 @@ func Test_CreatePullRequest_InsidersMode_UIGate(t *testing.T) {
 			"base":          "main",
 			"_ui_submitted": true,
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 		require.NoError(t, err)
 
 		textContent := getTextResult(t, result)
@@ -2239,7 +2237,7 @@ func Test_CreatePullRequest_InsidersMode_UIGate(t *testing.T) {
 			"head":  "feature",
 			"base":  "main",
 		})
-		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 		require.NoError(t, err)
 
 		textContent := getTextResult(t, result)
@@ -2435,7 +2433,7 @@ func TestCreateAndSubmitPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -2627,7 +2625,7 @@ func TestCreatePendingPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -2810,7 +2808,7 @@ func TestAddPullRequestReviewCommentToPendingReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -2915,7 +2913,7 @@ func TestSubmitPendingPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -3014,7 +3012,7 @@ func TestDeletePendingPullRequestReview(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -3103,7 +3101,7 @@ index 5d6e7b2..8a4f5c3 100644
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			textContent := getTextResult(t, result)
@@ -3338,7 +3336,7 @@ func TestAddReplyToPullRequestComment(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			require.NoError(t, err)
 
 			if tc.expectToolError {

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -390,7 +389,7 @@ func Test_GetFileContents(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -523,7 +522,7 @@ func Test_ForkRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -695,7 +694,7 @@ func Test_CreateBranch(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -821,7 +820,7 @@ func Test_GetCommit(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1035,7 +1034,7 @@ func Test_ListCommits(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1410,7 +1409,7 @@ func Test_CreateOrUpdateFile(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -1599,7 +1598,7 @@ func Test_CreateRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2337,7 +2336,7 @@ func Test_PushFiles(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2458,7 +2457,7 @@ func Test_ListBranches(t *testing.T) {
 			request := createMCPRequest(tt.args)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 			if tt.wantErr {
 				require.NoError(t, err)
 				if tt.errContains != "" {
@@ -2646,7 +2645,7 @@ func Test_DeleteFile(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2773,7 +2772,7 @@ func Test_ListTags(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -2933,7 +2932,7 @@ func Test_GetTag(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3042,7 +3041,7 @@ func Test_ListReleases(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -3133,7 +3132,7 @@ func Test_GetLatestRelease(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 			request := createMCPRequest(tc.requestArgs)
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -3283,7 +3282,7 @@ func Test_GetReleaseByTag(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -3484,7 +3483,7 @@ func Test_filterPaths(t *testing.T) {
 }
 
 func Test_resolveGitReference(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	owner := "owner"
 	repo := "repo"
 
@@ -3876,7 +3875,7 @@ func Test_ListStarredRepositories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -3977,7 +3976,7 @@ func Test_StarRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -4068,7 +4067,7 @@ func Test_UnstarRepository(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/repository_resource_test.go
+++ b/pkg/github/repository_resource_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -242,7 +241,7 @@ func Test_repositoryResourceContents(t *testing.T) {
 				Client:    client,
 				RawClient: mockRawClient,
 			}
-			ctx := ContextWithDeps(context.Background(), deps)
+			ctx := ContextWithDeps(t.Context(), deps)
 			handler := tc.handlerFn()
 
 			request := &mcp.ReadResourceRequest{

--- a/pkg/github/scope_filter_test.go
+++ b/pkg/github/scope_filter_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"testing"
 
 	"github.com/github/github-mcp-server/pkg/inventory"
@@ -135,7 +134,7 @@ func TestCreateToolScopeFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filter := CreateToolScopeFilter(tt.tokenScopes)
-			result, err := filter(context.Background(), tt.tool)
+			result, err := filter(t.Context(), tt.tool)
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "filter result should match expected")
@@ -175,7 +174,7 @@ func TestCreateToolScopeFilter_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get available tools
-	availableTools := inv.AvailableTools(context.Background())
+	availableTools := inv.AvailableTools(t.Context())
 
 	// Should see public_tool and repo_tool, but not gist_tool
 	assert.Len(t, availableTools, 2)

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -133,7 +132,7 @@ func Test_SearchRepositories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -208,7 +207,7 @@ func Test_SearchRepositories_FullOutput(t *testing.T) {
 
 	request := createMCPRequest(args)
 
-	result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+	result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 	require.NoError(t, err)
 	require.False(t, result.IsError)
@@ -345,7 +344,7 @@ func Test_SearchCode(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -530,7 +529,7 @@ func Test_SearchUsers(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -693,7 +692,7 @@ func Test_SearchOrgs(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {

--- a/pkg/github/secret_scanning_test.go
+++ b/pkg/github/secret_scanning_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -89,7 +88,7 @@ func Test_GetSecretScanningAlert(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -219,7 +218,7 @@ func Test_ListSecretScanningAlerts(t *testing.T) {
 
 			request := createMCPRequest(tc.requestArgs)
 
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.NoError(t, err)

--- a/pkg/github/security_advisories_test.go
+++ b/pkg/github/security_advisories_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -100,7 +99,7 @@ func Test_ListGlobalSecurityAdvisories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -212,7 +211,7 @@ func Test_GetGlobalSecurityAdvisory(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			// Verify results
 			if tc.expectError {
@@ -344,7 +343,7 @@ func Test_ListRepositorySecurityAdvisories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -474,7 +473,7 @@ func Test_ListOrgRepositorySecurityAdvisories(t *testing.T) {
 			request := createMCPRequest(tc.requestArgs)
 
 			// Call handler
-			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			result, err := handler(ContextWithDeps(t.Context(), deps), &request)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/pkg/github/server_test.go
+++ b/pkg/github/server_test.go
@@ -135,7 +135,7 @@ func TestNewMCPServer_CreatesSuccessfully(t *testing.T) {
 	require.NoError(t, err, "expected inventory build to succeed")
 
 	// Create the server
-	server, err := NewMCPServer(context.Background(), &cfg, deps, inv)
+	server, err := NewMCPServer(t.Context(), &cfg, deps, inv)
 	require.NoError(t, err, "expected server creation to succeed")
 	require.NotNil(t, server, "expected server to be non-nil")
 

--- a/pkg/github/ui_capability_test.go
+++ b/pkg/github/ui_capability_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -44,7 +43,7 @@ func Test_clientSupportsUI_nilClientInfo(t *testing.T) {
 
 	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
 	st, _ := mcp.NewInMemoryTransports()
-	session, err := srv.Connect(context.Background(), st, &mcp.ServerSessionOptions{
+	session, err := srv.Connect(t.Context(), st, &mcp.ServerSessionOptions{
 		State: &mcp.ServerSessionState{
 			InitializeParams: &mcp.InitializeParams{
 				ClientInfo: nil,

--- a/pkg/http/handler_test.go
+++ b/pkg/http/handler_test.go
@@ -144,7 +144,7 @@ func TestInventoryFiltersForRequest(t *testing.T) {
 			inv, err := builder.Build()
 			require.NoError(t, err)
 
-			available := inv.AvailableTools(context.Background())
+			available := inv.AvailableTools(t.Context())
 			toolNames := make([]string, len(available))
 			for i, tool := range available {
 				toolNames[i] = tool.Tool.Name
@@ -367,7 +367,7 @@ func TestHTTPHandlerRoutes(t *testing.T) {
 
 			// Create handler with our factories
 			handler := NewHTTPMcpHandler(
-				context.Background(),
+				t.Context(),
 				&ServerConfig{Version: "test"},
 				nil, // deps not needed for this test
 				translations.NullTranslationHelper,

--- a/pkg/http/transport/graphql_features_test.go
+++ b/pkg/http/transport/graphql_features_test.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -69,7 +68,7 @@ func TestGraphQLFeaturesTransport(t *testing.T) {
 			}
 
 			// Create a request
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.features != nil {
 				ctx = ghcontext.WithGraphQLFeatures(ctx, tc.features...)
 			}
@@ -109,7 +108,7 @@ func TestGraphQLFeaturesTransport_NilTransport(t *testing.T) {
 	}
 
 	// Create a request with features
-	ctx := ghcontext.WithGraphQLFeatures(context.Background(), "test_feature")
+	ctx := ghcontext.WithGraphQLFeatures(t.Context(), "test_feature")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL, nil)
 	require.NoError(t, err)
 
@@ -137,7 +136,7 @@ func TestGraphQLFeaturesTransport_DoesNotMutateOriginalRequest(t *testing.T) {
 	}
 
 	// Create a request with features
-	ctx := ghcontext.WithGraphQLFeatures(context.Background(), "test_feature")
+	ctx := ghcontext.WithGraphQLFeatures(t.Context(), "test_feature")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL, nil)
 	require.NoError(t, err)
 

--- a/pkg/inventory/instructions_test.go
+++ b/pkg/inventory/instructions_test.go
@@ -1,7 +1,6 @@
 package inventory
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
@@ -104,22 +103,7 @@ func TestGenerateInstructionsWithDisableFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save original env value
-			originalValue := os.Getenv("DISABLE_INSTRUCTIONS")
-			defer func() {
-				if originalValue == "" {
-					os.Unsetenv("DISABLE_INSTRUCTIONS")
-				} else {
-					os.Setenv("DISABLE_INSTRUCTIONS", originalValue)
-				}
-			}()
-
-			// Set test env value
-			if tt.disableEnvValue == "" {
-				os.Unsetenv("DISABLE_INSTRUCTIONS")
-			} else {
-				os.Setenv("DISABLE_INSTRUCTIONS", tt.disableEnvValue)
-			}
+			t.Setenv("DISABLE_INSTRUCTIONS", tt.disableEnvValue)
 
 			inv := createTestInventory([]ToolsetMetadata{
 				{ID: "test", Description: "Test"},

--- a/pkg/inventory/registry_test.go
+++ b/pkg/inventory/registry_test.go
@@ -76,13 +76,13 @@ func mockTool(name string, toolsetID string, readOnly bool) ServerTool {
 
 func TestNewRegistryEmpty(t *testing.T) {
 	reg := mustBuild(t, NewBuilder())
-	if len(reg.AvailableTools(context.Background())) != 0 {
+	if len(reg.AvailableTools(t.Context())) != 0 {
 		t.Fatalf("Expected tools to be empty")
 	}
-	if len(reg.AvailableResourceTemplates(context.Background())) != 0 {
+	if len(reg.AvailableResourceTemplates(t.Context())) != 0 {
 		t.Fatalf("Expected resourceTemplates to be empty")
 	}
-	if len(reg.AvailablePrompts(context.Background())) != 0 {
+	if len(reg.AvailablePrompts(t.Context())) != 0 {
 		t.Fatalf("Expected prompts to be empty")
 	}
 }
@@ -109,7 +109,7 @@ func TestAvailableTools_NoFilters(t *testing.T) {
 	}
 
 	reg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 
 	if len(available) != 3 {
 		t.Fatalf("Expected 3 available tools, got %d", len(available))
@@ -132,14 +132,14 @@ func TestWithReadOnly(t *testing.T) {
 
 	// Build without read-only - should have both tools
 	reg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}))
-	allTools := reg.AvailableTools(context.Background())
+	allTools := reg.AvailableTools(t.Context())
 	if len(allTools) != 2 {
 		t.Fatalf("Expected 2 tools without read-only, got %d", len(allTools))
 	}
 
 	// Build with read-only - should filter out write tools
 	readOnlyReg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}).WithReadOnly(true))
-	readOnlyTools := readOnlyReg.AvailableTools(context.Background())
+	readOnlyTools := readOnlyReg.AvailableTools(t.Context())
 	if len(readOnlyTools) != 1 {
 		t.Fatalf("Expected 1 tool in read-only, got %d", len(readOnlyTools))
 	}
@@ -157,14 +157,14 @@ func TestWithToolsets(t *testing.T) {
 
 	// Build with all toolsets
 	allReg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}))
-	allTools := allReg.AvailableTools(context.Background())
+	allTools := allReg.AvailableTools(t.Context())
 	if len(allTools) != 3 {
 		t.Fatalf("Expected 3 tools without filter, got %d", len(allTools))
 	}
 
 	// Build with specific toolsets
 	filteredReg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"toolset1", "toolset3"}))
-	filteredTools := filteredReg.AvailableTools(context.Background())
+	filteredTools := filteredReg.AvailableTools(t.Context())
 
 	if len(filteredTools) != 2 {
 		t.Fatalf("Expected 2 filtered tools, got %d", len(filteredTools))
@@ -188,7 +188,7 @@ func TestWithToolsetsTrimsWhitespace(t *testing.T) {
 
 	// Whitespace should be trimmed
 	filteredReg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{" toolset1 ", "  toolset2  "}))
-	filteredTools := filteredReg.AvailableTools(context.Background())
+	filteredTools := filteredReg.AvailableTools(t.Context())
 
 	if len(filteredTools) != 2 {
 		t.Fatalf("Expected 2 tools after whitespace trimming, got %d", len(filteredTools))
@@ -202,7 +202,7 @@ func TestWithToolsetsDeduplicates(t *testing.T) {
 
 	// Duplicates should be removed
 	filteredReg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"toolset1", "toolset1", " toolset1 "}))
-	filteredTools := filteredReg.AvailableTools(context.Background())
+	filteredTools := filteredReg.AvailableTools(t.Context())
 
 	if len(filteredTools) != 1 {
 		t.Fatalf("Expected 1 tool after deduplication, got %d", len(filteredTools))
@@ -216,7 +216,7 @@ func TestWithToolsetsIgnoresEmptyStrings(t *testing.T) {
 
 	// Empty strings should be ignored
 	filteredReg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"", "toolset1", "  ", ""}))
-	filteredTools := filteredReg.AvailableTools(context.Background())
+	filteredTools := filteredReg.AvailableTools(t.Context())
 
 	if len(filteredTools) != 1 {
 		t.Fatalf("Expected 1 tool, got %d", len(filteredTools))
@@ -393,7 +393,7 @@ func TestWithTools(t *testing.T) {
 	// WithTools adds additional tools that bypass toolset filtering
 	// When combined with WithToolsets([]), only the additional tools should be available
 	filteredReg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{}).WithTools([]string{"tool1", "tool3"}))
-	filteredTools := filteredReg.AvailableTools(context.Background())
+	filteredTools := filteredReg.AvailableTools(t.Context())
 
 	if len(filteredTools) != 2 {
 		t.Fatalf("Expected 2 filtered tools, got %d", len(filteredTools))
@@ -418,7 +418,7 @@ func TestChainedFilters(t *testing.T) {
 
 	// Chain read-only and toolset filter
 	filtered := mustBuild(t, NewBuilder().SetTools(tools).WithReadOnly(true).WithToolsets([]string{"toolset1"}))
-	result := filtered.AvailableTools(context.Background())
+	result := filtered.AvailableTools(t.Context())
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 tool after chained filters, got %d", len(result))
@@ -571,7 +571,7 @@ func TestWithToolsAdditive(t *testing.T) {
 	// Enable only toolset2, but add issue_read as additional tool
 	filtered := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"toolset2"}).WithTools([]string{"issue_read"}))
 
-	available := filtered.AvailableTools(context.Background())
+	available := filtered.AvailableTools(t.Context())
 	if len(available) != 2 {
 		t.Errorf("expected 2 tools (repo_read from toolset + issue_read additional), got %d", len(available))
 	}
@@ -590,7 +590,7 @@ func TestWithToolsAdditive(t *testing.T) {
 
 	// Test WithTools respects read-only mode
 	readOnlyFiltered := mustBuild(t, NewBuilder().SetTools(tools).WithReadOnly(true).WithTools([]string{"issue_write"}))
-	available = readOnlyFiltered.AvailableTools(context.Background())
+	available = readOnlyFiltered.AvailableTools(t.Context())
 
 	// issue_write should be excluded because read-only applies to additional tools too
 	for _, tool := range available {
@@ -617,7 +617,7 @@ func TestWithToolsResolvesAliases(t *testing.T) {
 		}).
 		WithToolsets([]string{}).
 		WithTools([]string{"get_issue"}))
-	available := filtered.AvailableTools(context.Background())
+	available := filtered.AvailableTools(t.Context())
 
 	if len(available) != 1 {
 		t.Errorf("expected 1 tool, got %d", len(available))
@@ -681,7 +681,7 @@ func TestAllTools(t *testing.T) {
 	}
 
 	// But AvailableTools respects the filter
-	availableTools := readOnlyReg.AvailableTools(context.Background())
+	availableTools := readOnlyReg.AvailableTools(t.Context())
 	if len(availableTools) != 1 {
 		t.Fatalf("Expected 1 tool from AvailableTools, got %d", len(availableTools))
 	}
@@ -742,14 +742,14 @@ func TestForMCPRequest_Initialize(t *testing.T) {
 	filtered := reg.ForMCPRequest(MCPMethodInitialize, "")
 
 	// Initialize should return empty - capabilities come from ServerOptions
-	if len(filtered.AvailableTools(context.Background())) != 0 {
-		t.Errorf("Expected 0 tools for initialize, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 0 {
+		t.Errorf("Expected 0 tools for initialize, got %d", got)
 	}
-	if len(filtered.AvailableResourceTemplates(context.Background())) != 0 {
-		t.Errorf("Expected 0 resources for initialize, got %d", len(filtered.AvailableResourceTemplates(context.Background())))
+	if got := len(filtered.AvailableResourceTemplates(t.Context())); got != 0 {
+		t.Errorf("Expected 0 resources for initialize, got %d", got)
 	}
-	if len(filtered.AvailablePrompts(context.Background())) != 0 {
-		t.Errorf("Expected 0 prompts for initialize, got %d", len(filtered.AvailablePrompts(context.Background())))
+	if got := len(filtered.AvailablePrompts(t.Context())); got != 0 {
+		t.Errorf("Expected 0 prompts for initialize, got %d", got)
 	}
 }
 
@@ -769,14 +769,14 @@ func TestForMCPRequest_ToolsList(t *testing.T) {
 	filtered := reg.ForMCPRequest(MCPMethodToolsList, "")
 
 	// tools/list should return all tools, no resources or prompts
-	if len(filtered.AvailableTools(context.Background())) != 2 {
-		t.Errorf("Expected 2 tools for tools/list, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 2 {
+		t.Errorf("Expected 2 tools for tools/list, got %d", got)
 	}
-	if len(filtered.AvailableResourceTemplates(context.Background())) != 0 {
-		t.Errorf("Expected 0 resources for tools/list, got %d", len(filtered.AvailableResourceTemplates(context.Background())))
+	if got := len(filtered.AvailableResourceTemplates(t.Context())); got != 0 {
+		t.Errorf("Expected 0 resources for tools/list, got %d", got)
 	}
-	if len(filtered.AvailablePrompts(context.Background())) != 0 {
-		t.Errorf("Expected 0 prompts for tools/list, got %d", len(filtered.AvailablePrompts(context.Background())))
+	if got := len(filtered.AvailablePrompts(t.Context())); got != 0 {
+		t.Errorf("Expected 0 prompts for tools/list, got %d", got)
 	}
 }
 
@@ -790,7 +790,7 @@ func TestForMCPRequest_ToolsCall(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}))
 	filtered := reg.ForMCPRequest(MCPMethodToolsCall, "get_me")
 
-	available := filtered.AvailableTools(context.Background())
+	available := filtered.AvailableTools(t.Context())
 	if len(available) != 1 {
 		t.Fatalf("Expected 1 tool for tools/call with name, got %d", len(available))
 	}
@@ -807,8 +807,8 @@ func TestForMCPRequest_ToolsCall_NotFound(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}))
 	filtered := reg.ForMCPRequest(MCPMethodToolsCall, "nonexistent")
 
-	if len(filtered.AvailableTools(context.Background())) != 0 {
-		t.Errorf("Expected 0 tools for nonexistent tool, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 0 {
+		t.Fatalf("Expected 0 tools for nonexistent tool, got %d", got)
 	}
 }
 
@@ -827,7 +827,7 @@ func TestForMCPRequest_ToolsCall_DeprecatedAlias(t *testing.T) {
 	// Request using the deprecated alias
 	filtered := reg.ForMCPRequest(MCPMethodToolsCall, "old_get_me")
 
-	available := filtered.AvailableTools(context.Background())
+	available := filtered.AvailableTools(t.Context())
 	if len(available) != 1 {
 		t.Fatalf("Expected 1 tool when using deprecated alias, got %d", len(available))
 	}
@@ -846,7 +846,7 @@ func TestForMCPRequest_ToolsCall_RespectsFilters(t *testing.T) {
 	filtered := reg.ForMCPRequest(MCPMethodToolsCall, "create_issue")
 
 	// The tool exists in the filtered group, but AvailableTools respects read-only
-	available := filtered.AvailableTools(context.Background())
+	available := filtered.AvailableTools(t.Context())
 	if len(available) != 0 {
 		t.Errorf("Expected 0 tools - write tool should be filtered by read-only, got %d", len(available))
 	}
@@ -867,14 +867,14 @@ func TestForMCPRequest_ResourcesList(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().SetTools(tools).SetResources(resources).SetPrompts(prompts).WithToolsets([]string{"all"}))
 	filtered := reg.ForMCPRequest(MCPMethodResourcesList, "")
 
-	if len(filtered.AvailableTools(context.Background())) != 0 {
-		t.Errorf("Expected 0 tools for resources/list, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 0 {
+		t.Errorf("Expected 0 tools for resources/list, got %d", got)
 	}
-	if len(filtered.AvailableResourceTemplates(context.Background())) != 2 {
-		t.Errorf("Expected 2 resources for resources/list, got %d", len(filtered.AvailableResourceTemplates(context.Background())))
+	if got := len(filtered.AvailableResourceTemplates(t.Context())); got != 2 {
+		t.Errorf("Expected 2 resources for resources/list, got %d", got)
 	}
-	if len(filtered.AvailablePrompts(context.Background())) != 0 {
-		t.Errorf("Expected 0 prompts for resources/list, got %d", len(filtered.AvailablePrompts(context.Background())))
+	if got := len(filtered.AvailablePrompts(t.Context())); got != 0 {
+		t.Errorf("Expected 0 prompts for resources/list, got %d", got)
 	}
 }
 
@@ -889,11 +889,12 @@ func TestForMCPRequest_ResourcesRead(t *testing.T) {
 	filtered := reg.ForMCPRequest(MCPMethodResourcesRead, "repo://owner/repo")
 
 	// All resources should be available - SDK handles URI template matching internally
-	available := filtered.AvailableResourceTemplates(context.Background())
+	available := filtered.AvailableResourceTemplates(t.Context())
 	if len(available) != 2 {
 		t.Fatalf("Expected 2 resources for resources/read (SDK handles matching), got %d", len(available))
 	}
 }
+
 func TestForMCPRequest_PromptsList(t *testing.T) {
 	tools := []ServerTool{
 		mockTool("tool1", "repos", true),
@@ -909,14 +910,14 @@ func TestForMCPRequest_PromptsList(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().SetTools(tools).SetResources(resources).SetPrompts(prompts).WithToolsets([]string{"all"}))
 	filtered := reg.ForMCPRequest(MCPMethodPromptsList, "")
 
-	if len(filtered.AvailableTools(context.Background())) != 0 {
-		t.Errorf("Expected 0 tools for prompts/list, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 0 {
+		t.Errorf("Expected 0 tools for prompts/list, got %d", got)
 	}
-	if len(filtered.AvailableResourceTemplates(context.Background())) != 0 {
-		t.Errorf("Expected 0 resources for prompts/list, got %d", len(filtered.AvailableResourceTemplates(context.Background())))
+	if got := len(filtered.AvailableResourceTemplates(t.Context())); got != 0 {
+		t.Errorf("Expected 0 resources for prompts/list, got %d", got)
 	}
-	if len(filtered.AvailablePrompts(context.Background())) != 2 {
-		t.Errorf("Expected 2 prompts for prompts/list, got %d", len(filtered.AvailablePrompts(context.Background())))
+	if got := len(filtered.AvailablePrompts(t.Context())); got != 2 {
+		t.Errorf("Expected 2 prompts for prompts/list, got %d", got)
 	}
 }
 
@@ -929,7 +930,7 @@ func TestForMCPRequest_PromptsGet(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().SetPrompts(prompts).WithToolsets([]string{"all"}))
 	filtered := reg.ForMCPRequest(MCPMethodPromptsGet, "prompt1")
 
-	available := filtered.AvailablePrompts(context.Background())
+	available := filtered.AvailablePrompts(t.Context())
 	if len(available) != 1 {
 		t.Fatalf("Expected 1 prompt for prompts/get, got %d", len(available))
 	}
@@ -953,14 +954,14 @@ func TestForMCPRequest_UnknownMethod(t *testing.T) {
 	filtered := reg.ForMCPRequest("unknown/method", "")
 
 	// Unknown methods should return empty
-	if len(filtered.AvailableTools(context.Background())) != 0 {
-		t.Errorf("Expected 0 tools for unknown method, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 0 {
+		t.Errorf("Expected 0 tools for unknown method, got %d", got)
 	}
-	if len(filtered.AvailableResourceTemplates(context.Background())) != 0 {
-		t.Errorf("Expected 0 resources for unknown method, got %d", len(filtered.AvailableResourceTemplates(context.Background())))
+	if got := len(filtered.AvailableResourceTemplates(t.Context())); got != 0 {
+		t.Errorf("Expected 0 resources for unknown method, got %d", got)
 	}
-	if len(filtered.AvailablePrompts(context.Background())) != 0 {
-		t.Errorf("Expected 0 prompts for unknown method, got %d", len(filtered.AvailablePrompts(context.Background())))
+	if got := len(filtered.AvailablePrompts(t.Context())); got != 0 {
+		t.Errorf("Expected 0 prompts for unknown method, got %d", got)
 	}
 }
 
@@ -980,25 +981,25 @@ func TestForMCPRequest_DoesNotMutateOriginal(t *testing.T) {
 	filtered := original.ForMCPRequest(MCPMethodToolsCall, "tool1")
 
 	// Original should be unchanged
-	if len(original.AvailableTools(context.Background())) != 2 {
-		t.Errorf("Original was mutated! Expected 2 tools, got %d", len(original.AvailableTools(context.Background())))
+	if got := len(original.AvailableTools(t.Context())); got != 2 {
+		t.Errorf("Original was mutated! Expected 2 tools, got %d", got)
 	}
-	if len(original.AvailableResourceTemplates(context.Background())) != 1 {
-		t.Errorf("Original was mutated! Expected 1 resource, got %d", len(original.AvailableResourceTemplates(context.Background())))
+	if got := len(original.AvailableResourceTemplates(t.Context())); got != 1 {
+		t.Errorf("Original was mutated! Expected 1 resource, got %d", got)
 	}
-	if len(original.AvailablePrompts(context.Background())) != 1 {
-		t.Errorf("Original was mutated! Expected 1 prompt, got %d", len(original.AvailablePrompts(context.Background())))
+	if got := len(original.AvailablePrompts(t.Context())); got != 1 {
+		t.Errorf("Original was mutated! Expected 1 prompt, got %d", got)
 	}
 
 	// Filtered should have only the requested tool
-	if len(filtered.AvailableTools(context.Background())) != 1 {
-		t.Errorf("Expected 1 tool in filtered, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 1 {
+		t.Errorf("Expected 1 tool in filtered, got %d", got)
 	}
-	if len(filtered.AvailableResourceTemplates(context.Background())) != 0 {
-		t.Errorf("Expected 0 resources in filtered, got %d", len(filtered.AvailableResourceTemplates(context.Background())))
+	if got := len(filtered.AvailableResourceTemplates(t.Context())); got != 0 {
+		t.Errorf("Expected 0 resources in filtered, got %d", got)
 	}
-	if len(filtered.AvailablePrompts(context.Background())) != 0 {
-		t.Errorf("Expected 0 prompts in filtered, got %d", len(filtered.AvailablePrompts(context.Background())))
+	if got := len(filtered.AvailablePrompts(t.Context())); got != 0 {
+		t.Errorf("Expected 0 prompts in filtered, got %d", got)
 	}
 }
 
@@ -1016,7 +1017,7 @@ func TestForMCPRequest_ChainedWithOtherFilters(t *testing.T) {
 		WithReadOnly(true))
 	filtered := reg.ForMCPRequest(MCPMethodToolsList, "")
 
-	available := filtered.AvailableTools(context.Background())
+	available := filtered.AvailableTools(t.Context())
 
 	// Should have: get_me (context, read), list_repos (repos, read)
 	// Should NOT have: create_issue (issues not in default), delete_repo (write)
@@ -1055,11 +1056,11 @@ func TestForMCPRequest_ResourcesTemplatesList(t *testing.T) {
 	filtered := reg.ForMCPRequest(MCPMethodResourcesTemplatesList, "")
 
 	// Same behavior as resources/list
-	if len(filtered.AvailableTools(context.Background())) != 0 {
-		t.Errorf("Expected 0 tools, got %d", len(filtered.AvailableTools(context.Background())))
+	if got := len(filtered.AvailableTools(t.Context())); got != 0 {
+		t.Errorf("Expected 0 tools, got %d", got)
 	}
-	if len(filtered.AvailableResourceTemplates(context.Background())) != 1 {
-		t.Errorf("Expected 1 resource, got %d", len(filtered.AvailableResourceTemplates(context.Background())))
+	if got := len(filtered.AvailableResourceTemplates(t.Context())); got != 1 {
+		t.Errorf("Expected 1 resource, got %d", got)
 	}
 }
 
@@ -1102,7 +1103,7 @@ func TestFeatureFlagEnable(t *testing.T) {
 
 	// Without feature checker, tool with FeatureFlagEnable should be excluded
 	reg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 1 {
 		t.Fatalf("Expected 1 tool without feature checker, got %d", len(available))
 	}
@@ -1113,7 +1114,7 @@ func TestFeatureFlagEnable(t *testing.T) {
 	// With feature checker returning false, tool should still be excluded
 	checkerFalse := func(_ context.Context, _ string) (bool, error) { return false, nil }
 	regFalse := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}).WithFeatureChecker(checkerFalse))
-	availableFalse := regFalse.AvailableTools(context.Background())
+	availableFalse := regFalse.AvailableTools(t.Context())
 	if len(availableFalse) != 1 {
 		t.Fatalf("Expected 1 tool with false checker, got %d", len(availableFalse))
 	}
@@ -1123,7 +1124,7 @@ func TestFeatureFlagEnable(t *testing.T) {
 		return flag == "my_feature", nil
 	}
 	regTrue := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}).WithFeatureChecker(checkerTrue))
-	availableTrue := regTrue.AvailableTools(context.Background())
+	availableTrue := regTrue.AvailableTools(t.Context())
 	if len(availableTrue) != 2 {
 		t.Fatalf("Expected 2 tools with true checker, got %d", len(availableTrue))
 	}
@@ -1137,7 +1138,7 @@ func TestFeatureFlagDisable(t *testing.T) {
 
 	// Without feature checker, tool with FeatureFlagDisable should be included (flag is false)
 	reg := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 2 {
 		t.Fatalf("Expected 2 tools without feature checker, got %d", len(available))
 	}
@@ -1147,7 +1148,7 @@ func TestFeatureFlagDisable(t *testing.T) {
 		return flag == "kill_switch", nil
 	}
 	regFiltered := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}).WithFeatureChecker(checkerTrue))
-	availableFiltered := regFiltered.AvailableTools(context.Background())
+	availableFiltered := regFiltered.AvailableTools(t.Context())
 	if len(availableFiltered) != 1 {
 		t.Fatalf("Expected 1 tool with kill_switch enabled, got %d", len(availableFiltered))
 	}
@@ -1165,21 +1166,21 @@ func TestFeatureFlagBoth(t *testing.T) {
 	// Enable flag not set -> excluded
 	checker1 := func(_ context.Context, _ string) (bool, error) { return false, nil }
 	reg1 := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}).WithFeatureChecker(checker1))
-	if len(reg1.AvailableTools(context.Background())) != 0 {
+	if len(reg1.AvailableTools(t.Context())) != 0 {
 		t.Error("Tool should be excluded when enable flag is false")
 	}
 
 	// Enable flag set, disable flag not set -> included
 	checker2 := func(_ context.Context, flag string) (bool, error) { return flag == "new_feature", nil }
 	reg2 := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}).WithFeatureChecker(checker2))
-	if len(reg2.AvailableTools(context.Background())) != 1 {
+	if len(reg2.AvailableTools(t.Context())) != 1 {
 		t.Error("Tool should be included when enable flag is true and disable flag is false")
 	}
 
 	// Enable flag set, disable flag also set -> excluded (disable wins)
 	checker3 := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	reg3 := mustBuild(t, NewBuilder().SetTools(tools).WithToolsets([]string{"all"}).WithFeatureChecker(checker3))
-	if len(reg3.AvailableTools(context.Background())) != 0 {
+	if len(reg3.AvailableTools(t.Context())) != 0 {
 		t.Error("Tool should be excluded when both flags are true (disable wins)")
 	}
 }
@@ -1194,7 +1195,7 @@ func TestFeatureFlagError(t *testing.T) {
 		return false, fmt.Errorf("simulated error")
 	}
 	reg := mustBuild(t, NewBuilder().SetTools(tools).WithFeatureChecker(checkerError))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 0 {
 		t.Errorf("Expected 0 tools when checker errors, got %d", len(available))
 	}
@@ -1212,7 +1213,7 @@ func TestFeatureFlagResources(t *testing.T) {
 
 	// Without checker, resource with enable flag should be excluded
 	reg := mustBuild(t, NewBuilder().SetResources(resources).WithToolsets([]string{"all"}))
-	available := reg.AvailableResourceTemplates(context.Background())
+	available := reg.AvailableResourceTemplates(t.Context())
 	if len(available) != 1 {
 		t.Fatalf("Expected 1 resource without checker, got %d", len(available))
 	}
@@ -1220,8 +1221,8 @@ func TestFeatureFlagResources(t *testing.T) {
 	// With checker returning true, both should be included
 	checker := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	regWithChecker := mustBuild(t, NewBuilder().SetResources(resources).WithToolsets([]string{"all"}).WithFeatureChecker(checker))
-	if len(regWithChecker.AvailableResourceTemplates(context.Background())) != 2 {
-		t.Errorf("Expected 2 resources with checker, got %d", len(regWithChecker.AvailableResourceTemplates(context.Background())))
+	if got := len(regWithChecker.AvailableResourceTemplates(t.Context())); got != 2 {
+		t.Errorf("Expected 2 resources with checker, got %d", got)
 	}
 }
 
@@ -1237,7 +1238,7 @@ func TestFeatureFlagPrompts(t *testing.T) {
 
 	// Without checker, prompt with enable flag should be excluded
 	reg := mustBuild(t, NewBuilder().SetPrompts(prompts).WithToolsets([]string{"all"}))
-	available := reg.AvailablePrompts(context.Background())
+	available := reg.AvailablePrompts(t.Context())
 	if len(available) != 1 {
 		t.Fatalf("Expected 1 prompt without checker, got %d", len(available))
 	}
@@ -1245,8 +1246,8 @@ func TestFeatureFlagPrompts(t *testing.T) {
 	// With checker returning true, both should be included
 	checker := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	regWithChecker := mustBuild(t, NewBuilder().SetPrompts(prompts).WithToolsets([]string{"all"}).WithFeatureChecker(checker))
-	if len(regWithChecker.AvailablePrompts(context.Background())) != 2 {
-		t.Errorf("Expected 2 prompts with checker, got %d", len(regWithChecker.AvailablePrompts(context.Background())))
+	if got := len(regWithChecker.AvailablePrompts(t.Context())); got != 2 {
+		t.Errorf("Expected 2 prompts with checker, got %d", got)
 	}
 }
 
@@ -1328,7 +1329,7 @@ func TestServerToolEnabled(t *testing.T) {
 			tool.Enabled = tt.enabledFunc
 
 			reg := mustBuild(t, NewBuilder().SetTools([]ServerTool{tool}).WithToolsets([]string{"all"}))
-			available := reg.AvailableTools(context.Background())
+			available := reg.AvailableTools(t.Context())
 
 			if len(available) != tt.expectedCount {
 				t.Errorf("Expected %d tools, got %d", tt.expectedCount, len(available))
@@ -1362,20 +1363,20 @@ func TestServerToolEnabledWithContext(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().SetTools([]ServerTool{tool}).WithToolsets([]string{"all"}))
 
 	// Without user in context - tool should be excluded
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 0 {
 		t.Errorf("Expected 0 tools without user, got %d", len(available))
 	}
 
 	// With authorized user - tool should be included
-	ctxWithUser := context.WithValue(context.Background(), userKey, "authorized")
+	ctxWithUser := context.WithValue(t.Context(), userKey, "authorized")
 	availableWithUser := reg.AvailableTools(ctxWithUser)
 	if len(availableWithUser) != 1 {
 		t.Errorf("Expected 1 tool with authorized user, got %d", len(availableWithUser))
 	}
 
 	// With unauthorized user - tool should be excluded
-	ctxWithBadUser := context.WithValue(context.Background(), userKey, "unauthorized")
+	ctxWithBadUser := context.WithValue(t.Context(), userKey, "unauthorized")
 	availableWithBadUser := reg.AvailableTools(ctxWithBadUser)
 	if len(availableWithBadUser) != 0 {
 		t.Errorf("Expected 0 tools with unauthorized user, got %d", len(availableWithBadUser))
@@ -1400,7 +1401,7 @@ func TestBuilderWithFilter(t *testing.T) {
 		WithToolsets([]string{"all"}).
 		WithFilter(filter))
 
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 2 {
 		t.Fatalf("Expected 2 tools after filter, got %d", len(available))
 	}
@@ -1436,7 +1437,7 @@ func TestBuilderWithMultipleFilters(t *testing.T) {
 		WithFilter(filter1).
 		WithFilter(filter2))
 
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 2 {
 		t.Fatalf("Expected 2 tools after multiple filters, got %d", len(available))
 	}
@@ -1469,7 +1470,7 @@ func TestBuilderFilterError(t *testing.T) {
 		WithToolsets([]string{"all"}).
 		WithFilter(filter))
 
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 0 {
 		t.Errorf("Expected 0 tools when filter returns error, got %d", len(available))
 	}
@@ -1499,7 +1500,7 @@ func TestBuilderFilterWithContext(t *testing.T) {
 		WithFilter(filter))
 
 	// With public scope - private_tool should be excluded
-	ctxPublic := context.WithValue(context.Background(), scopeKey, "public")
+	ctxPublic := context.WithValue(t.Context(), scopeKey, "public")
 	availablePublic := reg.AvailableTools(ctxPublic)
 	if len(availablePublic) != 1 {
 		t.Fatalf("Expected 1 tool with public scope, got %d", len(availablePublic))
@@ -1509,7 +1510,7 @@ func TestBuilderFilterWithContext(t *testing.T) {
 	}
 
 	// With private scope - both tools should be available
-	ctxPrivate := context.WithValue(context.Background(), scopeKey, "private")
+	ctxPrivate := context.WithValue(t.Context(), scopeKey, "private")
 	availablePrivate := reg.AvailableTools(ctxPrivate)
 	if len(availablePrivate) != 2 {
 		t.Errorf("Expected 2 tools with private scope, got %d", len(availablePrivate))
@@ -1528,7 +1529,7 @@ func TestEnabledAndFeatureFlagInteraction(t *testing.T) {
 	reg1 := mustBuild(t, NewBuilder().
 		SetTools([]ServerTool{tool}).
 		WithToolsets([]string{"all"}))
-	available1 := reg1.AvailableTools(context.Background())
+	available1 := reg1.AvailableTools(t.Context())
 	if len(available1) != 0 {
 		t.Error("Tool should be excluded when feature flag is not enabled")
 	}
@@ -1541,7 +1542,7 @@ func TestEnabledAndFeatureFlagInteraction(t *testing.T) {
 		SetTools([]ServerTool{tool}).
 		WithToolsets([]string{"all"}).
 		WithFeatureChecker(checker))
-	available2 := reg2.AvailableTools(context.Background())
+	available2 := reg2.AvailableTools(t.Context())
 	if len(available2) != 1 {
 		t.Error("Tool should be included when both Enabled and feature flag pass")
 	}
@@ -1554,7 +1555,7 @@ func TestEnabledAndFeatureFlagInteraction(t *testing.T) {
 		SetTools([]ServerTool{tool}).
 		WithToolsets([]string{"all"}).
 		WithFeatureChecker(checker))
-	available3 := reg3.AvailableTools(context.Background())
+	available3 := reg3.AvailableTools(t.Context())
 	if len(available3) != 0 {
 		t.Error("Tool should be excluded when Enabled returns false")
 	}
@@ -1576,7 +1577,7 @@ func TestEnabledAndBuilderFilterInteraction(t *testing.T) {
 		WithToolsets([]string{"all"}).
 		WithFilter(filter))
 
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 0 {
 		t.Error("Tool should be excluded when filter returns false, despite Enabled returning true")
 	}
@@ -1604,7 +1605,7 @@ func TestAllFiltersInteraction(t *testing.T) {
 		WithFeatureChecker(checker).
 		WithFilter(filter))
 
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	if len(available) != 1 {
 		t.Error("Tool should be included when all filters pass")
 	}
@@ -1620,7 +1621,7 @@ func TestAllFiltersInteraction(t *testing.T) {
 		WithFeatureChecker(checker).
 		WithFilter(filterFalse))
 
-	available2 := reg2.AvailableTools(context.Background())
+	available2 := reg2.AvailableTools(t.Context())
 	if len(available2) != 0 {
 		t.Error("Tool should be excluded when any filter fails")
 	}
@@ -1642,7 +1643,7 @@ func TestFilteredTools(t *testing.T) {
 		WithToolsets([]string{"all"}).
 		WithFilter(filter))
 
-	filtered, err := reg.FilteredTools(context.Background())
+	filtered, err := reg.FilteredTools(t.Context())
 	if err != nil {
 		t.Fatalf("FilteredTools returned error: %v", err)
 	}
@@ -1668,7 +1669,7 @@ func TestFilteredToolsMatchesAvailableTools(t *testing.T) {
 		WithToolsets([]string{"toolset1"}).
 		WithReadOnly(true))
 
-	ctx := context.Background()
+	ctx := t.Context()
 	filtered, err := reg.FilteredTools(ctx)
 	if err != nil {
 		t.Fatalf("FilteredTools returned error: %v", err)
@@ -1723,7 +1724,7 @@ func TestFilteringOrder(t *testing.T) {
 		WithFeatureChecker(checker).
 		WithFilter(filter))
 
-	_ = reg.AvailableTools(context.Background())
+	_ = reg.AvailableTools(t.Context())
 
 	// Expected order: Enabled, FeatureFlag, ReadOnly (stops here because it's write tool)
 	expectedOrder := []string{"Enabled", "FeatureFlag"}
@@ -1753,7 +1754,7 @@ func TestForMCPRequest_ToolsCall_FeatureFlaggedVariants(t *testing.T) {
 		SetTools(tools).
 		WithToolsets([]string{"all"}))
 	filteredOff := regFlagOff.ForMCPRequest(MCPMethodToolsCall, "get_job_logs")
-	availableOff := filteredOff.AvailableTools(context.Background())
+	availableOff := filteredOff.AvailableTools(t.Context())
 	if len(availableOff) != 1 {
 		t.Fatalf("Flag OFF: Expected 1 tool, got %d", len(availableOff))
 	}
@@ -1771,7 +1772,7 @@ func TestForMCPRequest_ToolsCall_FeatureFlaggedVariants(t *testing.T) {
 		WithToolsets([]string{"all"}).
 		WithFeatureChecker(checker))
 	filteredOn := regFlagOn.ForMCPRequest(MCPMethodToolsCall, "get_job_logs")
-	availableOn := filteredOn.AvailableTools(context.Background())
+	availableOn := filteredOn.AvailableTools(t.Context())
 	if len(availableOn) != 1 {
 		t.Fatalf("Flag ON: Expected 1 tool, got %d", len(availableOn))
 	}
@@ -1806,7 +1807,7 @@ func TestWithTools_DeprecatedAliasAndFeatureFlag(t *testing.T) {
 		WithDeprecatedAliases(deprecatedAliases).
 		WithToolsets([]string{}).        // No toolsets enabled
 		WithTools([]string{"old_tool"})) // Explicitly request old tool
-	availableOff := regFlagOff.AvailableTools(context.Background())
+	availableOff := regFlagOff.AvailableTools(t.Context())
 	if len(availableOff) != 1 {
 		t.Fatalf("Flag OFF: Expected 1 tool, got %d", len(availableOff))
 	}
@@ -1824,7 +1825,7 @@ func TestWithTools_DeprecatedAliasAndFeatureFlag(t *testing.T) {
 		WithToolsets([]string{}).        // No toolsets enabled
 		WithTools([]string{"old_tool"}). // Request old tool name
 		WithFeatureChecker(checker))
-	availableOn := regFlagOn.AvailableTools(context.Background())
+	availableOn := regFlagOn.AvailableTools(t.Context())
 	if len(availableOn) != 1 {
 		t.Fatalf("Flag ON: Expected 1 tool, got %d", len(availableOn))
 	}
@@ -1861,7 +1862,7 @@ func TestWithInsidersMode_DisabledStripsUIMetadata(t *testing.T) {
 
 	// Default: insiders mode is disabled - UI meta should be stripped
 	reg := mustBuild(t, NewBuilder().SetTools([]ServerTool{toolWithUI}).WithToolsets([]string{"all"}))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 
 	require.Len(t, available, 1)
 	// UI metadata should be stripped
@@ -1886,7 +1887,7 @@ func TestWithInsidersMode_EnabledPreservesUIMetadata(t *testing.T) {
 		SetTools([]ServerTool{toolWithUI}).
 		WithToolsets([]string{"all"}).
 		WithInsidersMode(true))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 
 	require.Len(t, available, 1)
 	// UI metadata should be preserved
@@ -1909,7 +1910,7 @@ func TestWithInsidersMode_EnabledPreservesInsidersOnlyTools(t *testing.T) {
 		SetTools([]ServerTool{normalTool, insidersTool}).
 		WithToolsets([]string{"all"}).
 		WithInsidersMode(true))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 
 	require.Len(t, available, 2)
 	names := []string{available[0].Tool.Name, available[1].Tool.Name}
@@ -1927,7 +1928,7 @@ func TestWithInsidersMode_DisabledRemovesInsidersOnlyTools(t *testing.T) {
 		SetTools([]ServerTool{normalTool, insidersTool}).
 		WithToolsets([]string{"all"}).
 		WithInsidersMode(false))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 
 	require.Len(t, available, 1)
 	require.Equal(t, "normal", available[0].Tool.Name)
@@ -1944,7 +1945,7 @@ func TestWithInsidersMode_ToolsWithoutUIMetaUnaffected(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().
 		SetTools([]ServerTool{toolNoUI, toolNilMeta}).
 		WithToolsets([]string{"all"}))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 
 	require.Len(t, available, 2)
 
@@ -1982,7 +1983,7 @@ func TestWithInsidersMode_UIOnlyMetaBecomesNil(t *testing.T) {
 	reg := mustBuild(t, NewBuilder().
 		SetTools([]ServerTool{toolUIOnly}).
 		WithToolsets([]string{"all"}))
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 
 	require.Len(t, available, 1)
 	// Meta should be nil since ui was the only key
@@ -2202,7 +2203,7 @@ func TestWithExcludeTools(t *testing.T) {
 				WithToolsets(tt.toolsets).
 				WithExcludeTools(tt.excluded))
 
-			available := reg.AvailableTools(context.Background())
+			available := reg.AvailableTools(t.Context())
 			names := make(map[string]bool)
 			for _, tool := range available {
 				names[tool.Tool.Name] = true
@@ -2233,7 +2234,7 @@ func TestWithExcludeTools_OverridesAdditionalTools(t *testing.T) {
 		WithTools([]string{"tool3"}).
 		WithExcludeTools([]string{"tool3"}))
 
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	names := make(map[string]bool)
 	for _, tool := range available {
 		names[tool.Tool.Name] = true
@@ -2258,7 +2259,7 @@ func TestWithExcludeTools_CombinesWithReadOnly(t *testing.T) {
 		WithReadOnly(true).
 		WithExcludeTools([]string{"read_tool"}))
 
-	available := reg.AvailableTools(context.Background())
+	available := reg.AvailableTools(t.Context())
 	require.Len(t, available, 1)
 	require.Equal(t, "another_read", available[0].Tool.Name)
 }
@@ -2269,11 +2270,11 @@ func TestCreateExcludeToolsFilter(t *testing.T) {
 	blockedTool := mockTool("blocked_tool", "toolset1", true)
 	allowedTool := mockTool("allowed_tool", "toolset1", true)
 
-	allowed, err := filter(context.Background(), &blockedTool)
+	allowed, err := filter(t.Context(), &blockedTool)
 	require.NoError(t, err)
 	require.False(t, allowed, "blocked_tool should be excluded")
 
-	allowed, err = filter(context.Background(), &allowedTool)
+	allowed, err = filter(t.Context(), &allowedTool)
 	require.NoError(t, err)
 	require.True(t, allowed, "allowed_tool should be included")
 }

--- a/pkg/raw/raw_test.go
+++ b/pkg/raw/raw_test.go
@@ -2,7 +2,6 @@ package raw
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -110,7 +109,7 @@ func TestGetRawContent(t *testing.T) {
 			}
 			ghClient := github.NewClient(mockedClient)
 			client := NewClient(ghClient, base)
-			resp, err := client.GetRawContent(context.Background(), tc.owner, tc.repo, tc.path, tc.opts)
+			resp, err := client.GetRawContent(t.Context(), tc.owner, tc.repo, tc.path, tc.opts)
 			defer func() {
 				_ = resp.Body.Close()
 			}()

--- a/pkg/scopes/fetcher_test.go
+++ b/pkg/scopes/fetcher_test.go
@@ -167,7 +167,7 @@ func TestFetcher_FetchTokenScopes(t *testing.T) {
 			apiHost := testAPIHostResolver{baseURL: server.URL}
 			fetcher := NewFetcher(apiHost, FetcherOptions{})
 
-			scopes, err := fetcher.FetchTokenScopes(context.Background(), "test-token")
+			scopes, err := fetcher.FetchTokenScopes(t.Context(), "test-token")
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -187,7 +187,7 @@ func TestFetcher_DefaultOptions(t *testing.T) {
 	fetcher := NewFetcher(apiHost, FetcherOptions{})
 
 	// Verify default API host is set
-	apiURL, err := fetcher.apiHost.BaseRESTURL(context.Background())
+	apiURL, err := fetcher.apiHost.BaseRESTURL(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.github.com", apiURL.String())
 
@@ -211,7 +211,7 @@ func TestFetcher_CustomAPIHost(t *testing.T) {
 	apiHost := testAPIHostResolver{baseURL: "https://api.github.enterprise.com"}
 	fetcher := NewFetcher(apiHost, FetcherOptions{})
 
-	apiURL, err := fetcher.apiHost.BaseRESTURL(context.Background())
+	apiURL, err := fetcher.apiHost.BaseRESTURL(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.github.enterprise.com", apiURL.String())
 }
@@ -226,7 +226,7 @@ func TestFetcher_ContextCancellation(t *testing.T) {
 	apiHost := testAPIHostResolver{baseURL: server.URL}
 	fetcher := NewFetcher(apiHost, FetcherOptions{})
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
 	_, err := fetcher.FetchTokenScopes(ctx, "test-token")


### PR DESCRIPTION
## Summary

Simplifies unit tests by using `testing.T` helpers like `t.Setenv` and `t.Context`, and enables the `usetesting` linter to enforce these patterns.

## Why

Keeps tests concise and consistent by relying on standard `testing` helpers and linting for cleanup-safe patterns.

## What changed

- Enabled the `usetesting` linter in `.golangci.yml`.
- Replaced manual env/context handling in tests with `t.Setenv` and `t.Context` across packages.

## MCP impact

- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
- N/A

## Security / limits
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
