### PR TITLE
chore: enable Go code formatters: gci and gofumpt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,9 +41,12 @@ linters:
         - -QF1008
         - -ST1000
 formatters:
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule

--- a/cmd/github-mcp-server/generate_docs.go
+++ b/cmd/github-mcp-server/generate_docs.go
@@ -9,11 +9,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/spf13/cobra"
+
 	"github.com/github/github-mcp-server/pkg/github"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/translations"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/spf13/cobra"
 )
 
 var generateDocsCmd = &cobra.Command{
@@ -81,7 +82,7 @@ func generateReadmeDocs(readmePath string) error {
 	}
 
 	// Write back to file
-	err = os.WriteFile(readmePath, []byte(updatedContent), 0600)
+	err = os.WriteFile(readmePath, []byte(updatedContent), 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to write README.md: %w", err)
 	}
@@ -110,7 +111,7 @@ func generateRemoteServerDocs(docsPath string) error {
 		return err
 	}
 
-	return os.WriteFile(docsPath, []byte(updatedContent), 0600) //#nosec G306
+	return os.WriteFile(docsPath, []byte(updatedContent), 0o600) //#nosec G306
 }
 
 // octiconImg returns an img tag for an Octicon that works with GitHub's light/dark theme.
@@ -436,7 +437,7 @@ func generateDeprecatedAliasesDocs(docsPath string) error {
 	}
 
 	// Write back to file
-	err = os.WriteFile(docsPath, []byte(updatedContent), 0600)
+	err = os.WriteFile(docsPath, []byte(updatedContent), 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to write deprecated aliases docs: %w", err)
 	}

--- a/cmd/github-mcp-server/list_scopes.go
+++ b/cmd/github-mcp-server/list_scopes.go
@@ -8,11 +8,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/github/github-mcp-server/pkg/github"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/translations"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // ToolScopeInfo contains scope information for a single tool.

--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -7,18 +7,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/ghmcp"
-	"github.com/github/github-mcp-server/pkg/github"
-	ghhttp "github.com/github/github-mcp-server/pkg/http"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/github/github-mcp-server/internal/ghmcp"
+	"github.com/github/github-mcp-server/pkg/github"
+	ghhttp "github.com/github/github-mcp-server/pkg/http"
 )
 
 // These variables are set by the build process using ldflags.
