### PR TITLE
Update MIME types for UI resources to include profile for MCP Apps

### DIFF
--- a/pkg/github/ui_capability.go
+++ b/pkg/github/ui_capability.go
@@ -11,6 +11,9 @@ import (
 // advertise MCP Apps UI support.
 const mcpAppsExtensionKey = "io.modelcontextprotocol/ui"
 
+// MCPAppMIMEType is the MIME type for MCP App UI resources.
+const MCPAppMIMEType = "text/html;profile=mcp-app"
+
 // clientSupportsUI reports whether the MCP client that sent this request
 // supports MCP Apps UI rendering.
 // It checks the context first (set by HTTP/stateless servers from stored

--- a/pkg/github/ui_resources.go
+++ b/pkg/github/ui_resources.go
@@ -17,7 +17,7 @@ func RegisterUIResources(s *mcp.Server) {
 			URI:         GetMeUIResourceURI,
 			Name:        "get_me_ui",
 			Description: "MCP App UI for the get_me tool",
-			MIMEType:    "text/html;profile=mcp-app",
+			MIMEType:    MCPAppMIMEType,
 		},
 		func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 			html := MustGetUIAsset("get-me.html")
@@ -25,7 +25,7 @@ func RegisterUIResources(s *mcp.Server) {
 				Contents: []*mcp.ResourceContents{
 					{
 						URI:      GetMeUIResourceURI,
-						MIMEType: "text/html;profile=mcp-app",
+						MIMEType: MCPAppMIMEType,
 						Text:     html,
 						// MCP Apps UI metadata - CSP configuration to allow loading GitHub avatars
 						// See: https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx
@@ -49,7 +49,7 @@ func RegisterUIResources(s *mcp.Server) {
 			URI:         IssueWriteUIResourceURI,
 			Name:        "issue_write_ui",
 			Description: "MCP App UI for creating and updating GitHub issues",
-			MIMEType:    "text/html;profile=mcp-app",
+			MIMEType:    MCPAppMIMEType,
 		},
 		func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 			html := MustGetUIAsset("issue-write.html")
@@ -57,7 +57,7 @@ func RegisterUIResources(s *mcp.Server) {
 				Contents: []*mcp.ResourceContents{
 					{
 						URI:      IssueWriteUIResourceURI,
-						MIMEType: "text/html;profile=mcp-app",
+						MIMEType: MCPAppMIMEType,
 						Text:     html,
 					},
 				},
@@ -71,7 +71,7 @@ func RegisterUIResources(s *mcp.Server) {
 			URI:         PullRequestWriteUIResourceURI,
 			Name:        "pr_write_ui",
 			Description: "MCP App UI for creating GitHub pull requests",
-			MIMEType:    "text/html;profile=mcp-app",
+			MIMEType:    MCPAppMIMEType,
 		},
 		func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 			html := MustGetUIAsset("pr-write.html")
@@ -79,7 +79,7 @@ func RegisterUIResources(s *mcp.Server) {
 				Contents: []*mcp.ResourceContents{
 					{
 						URI:      PullRequestWriteUIResourceURI,
-						MIMEType: "text/html;profile=mcp-app",
+						MIMEType: MCPAppMIMEType,
 						Text:     html,
 					},
 				},


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->
Updates MCP Apps MIME types to include the correct `profile`

## Why
<!-- Why is this change needed? Link issues or discussions. -->
For parity with the TypeScript SDK examples

## What changed
<!-- Bullet list of concrete changes. -->
**MIME type updates for UI resources:**

* Changed the `MIMEType` for the "get_me_ui" resource and its response contents from `"text/html"` to `"text/html;profile=mcp-app"` to specify the MCP App profile.
* Updated the `MIMEType` for the "issue_write_ui" resource and its response contents to `"text/html;profile=mcp-app"`.
* Set the `MIMEType` for the "pr_write_ui" resource and its response contents to `"text/html;profile=mcp-app"`.

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
