### PR TITLE
Generate authorization server urls during API resolution.

### DIFF
--- a/pkg/http/oauth/oauth.go
+++ b/pkg/http/oauth/oauth.go
@@ -3,7 +3,6 @@
 package oauth
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -59,7 +58,7 @@ type AuthHandler struct {
 }
 
 // NewAuthHandler creates a new OAuth auth handler.
-func NewAuthHandler(ctx context.Context, cfg *Config, apiHost utils.APIHostResolver) (*AuthHandler, error) {
+func NewAuthHandler(cfg *Config, apiHost utils.APIHostResolver) (*AuthHandler, error) {
 	if cfg == nil {
 		cfg = &Config{}
 	}

--- a/pkg/http/oauth/oauth.go
+++ b/pkg/http/oauth/oauth.go
@@ -63,6 +63,14 @@ func NewAuthHandler(cfg *Config, apiHost utils.APIHostResolver) (*AuthHandler, e
 		cfg = &Config{}
 	}
 
+	if apiHost == nil {
+		var err error
+		apiHost, err = utils.NewAPIHost("https://api.github.com")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create default API host: %w", err)
+		}
+	}
+
 	return &AuthHandler{
 		cfg:     cfg,
 		apiHost: apiHost,

--- a/pkg/http/oauth/oauth_test.go
+++ b/pkg/http/oauth/oauth_test.go
@@ -53,7 +53,7 @@ func TestNewAuthHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler, err := NewAuthHandler(t.Context(), tc.cfg, dotcomHost)
+			handler, err := NewAuthHandler(tc.cfg, dotcomHost)
 			require.NoError(t, err)
 			require.NotNil(t, handler)
 
@@ -451,7 +451,7 @@ func TestHandleProtectedResource(t *testing.T) {
 			dotcomHost, err := utils.NewAPIHost("https://api.github.com")
 			require.NoError(t, err)
 
-			handler, err := NewAuthHandler(t.Context(), tc.cfg, dotcomHost)
+			handler, err := NewAuthHandler(tc.cfg, dotcomHost)
 			require.NoError(t, err)
 
 			router := chi.NewRouter()
@@ -496,7 +496,7 @@ func TestRegisterRoutes(t *testing.T) {
 	dotcomHost, err := utils.NewAPIHost("https://api.github.com")
 	require.NoError(t, err)
 
-	handler, err := NewAuthHandler(t.Context(), &Config{
+	handler, err := NewAuthHandler(&Config{
 		BaseURL: "https://api.example.com",
 	}, dotcomHost)
 	require.NoError(t, err)
@@ -565,7 +565,7 @@ func TestProtectedResourceResponseFormat(t *testing.T) {
 	dotcomHost, err := utils.NewAPIHost("https://api.github.com")
 	require.NoError(t, err)
 
-	handler, err := NewAuthHandler(t.Context(), &Config{
+	handler, err := NewAuthHandler(&Config{
 		BaseURL: "https://api.example.com",
 	}, dotcomHost)
 	require.NoError(t, err)
@@ -676,11 +676,10 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 					assert.Contains(t, err.Error(), tc.errorContains)
 				}
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 
-			handler, err := NewAuthHandler(t.Context(), &Config{
+			handler, err := NewAuthHandler(&Config{
 				BaseURL: "https://api.example.com",
 			}, apiHost)
 			require.NoError(t, err)
@@ -708,7 +707,6 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 				}
 				return
 			}
-			require.NoError(t, err)
 
 			responseAuthServers, ok := response["authorization_servers"].([]any)
 			require.True(t, ok)

--- a/pkg/http/oauth/oauth_test.go
+++ b/pkg/http/oauth/oauth_test.go
@@ -644,7 +644,7 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 	}{
 		{
 			name:        "valid host returns authorization server URL",
-			host:        "http://api.github.com",
+			host:        "http://github.com",
 			expectedURL: "https://github.com/login/oauth",
 			expectError: false,
 		},
@@ -657,20 +657,20 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 		},
 		{
 			name:          "host without scheme returns error",
-			host:          "api.github.com",
+			host:          "github.com",
 			expectedURL:   "",
 			expectError:   true,
 			errorContains: "host must have a scheme",
 		},
 		{
 			name:        "GHES host returns correct authorization server URL with subdomain isolation",
-			host:        "https://api.ghe.example.com",
+			host:        "https://ghe.example.com",
 			expectedURL: "https://ghe.example.com/login/oauth",
 			expectError: false,
 		},
 		{
 			name:        "GHES host returns correct authorization server URL without subdomain isolation",
-			host:        "https://ghe-nosubdomain.example.com/api/v3",
+			host:        "https://ghe-nosubdomain.example.com",
 			expectedURL: "https://ghe-nosubdomain.example.com/login/oauth",
 			expectError: false,
 		},

--- a/pkg/http/oauth/oauth_test.go
+++ b/pkg/http/oauth/oauth_test.go
@@ -663,15 +663,14 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 			errorContains: "host must have a scheme",
 		},
 		{
-			name:        "GHES host returns correct authorization server URL with subdomain isolation",
-			host:        "https://ghe.example.com",
-			expectedURL: "https://ghe.example.com/login/oauth",
-			expectError: false,
+			name:        "GHEC host returns correct authorization server URL",
+			host:        "https://test.ghe.com",
+			expectedURL: "https://test.ghe.com/login/oauth",
 		},
 		{
-			name:        "GHES host returns correct authorization server URL without subdomain isolation",
-			host:        "https://ghe-nosubdomain.example.com",
-			expectedURL: "https://ghe-nosubdomain.example.com/login/oauth",
+			name:        "GHES host returns correct authorization server URL",
+			host:        "https://ghe.example.com",
+			expectedURL: "https://ghe.example.com/login/oauth",
 			expectError: false,
 		},
 	}

--- a/pkg/http/oauth/oauth_test.go
+++ b/pkg/http/oauth/oauth_test.go
@@ -633,7 +633,7 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 	}{
 		{
 			name:               "valid host returns authorization server URL",
-			host:               "http://github.com",
+			host:               "https://github.com",
 			expectedURL:        "https://github.com/login/oauth",
 			expectedStatusCode: http.StatusOK,
 		},
@@ -661,6 +661,12 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 			name:               "GHES host returns correct authorization server URL",
 			host:               "https://ghe.example.com",
 			expectedURL:        "https://ghe.example.com/login/oauth",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "GHES with http scheme returns the correct authorization server URL",
+			host:               "http://ghe.example.com",
+			expectedURL:        "http://ghe.example.com/login/oauth",
 			expectedStatusCode: http.StatusOK,
 		},
 	}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -136,7 +136,7 @@ func RunHTTPServer(cfg ServerConfig) error {
 
 	r := chi.NewRouter()
 	handler := NewHTTPMcpHandler(ctx, &cfg, deps, t, logger, apiHost, append(serverOptions, WithFeatureChecker(featureChecker), WithOAuthConfig(oauthCfg))...)
-	oauthHandler, err := oauth.NewAuthHandler(oauthCfg)
+	oauthHandler, err := oauth.NewAuthHandler(ctx, oauthCfg, apiHost)
 	if err != nil {
 		return fmt.Errorf("failed to create OAuth handler: %w", err)
 	}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -136,7 +136,7 @@ func RunHTTPServer(cfg ServerConfig) error {
 
 	r := chi.NewRouter()
 	handler := NewHTTPMcpHandler(ctx, &cfg, deps, t, logger, apiHost, append(serverOptions, WithFeatureChecker(featureChecker), WithOAuthConfig(oauthCfg))...)
-	oauthHandler, err := oauth.NewAuthHandler(ctx, oauthCfg, apiHost)
+	oauthHandler, err := oauth.NewAuthHandler(oauthCfg, apiHost)
 	if err != nil {
 		return fmt.Errorf("failed to create OAuth handler: %w", err)
 	}

--- a/pkg/scopes/fetcher_test.go
+++ b/pkg/scopes/fetcher_test.go
@@ -28,6 +28,9 @@ func (t testAPIHostResolver) UploadURL(_ context.Context) (*url.URL, error) {
 func (t testAPIHostResolver) RawURL(_ context.Context) (*url.URL, error) {
 	return nil, nil
 }
+func (t testAPIHostResolver) AuthorizationServerURL(_ context.Context) (*url.URL, error) {
+	return nil, nil
+}
 
 func TestParseScopeHeader(t *testing.T) {
 	tests := []struct {

--- a/pkg/utils/api.go
+++ b/pkg/utils/api.go
@@ -125,9 +125,7 @@ func newGHECHost(hostname string) (APIHost, error) {
 		return APIHost{}, fmt.Errorf("failed to parse GHEC Raw URL: %w", err)
 	}
 
-	// The authorization server for GHEC is still on the root domain, not the api subdomain
-	rootHost := strings.TrimPrefix(u.Hostname(), "api.")
-	authorizationServerURL, err := url.Parse(fmt.Sprintf("https://%s/login/oauth", rootHost))
+	authorizationServerURL, err := url.Parse(fmt.Sprintf("https://%s/login/oauth", u.Hostname()))
 	if err != nil {
 		return APIHost{}, fmt.Errorf("failed to parse GHEC Authorization Server URL: %w", err)
 	}
@@ -185,16 +183,7 @@ func newGHESHost(hostname string) (APIHost, error) {
 		return APIHost{}, fmt.Errorf("failed to parse GHES Raw URL: %w", err)
 	}
 
-	// If subdomain isolation is enabled, the hostname will be api.hostname, but the authorization server is still on the root domain at hostname/login/oauth
-	// If subdomain isolation is not enabled, the hostname is still hostname and the authorization server is at hostname/login/oauth
-	var rootHost string
-	if hasSubdomainIsolation {
-		rootHost = strings.TrimPrefix(u.Hostname(), "api.")
-	} else {
-		rootHost = u.Hostname()
-	}
-	authorizationServerURL, err := url.Parse(fmt.Sprintf("%s://%s/login/oauth", u.Scheme, rootHost))
-
+	authorizationServerURL, err := url.Parse(fmt.Sprintf("%s://%s/login/oauth", u.Scheme, u.Hostname()))
 	if err != nil {
 		return APIHost{}, fmt.Errorf("failed to parse GHES Authorization Server URL: %w", err)
 	}

--- a/pkg/utils/api.go
+++ b/pkg/utils/api.go
@@ -14,13 +14,15 @@ type APIHostResolver interface {
 	GraphqlURL(ctx context.Context) (*url.URL, error)
 	UploadURL(ctx context.Context) (*url.URL, error)
 	RawURL(ctx context.Context) (*url.URL, error)
+	AuthorizationServerURL(ctx context.Context) (*url.URL, error)
 }
 
 type APIHost struct {
-	restURL   *url.URL
-	gqlURL    *url.URL
-	uploadURL *url.URL
-	rawURL    *url.URL
+	restURL                *url.URL
+	gqlURL                 *url.URL
+	uploadURL              *url.URL
+	rawURL                 *url.URL
+	authorizationServerURL *url.URL
 }
 
 var _ APIHostResolver = APIHost{}
@@ -52,6 +54,10 @@ func (a APIHost) RawURL(_ context.Context) (*url.URL, error) {
 	return a.rawURL, nil
 }
 
+func (a APIHost) AuthorizationServerURL(_ context.Context) (*url.URL, error) {
+	return a.authorizationServerURL, nil
+}
+
 func newDotcomHost() (APIHost, error) {
 	baseRestURL, err := url.Parse("https://api.github.com/")
 	if err != nil {
@@ -73,11 +79,18 @@ func newDotcomHost() (APIHost, error) {
 		return APIHost{}, fmt.Errorf("failed to parse dotcom Raw URL: %w", err)
 	}
 
+	// The authorization server for GitHub.com is at github.com/login/oauth, not api.github.com
+	authorizationServerURL, err := url.Parse("https://github.com/login/oauth")
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse dotcom Authorization Server URL: %w", err)
+	}
+
 	return APIHost{
-		restURL:   baseRestURL,
-		gqlURL:    gqlURL,
-		uploadURL: uploadURL,
-		rawURL:    rawURL,
+		restURL:                baseRestURL,
+		gqlURL:                 gqlURL,
+		uploadURL:              uploadURL,
+		rawURL:                 rawURL,
+		authorizationServerURL: authorizationServerURL,
 	}, nil
 }
 
@@ -112,11 +125,19 @@ func newGHECHost(hostname string) (APIHost, error) {
 		return APIHost{}, fmt.Errorf("failed to parse GHEC Raw URL: %w", err)
 	}
 
+	// The authorization server for GHEC is still on the root domain, not the api subdomain
+	rootHost := strings.TrimPrefix(u.Hostname(), "api.")
+	authorizationServerURL, err := url.Parse(fmt.Sprintf("https://%s/login/oauth", rootHost))
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse GHEC Authorization Server URL: %w", err)
+	}
+
 	return APIHost{
-		restURL:   restURL,
-		gqlURL:    gqlURL,
-		uploadURL: uploadURL,
-		rawURL:    rawURL,
+		restURL:                restURL,
+		gqlURL:                 gqlURL,
+		uploadURL:              uploadURL,
+		rawURL:                 rawURL,
+		authorizationServerURL: authorizationServerURL,
 	}, nil
 }
 
@@ -164,11 +185,26 @@ func newGHESHost(hostname string) (APIHost, error) {
 		return APIHost{}, fmt.Errorf("failed to parse GHES Raw URL: %w", err)
 	}
 
+	// If subdomain isolation is enabled, the hostname will be api.hostname, but the authorization server is still on the root domain at hostname/login/oauth
+	// If subdomain isolation is not enabled, the hostname is still hostname and the authorization server is at hostname/login/oauth
+	var rootHost string
+	if hasSubdomainIsolation {
+		rootHost = strings.TrimPrefix(u.Hostname(), "api.")
+	} else {
+		rootHost = u.Hostname()
+	}
+	authorizationServerURL, err := url.Parse(fmt.Sprintf("%s://%s/login/oauth", u.Scheme, rootHost))
+
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse GHES Authorization Server URL: %w", err)
+	}
+
 	return APIHost{
-		restURL:   restURL,
-		gqlURL:    gqlURL,
-		uploadURL: uploadURL,
-		rawURL:    rawURL,
+		restURL:                restURL,
+		gqlURL:                 gqlURL,
+		uploadURL:              uploadURL,
+		rawURL:                 rawURL,
+		authorizationServerURL: authorizationServerURL,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Handle generation of the OAuth Authorization Server URL when we're parsing URLs for the underlying clients.

## Why

As highlighted in https://github.com/github/github-mcp-server/pull/2046, we're not generating the OAuth Authorization Server URLs correctly.

This PR moves the generation into the `APIHostResolver` implementation and uses that in the OAuthHandler.

## What changed
<!-- Bullet list of concrete changes. -->
- 
- 

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [ ] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [ ] Linted locally with `./script/lint`
- [ ] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [ ] Updated (README / docs / examples)