-var version = "version"
-var commit = "commit"
-var date = "date"
+var (
+	version = "version"
+	commit  = "commit"
+	date    = "date"
+)
 
 var (
 	rootCmd = &cobra.Command{

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -15,12 +15,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/ghmcp"
-	"github.com/github/github-mcp-server/pkg/github"
-	"github.com/github/github-mcp-server/pkg/translations"
 	gogithub "github.com/google/go-github/v82/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/ghmcp"
+	"github.com/github/github-mcp-server/pkg/github"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 var (
@@ -277,7 +278,6 @@ func TestGetMe(t *testing.T) {
 	user, _, err := ghClient.Users.Get(context.Background(), "")
 	require.NoError(t, err, "expected to get user successfully")
 	require.Equal(t, trimmedContent.Login, *user.Login, "expected login to match")
-
 }
 
 func TestToolsets(t *testing.T) {
@@ -296,7 +296,7 @@ func TestToolsets(t *testing.T) {
 	// We could enumerate the tools here, but we'll need to expose that information
 	// declaratively in the MCP server, so for the moment let's just check the existence
 	// of an issue and repo tool, and the non-existence of a pull_request tool.
-	var toolsContains = func(expectedName string) bool {
+	toolsContains := func(expectedName string) bool {
 		return slices.ContainsFunc(response.Tools, func(tool *mcp.Tool) bool {
 			return tool.Name == expectedName
 		})

--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -12,6 +12,10 @@ import (
 	"syscall"
 	"time"
 
+	gogithub "github.com/google/go-github/v82/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
 	"github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/github"
 	"github.com/github/github-mcp-server/pkg/http/transport"
@@ -22,9 +26,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	gogithub "github.com/google/go-github/v82/github"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 )
 
 // githubClients holds all the GitHub API clients created for a server instance.
@@ -235,7 +236,7 @@ func RunStdioServer(cfg StdioServerConfig) error {
 	var slogHandler slog.Handler
 	var logOutput io.Writer
 	if cfg.LogFilePath != "" {
-		file, err := os.OpenFile(cfg.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+		file, err := os.OpenFile(cfg.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 		if err != nil {
 			return fmt.Errorf("failed to open log file: %w", err)
 		}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -3,13 +3,12 @@ package profiler
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"math"
 	"os"
 	"runtime"
 	"strconv"
 	"time"
-
-	"log/slog"
-	"math"
 )
 
 // Profile represents performance metrics for an operation

--- a/internal/toolsnaps/toolsnaps.go
+++ b/internal/toolsnaps/toolsnaps.go
@@ -76,12 +76,12 @@ func writeSnap(snapPath string, contents []byte) error {
 	}
 
 	// Ensure the directory exists
-	if err := os.MkdirAll(filepath.Dir(snapPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(snapPath), 0o700); err != nil {
 		return fmt.Errorf("failed to create snapshot directory: %w", err)
 	}
 
 	// Write the snapshot file
-	if err := os.WriteFile(snapPath, sortedJSON, 0600); err != nil {
+	if err := os.WriteFile(snapPath, sortedJSON, 0o600); err != nil {
 		return fmt.Errorf("failed to write snapshot file: %w", err)
 	}
 

--- a/internal/toolsnaps/toolsnaps_test.go
+++ b/internal/toolsnaps/toolsnaps_test.go
@@ -65,8 +65,8 @@ func TestSnapshotExistsMatch(t *testing.T) {
 	// Given a matching snapshot file exists
 	tool := dummyTool{"foo", 42}
 	b, _ := json.MarshalIndent(tool, "", "  ")
-	require.NoError(t, os.MkdirAll("__toolsnaps__", 0700))
-	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), b, 0600))
+	require.NoError(t, os.MkdirAll("__toolsnaps__", 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), b, 0o600))
 
 	// When we test the snapshot
 	err := Test("dummy", tool)
@@ -82,8 +82,8 @@ func TestSnapshotExistsDiff(t *testing.T) {
 	t.Setenv("UPDATE_TOOLSNAPS", "false")
 
 	// Given a non-matching snapshot file exists
-	require.NoError(t, os.MkdirAll("__toolsnaps__", 0700))
-	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), []byte(`{"name":"foo","value":1}`), 0600))
+	require.NoError(t, os.MkdirAll("__toolsnaps__", 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), []byte(`{"name":"foo","value":1}`), 0o600))
 	tool := dummyTool{"foo", 2}
 
 	// When we test the snapshot
@@ -99,8 +99,8 @@ func TestUpdateToolsnaps(t *testing.T) {
 
 	// Given UPDATE_TOOLSNAPS is set, regardless of whether a matching snapshot file exists
 	t.Setenv("UPDATE_TOOLSNAPS", "true")
-	require.NoError(t, os.MkdirAll("__toolsnaps__", 0700))
-	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), []byte(`{"name":"foo","value":1}`), 0600))
+	require.NoError(t, os.MkdirAll("__toolsnaps__", 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), []byte(`{"name":"foo","value":1}`), 0o600))
 	tool := dummyTool{"foo", 42}
 
 	// When we test the snapshot
@@ -120,8 +120,8 @@ func TestMalformedSnapshotJSON(t *testing.T) {
 	t.Setenv("UPDATE_TOOLSNAPS", "false")
 
 	// Given a malformed snapshot file exists
-	require.NoError(t, os.MkdirAll("__toolsnaps__", 0700))
-	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), []byte(`not-json`), 0600))
+	require.NoError(t, os.MkdirAll("__toolsnaps__", 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join("__toolsnaps__", "dummy.snap"), []byte(`not-json`), 0o600))
 	tool := dummyTool{"foo", 42}
 
 	// When we test the snapshot

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/google/go-github/v82/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/github/github-mcp-server/pkg/utils"
 )
 
 type GitHubAPIError struct {
@@ -63,12 +64,14 @@ func (e *GitHubRawAPIError) Error() string {
 	return fmt.Errorf("%s: %w", e.Message, e.Err).Error()
 }
 
-type GitHubErrorKey struct{}
-type GitHubCtxErrors struct {
-	api     []*GitHubAPIError
-	graphQL []*GitHubGraphQLError
-	raw     []*GitHubRawAPIError
-}
+type (
+	GitHubErrorKey  struct{}
+	GitHubCtxErrors struct {
+		api     []*GitHubAPIError
+		graphQL []*GitHubGraphQLError
+		raw     []*GitHubRawAPIError
+	}
+)
 
 // ContextWithGitHubErrors updates or creates a context with a pointer to GitHub error information (to be used by middleware).
 func ContextWithGitHubErrors(ctx context.Context) context.Context {

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -9,6 +9,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/github/github-mcp-server/internal/profiler"
 	buffer "github.com/github/github-mcp-server/pkg/buffer"
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
@@ -16,9 +20,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 // Tests for consolidated actions tools

--- a/pkg/github/code_scanning.go
+++ b/pkg/github/code_scanning.go
@@ -6,14 +6,15 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func GetCodeScanningAlert(t translations.TranslationHelperFunc) inventory.ServerTool {

--- a/pkg/github/code_scanning_test.go
+++ b/pkg/github/code_scanning_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_GetCodeScanningAlert(t *testing.T) {
@@ -115,7 +116,6 @@ func Test_GetCodeScanningAlert(t *testing.T) {
 			assert.Equal(t, *tc.expectedAlert.State, *returnedAlert.State)
 			assert.Equal(t, *tc.expectedAlert.Rule.ID, *returnedAlert.Rule.ID)
 			assert.Equal(t, *tc.expectedAlert.HTMLURL, *returnedAlert.HTMLURL)
-
 		})
 	}
 }

--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 )
 
 // GetMeUIResourceURI is the URI for the get_me tool's MCP App UI resource.

--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_GetMe(t *testing.T) {

--- a/pkg/github/copilot.go
+++ b/pkg/github/copilot.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
@@ -16,11 +22,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/go-viper/mapstructure/v2"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 )
 
 // mvpDescription is an MVP idea for generating tool descriptions from structured data in a shared format.

--- a/pkg/github/copilot_test.go
+++ b/pkg/github/copilot_test.go
@@ -7,14 +7,15 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func TestAssignCopilotToIssue(t *testing.T) {
@@ -40,7 +41,7 @@ func TestAssignCopilotToIssue(t *testing.T) {
 		return &v
 	}
 
-	var pageOfFakeBots = func(n int) []struct{} {
+	pageOfFakeBots := func(n int) []struct{} {
 		// We don't _really_ need real bots here, just objects that count as entries for the page
 		bots := make([]struct{}, n)
 		for i := range n {
@@ -698,7 +699,6 @@ func TestAssignCopilotToIssue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			t.Parallel()
 			// Setup client with mock
 			client := githubv4.NewClient(tc.mockedClient)

--- a/pkg/github/dependabot.go
+++ b/pkg/github/dependabot.go
@@ -7,14 +7,15 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func GetDependabotAlert(t translations.TranslationHelperFunc) inventory.ServerTool {

--- a/pkg/github/dependabot_test.go
+++ b/pkg/github/dependabot_test.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_GetDependabotAlert(t *testing.T) {

--- a/pkg/github/dependencies.go
+++ b/pkg/github/dependencies.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 	"os"
 
+	gogithub "github.com/google/go-github/v82/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/github/github-mcp-server/pkg/http/transport"
 	"github.com/github/github-mcp-server/pkg/inventory"
@@ -15,9 +19,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	gogithub "github.com/google/go-github/v82/github"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 )
 
 // depsContextKey is the context key for ToolDependencies.

--- a/pkg/github/dependencies_test.go
+++ b/pkg/github/dependencies_test.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/github/github-mcp-server/pkg/github"
 	"github.com/github/github-mcp-server/pkg/translations"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIsFeatureEnabled_WithEnabledFlag(t *testing.T) {

--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -5,15 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/github/github-mcp-server/pkg/inventory"
-	"github.com/github/github-mcp-server/pkg/scopes"
-	"github.com/github/github-mcp-server/pkg/translations"
-	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/scopes"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/github/github-mcp-server/pkg/utils"
 )
 
 const DefaultGraphQLPageSize = 30

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -6,14 +6,15 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 var (

--- a/pkg/github/dynamic_tools.go
+++ b/pkg/github/dynamic_tools.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // DynamicToolDependencies contains dependencies for dynamic toolset management tools.

--- a/pkg/github/dynamic_tools_test.go
+++ b/pkg/github/dynamic_tools_test.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/github/github-mcp-server/pkg/inventory"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 // createDynamicRequest creates an MCP request with the given arguments for dynamic tools.

--- a/pkg/github/feature_flags_test.go
+++ b/pkg/github/feature_flags_test.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
+	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
 )
 
@@ -39,7 +39,6 @@ func HelloWorldTool(t translations.TranslationHelperFunc) inventory.ServerTool {
 		},
 		[]scopes.Scope{},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
-
 			// Check feature flag to determine greeting style
 			greeting := "Hello, world!"
 			if deps.IsFeatureEnabled(ctx, RemoteMCPEnthusiasticGreeting) {

--- a/pkg/github/gists.go
+++ b/pkg/github/gists.go
@@ -7,14 +7,15 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // ListGists creates a tool to list gists for a user

--- a/pkg/github/gists_test.go
+++ b/pkg/github/gists_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_ListGists(t *testing.T) {

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // TreeEntryResponse represents a single entry in a Git tree.

--- a/pkg/github/git_test.go
+++ b/pkg/github/git_test.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_GetRepositoryTree(t *testing.T) {

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -9,16 +9,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/sanitize"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 )
 
 // CloseIssueInput represents the input for closing an issue via the GraphQL API.
@@ -554,7 +555,6 @@ func GetIssueLabels(ctx context.Context, client *githubv4.Client, owner string, 
 	}
 
 	return utils.NewToolResultText(string(out)), nil
-
 }
 
 // ListIssueTypes creates a tool to list defined issue types for an organization. This can be used to understand supported issue type values for creating or updating issues.
@@ -842,7 +842,6 @@ func AddSubIssue(ctx context.Context, client *github.Client, owner string, repo 
 	}
 
 	return utils.NewToolResultText(string(r)), nil
-
 }
 
 func RemoveSubIssue(ctx context.Context, client *github.Client, owner string, repo string, issueNumber int, subIssueID int) (*mcp.CallToolResult, error) {

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -11,19 +11,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/lockdown"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/lockdown"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
-var defaultGQLClient *githubv4.Client = githubv4.NewClient(newRepoAccessHTTPClient())
-var repoAccessCache *lockdown.RepoAccessCache = stubRepoAccessCache(defaultGQLClient, 15*time.Minute)
+var (
+	defaultGQLClient *githubv4.Client          = githubv4.NewClient(newRepoAccessHTTPClient())
+	repoAccessCache  *lockdown.RepoAccessCache = stubRepoAccessCache(defaultGQLClient, 15*time.Minute)
+)
 
 type repoAccessKey struct {
 	owner    string
@@ -465,7 +468,6 @@ func Test_AddIssueComment(t *testing.T) {
 			assert.Equal(t, *tc.expectedComment.ID, *returnedComment.ID)
 			assert.Equal(t, *tc.expectedComment.Body, *returnedComment.Body)
 			assert.Equal(t, *tc.expectedComment.User.Login, *returnedComment.User.Login)
-
 		})
 	}
 }

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 )
 
 // GetLabel retrieves a specific label by name from a GitHub repository

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func TestGetLabel(t *testing.T) {

--- a/pkg/github/notifications.go
+++ b/pkg/github/notifications.go
@@ -9,14 +9,15 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (

--- a/pkg/github/notifications_test.go
+++ b/pkg/github/notifications_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_ListNotifications(t *testing.T) {

--- a/pkg/github/params_test.go
+++ b/pkg/github/params_test.go
@@ -192,6 +192,7 @@ func Test_RequiredInt(t *testing.T) {
 		})
 	}
 }
+
 func Test_OptionalIntParam(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -8,15 +8,16 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 )
 
 const (

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -6,14 +6,15 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	gh "github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 // Tests for consolidated project tools

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -7,15 +7,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/lockdown"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/lockdown"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_GetPullRequest(t *testing.T) {
@@ -1083,7 +1084,6 @@ func Test_SearchPullRequests(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_GetPullRequestFiles(t *testing.T) {

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -10,15 +10,16 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/octicons"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func GetCommit(t translations.TranslationHelperFunc) inventory.ServerTool {

--- a/pkg/github/repositories_helper.go
+++ b/pkg/github/repositories_helper.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/raw"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // initializeRepository creates an initial commit in an empty repository and returns the default branch ref and base commit

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -10,15 +10,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/raw"
-	"github.com/github/github-mcp-server/pkg/translations"
-	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/raw"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/github/github-mcp-server/pkg/utils"
 )
 
 func Test_GetFileContents(t *testing.T) {
@@ -3062,6 +3063,7 @@ func Test_ListReleases(t *testing.T) {
 		})
 	}
 }
+
 func Test_GetLatestRelease(t *testing.T) {
 	serverTool := GetLatestRelease(translations.NullTranslationHelper)
 	tool := serverTool.Tool

--- a/pkg/github/repository_resource.go
+++ b/pkg/github/repository_resource.go
@@ -13,13 +13,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yosida95/uritemplate/v3"
+
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/octicons"
 	"github.com/github/github-mcp-server/pkg/raw"
 	"github.com/github/github-mcp-server/pkg/translations"
-	"github.com/google/go-github/v82/github"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/yosida95/uritemplate/v3"
 )
 
 var (
@@ -185,7 +186,6 @@ func RepositoryResourceContentsHandler(resourceURITemplate *uritemplate.Template
 			return nil, fmt.Errorf("directories are not supported: %s", path)
 		}
 		rawClient, err := deps.GetRawClient(ctx)
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to get GitHub raw content client: %w", err)
 		}

--- a/pkg/github/repository_resource_test.go
+++ b/pkg/github/repository_resource_test.go
@@ -6,10 +6,11 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/github/github-mcp-server/pkg/raw"
 	"github.com/google/go-github/v82/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/pkg/raw"
 )
 
 type resourceResponseType int
@@ -82,7 +83,8 @@ func Test_repositoryResourceContents(t *testing.T) {
 					Blob:     []byte("IyBUZXN0IFJlcG9zaXRvcnkKClRoaXMgaXMgYSB0ZXN0IHJlcG9zaXRvcnku"),
 					MIMEType: "image/png",
 					URI:      "",
-				}}},
+				}},
+			},
 		},
 		{
 			name: "successful text content fetch (HEAD)",
@@ -103,7 +105,8 @@ func Test_repositoryResourceContents(t *testing.T) {
 					Text:     "# Test Repository\n\nThis is a test repository.",
 					MIMEType: "text/markdown",
 					URI:      "",
-				}}},
+				}},
+			},
 		},
 		{
 			name: "successful text content fetch (HEAD)",
@@ -126,7 +129,8 @@ func Test_repositoryResourceContents(t *testing.T) {
 					Text:     "package actions\n\nfunc main() {\n    // Sample Go file content\n}\n",
 					MIMEType: "text/plain",
 					URI:      "",
-				}}},
+				}},
+			},
 		},
 		{
 			name: "successful text content fetch (branch)",
@@ -147,7 +151,8 @@ func Test_repositoryResourceContents(t *testing.T) {
 					Text:     "# Test Repository\n\nThis is a test repository.",
 					MIMEType: "text/markdown",
 					URI:      "",
-				}}},
+				}},
+			},
 		},
 		{
 			name: "successful text content fetch (tag)",
@@ -168,7 +173,8 @@ func Test_repositoryResourceContents(t *testing.T) {
 					Text:     "# Test Repository\n\nThis is a test repository.",
 					MIMEType: "text/markdown",
 					URI:      "",
-				}}},
+				}},
+			},
 		},
 		{
 			name: "successful text content fetch (sha)",
@@ -189,7 +195,8 @@ func Test_repositoryResourceContents(t *testing.T) {
 					Text:     "# Test Repository\n\nThis is a test repository.",
 					MIMEType: "text/markdown",
 					URI:      "",
-				}}},
+				}},
+			},
 		},
 		{
 			name: "successful text content fetch (pr)",
@@ -215,7 +222,8 @@ func Test_repositoryResourceContents(t *testing.T) {
 					Text:     "# Test Repository\n\nThis is a test repository.",
 					MIMEType: "text/markdown",
 					URI:      "",
-				}}},
+				}},
+			},
 		},
 		{
 			name: "content fetch fails",

--- a/pkg/github/scope_filter_test.go
+++ b/pkg/github/scope_filter_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
 )
 
 func TestCreateToolScopeFilter(t *testing.T) {

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -7,14 +7,15 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // SearchRepositories creates a tool to search for GitHub repositories.

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_SearchRepositories(t *testing.T) {
@@ -163,7 +164,6 @@ func Test_SearchRepositories(t *testing.T) {
 				assert.Equal(t, *tc.expectedResult.Repositories[i].FullName, repo.FullName)
 				assert.Equal(t, *tc.expectedResult.Repositories[i].HTMLURL, repo.HTMLURL)
 			}
-
 		})
 	}
 }

--- a/pkg/github/search_utils.go
+++ b/pkg/github/search_utils.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 	"regexp"
 
-	ghErrors "github.com/github/github-mcp-server/pkg/errors"
-	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/google/go-github/v82/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/utils"
 )
 
 func hasFilter(query, filterType string) bool {

--- a/pkg/github/secret_scanning.go
+++ b/pkg/github/secret_scanning.go
@@ -7,14 +7,15 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func GetSecretScanningAlert(t translations.TranslationHelperFunc) inventory.ServerTool {

--- a/pkg/github/secret_scanning_test.go
+++ b/pkg/github/secret_scanning_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_GetSecretScanningAlert(t *testing.T) {
@@ -113,7 +114,6 @@ func Test_GetSecretScanningAlert(t *testing.T) {
 			assert.Equal(t, *tc.expectedAlert.Number, *returnedAlert.Number)
 			assert.Equal(t, *tc.expectedAlert.State, *returnedAlert.State)
 			assert.Equal(t, *tc.expectedAlert.HTMLURL, *returnedAlert.HTMLURL)
-
 		})
 	}
 }

--- a/pkg/github/security_advisories.go
+++ b/pkg/github/security_advisories.go
@@ -7,14 +7,15 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/google/go-github/v82/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/google/go-github/v82/github"
-	"github.com/google/jsonschema-go/jsonschema"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func ListGlobalSecurityAdvisories(t translations.TranslationHelperFunc) inventory.ServerTool {

--- a/pkg/github/security_advisories_test.go
+++ b/pkg/github/security_advisories_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/github/github-mcp-server/internal/toolsnaps"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 func Test_ListGlobalSecurityAdvisories(t *testing.T) {

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	gherrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/octicons"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type MCPServerConfig struct {

--- a/pkg/github/server_test.go
+++ b/pkg/github/server_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/pkg/lockdown"
-	"github.com/github/github-mcp-server/pkg/raw"
-	"github.com/github/github-mcp-server/pkg/translations"
 	gogithub "github.com/google/go-github/v82/github"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/pkg/lockdown"
+	"github.com/github/github-mcp-server/pkg/raw"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
 // stubDeps is a test helper that implements ToolDependencies with configurable behavior.

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -5,14 +5,17 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/github/github-mcp-server/pkg/inventory"
-	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v82/github"
 	"github.com/shurcooL/githubv4"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/translations"
 )
 
-type GetClientFn func(context.Context) (*github.Client, error)
-type GetGQLClientFn func(context.Context) (*githubv4.Client, error)
+type (
+	GetClientFn    func(context.Context) (*github.Client, error)
+	GetGQLClientFn func(context.Context) (*githubv4.Client, error)
+)
 
 // Toolset metadata constants - these define all available toolsets and their descriptions.
 // Tools use these constants to declare which toolset they belong to.

--- a/pkg/github/tools_validation_test.go
+++ b/pkg/github/tools_validation_test.go
@@ -3,9 +3,10 @@ package github
 import (
 	"testing"
 
-	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
 )
 
 // stubTranslation is a simple translation function for testing

--- a/pkg/github/toolset_icons_test.go
+++ b/pkg/github/toolset_icons_test.go
@@ -3,9 +3,10 @@ package github
 import (
 	"testing"
 
-	"github.com/github/github-mcp-server/pkg/octicons"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/pkg/octicons"
 )
 
 // TestAllToolsetIconsExist validates that every toolset with an Icon field

--- a/pkg/github/workflow_prompts.go
+++ b/pkg/github/workflow_prompts.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/translations"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // IssueToFixWorkflowPrompt provides a guided workflow for creating an issue and then generating a PR to fix it

--- a/pkg/http/handler.go
+++ b/pkg/http/handler.go
@@ -6,6 +6,9 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/github/github-mcp-server/pkg/github"
 	"github.com/github/github-mcp-server/pkg/http/middleware"
@@ -14,8 +17,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/go-chi/chi/v5"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type InventoryFactoryFunc func(r *http.Request) (*inventory.Inventory, error)
@@ -85,7 +86,8 @@ func NewHTTPMcpHandler(
 	t translations.TranslationHelperFunc,
 	logger *slog.Logger,
 	apiHost utils.APIHostResolver,
-	options ...HandlerOption) *Handler {
+	options ...HandlerOption,
+) *Handler {
 	opts := &HandlerOptions{}
 	for _, o := range options {
 		o(opts)
@@ -217,7 +219,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	})
-
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/pkg/http/handler_test.go
+++ b/pkg/http/handler_test.go
@@ -9,6 +9,11 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/github/github-mcp-server/pkg/github"
 	"github.com/github/github-mcp-server/pkg/http/headers"
@@ -16,10 +21,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/go-chi/chi/v5"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func mockTool(name, toolsetID string, readOnly bool) inventory.ServerTool {

--- a/pkg/http/middleware/mcp_parse_test.go
+++ b/pkg/http/middleware/mcp_parse_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
 )
 
 func TestWithMCPParse(t *testing.T) {

--- a/pkg/http/middleware/pat_scope_test.go
+++ b/pkg/http/middleware/pat_scope_test.go
@@ -8,10 +8,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	ghcontext "github.com/github/github-mcp-server/pkg/context"
-	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
+	"github.com/github/github-mcp-server/pkg/utils"
 )
 
 // mockScopeFetcher is a mock implementation of scopes.FetcherInterface

--- a/pkg/http/middleware/token_test.go
+++ b/pkg/http/middleware/token_test.go
@@ -5,12 +5,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/github/github-mcp-server/pkg/http/headers"
 	"github.com/github/github-mcp-server/pkg/http/oauth"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExtractUserToken(t *testing.T) {

--- a/pkg/http/oauth/oauth.go
+++ b/pkg/http/oauth/oauth.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/github/github-mcp-server/pkg/http/headers"
 	"github.com/go-chi/chi/v5"
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/oauthex"
+
+	"github.com/github/github-mcp-server/pkg/http/headers"
 )
 
 const (

--- a/pkg/http/oauth/oauth_test.go
+++ b/pkg/http/oauth/oauth_test.go
@@ -7,10 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/github/github-mcp-server/pkg/http/headers"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/pkg/http/headers"
 )
 
 func TestNewAuthHandler(t *testing.T) {

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/github/github-mcp-server/pkg/github"
 	"github.com/github/github-mcp-server/pkg/http/oauth"
@@ -20,7 +22,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
-	"github.com/go-chi/chi/v5"
 )
 
 // knownFeatureFlags are the feature flags that can be enabled via X-MCP-Features header.
@@ -79,7 +80,7 @@ func RunHTTPServer(cfg ServerConfig) error {
 	var slogHandler slog.Handler
 	var logOutput io.Writer
 	if cfg.LogFilePath != "" {
-		file, err := os.OpenFile(cfg.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+		file, err := os.OpenFile(cfg.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 		if err != nil {
 			return fmt.Errorf("failed to open log file: %w", err)
 		}
@@ -192,7 +193,6 @@ func initGlobalToolScopeMap(t translations.TranslationHelperFunc) error {
 	inv, err := inventory.NewBuilder().
 		SetTools(github.AllTools(t)).
 		Build()
-
 	if err != nil {
 		return fmt.Errorf("failed to build inventory for tool scope map: %w", err)
 	}

--- a/pkg/http/transport/graphql_features_test.go
+++ b/pkg/http/transport/graphql_features_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	ghcontext "github.com/github/github-mcp-server/pkg/context"
-	"github.com/github/github-mcp-server/pkg/http/headers"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
+	"github.com/github/github-mcp-server/pkg/http/headers"
 )
 
 func TestGraphQLFeaturesTransport(t *testing.T) {

--- a/pkg/inventory/builder.go
+++ b/pkg/inventory/builder.go
@@ -9,10 +9,8 @@ import (
 	"strings"
 )
 
-var (
-	// ErrUnknownTools is returned when tools specified via WithTools() are not recognized.
-	ErrUnknownTools = errors.New("unknown tools specified in WithTools")
-)
+// ErrUnknownTools is returned when tools specified via WithTools() are not recognized.
+var ErrUnknownTools = errors.New("unknown tools specified in WithTools")
 
 // ToolFilter is a function that determines if a tool should be included.
 // Returns true if the tool should be included, false to exclude it.

--- a/pkg/inventory/registry_test.go
+++ b/pkg/inventory/registry_test.go
@@ -894,6 +894,7 @@ func TestForMCPRequest_ResourcesRead(t *testing.T) {
 		t.Fatalf("Expected 2 resources for resources/read (SDK handles matching), got %d", len(available))
 	}
 }
+
 func TestForMCPRequest_PromptsList(t *testing.T) {
 	tools := []ServerTool{
 		mockTool("tool1", "repos", true),

--- a/pkg/inventory/server_tool.go
+++ b/pkg/inventory/server_tool.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/github/github-mcp-server/pkg/octicons"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/github/github-mcp-server/pkg/octicons"
 )
 
 // HandlerFunc is a function that takes dependencies and returns an MCP tool handler.

--- a/pkg/lockdown/lockdown_test.go
+++ b/pkg/lockdown/lockdown_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github/github-mcp-server/internal/githubv4mock"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
 )
 
 const (

--- a/pkg/log/io.go
+++ b/pkg/log/io.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"io"
-
 	"log/slog"
 )
 

--- a/pkg/log/io_test.go
+++ b/pkg/log/io_test.go
@@ -2,10 +2,9 @@ package log
 
 import (
 	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
-
-	"log/slog"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/sanitize/sanitize.go
+++ b/pkg/sanitize/sanitize.go
@@ -8,8 +8,10 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 )
 
-var policy *bluemonday.Policy
-var policyOnce sync.Once
+var (
+	policy     *bluemonday.Policy
+	policyOnce sync.Once
+)
 
 func Sanitize(input string) string {
 	return FilterHTMLTags(FilterCodeFenceMetadata(FilterInvisibleCharacters(input)))

--- a/pkg/sanitize/sanitize_test.go
+++ b/pkg/sanitize/sanitize_test.go
@@ -252,6 +252,7 @@ func TestFilterHtmlTags(t *testing.T) {
 		})
 	}
 }
+
 func TestFilterCodeFenceMetadata(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/scopes/fetcher_test.go
+++ b/pkg/scopes/fetcher_test.go
@@ -19,12 +19,15 @@ type testAPIHostResolver struct {
 func (t testAPIHostResolver) BaseRESTURL(_ context.Context) (*url.URL, error) {
 	return url.Parse(t.baseURL)
 }
+
 func (t testAPIHostResolver) GraphqlURL(_ context.Context) (*url.URL, error) {
 	return nil, nil
 }
+
 func (t testAPIHostResolver) UploadURL(_ context.Context) (*url.URL, error) {
 	return nil, nil
 }
+
 func (t testAPIHostResolver) RawURL(_ context.Context) (*url.URL, error) {
 	return nil, nil
 }

--- a/pkg/translations/translations.go
+++ b/pkg/translations/translations.go
@@ -17,7 +17,7 @@ func NullTranslationHelper(_ string, defaultValue string) string {
 }
 
 func TranslationHelper() (TranslationHelperFunc, func()) {
-	var translationKeyMap = map[string]string{}
+	translationKeyMap := map[string]string{}
 	v := viper.New()
 
 	// Load from JSON file

--- a/pkg/utils/api.go
+++ b/pkg/utils/api.go
@@ -27,7 +27,6 @@ var _ APIHostResolver = APIHost{}
 
 func NewAPIHost(s string) (APIHostResolver, error) {
 	a, err := parseAPIHost(s)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Enables Go code formatters `gci` and `gofumpt` in the linter configuration to improve code consistency and organization throughout the codebase.

## Why
Enforcing consistent code formatting improves code readability and maintainability. Adding these formatters ensures imports are organized and code style is uniform across the project.

## What changed
- Updated `.golangci.yml` to enable `gci` and `gofumpt` formatters
- Applied formatting changes (run `golangci-lint fmt`) across 65+ Go files to comply with the new formatter rules

## MCP impact
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
N/A

## Security / limits
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
