### PR TITLE
Reduce context usage for `list_releases`

### DIFF
--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -702,6 +702,25 @@ func convertToMinimalBranch(branch *github.Branch) MinimalBranch {
 	}
 }
 
+func convertToMinimalRelease(release *github.RepositoryRelease) MinimalRelease {
+	m := MinimalRelease{
+		ID:         release.GetID(),
+		TagName:    release.GetTagName(),
+		Name:       release.GetName(),
+		Body:       release.GetBody(),
+		HTMLURL:    release.GetHTMLURL(),
+		Prerelease: release.GetPrerelease(),
+		Draft:      release.GetDraft(),
+		Author:     convertToMinimalUser(release.GetAuthor()),
+	}
+
+	if release.PublishedAt != nil {
+		m.PublishedAt = release.PublishedAt.Format(time.RFC3339)
+	}
+
+	return m
+}
+
 // MinimalCheckRun is the trimmed output type for check run objects.
 type MinimalCheckRun struct {
 	ID          int64  `json:"id"`

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1670,7 +1670,14 @@ func ListReleases(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list releases", resp, body), nil, nil
 			}
 
-			r, err := json.Marshal(releases)
+			minimalReleases := make([]MinimalRelease, 0, len(releases))
+			for _, release := range releases {
+				if release != nil {
+					minimalReleases = append(minimalReleases, convertToMinimalRelease(release))
+				}
+			}
+
+			r, err := json.Marshal(minimalReleases)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -3052,12 +3052,12 @@ func Test_ListReleases(t *testing.T) {
 
 			require.NoError(t, err)
 			textContent := getTextResult(t, result)
-			var returnedReleases []*github.RepositoryRelease
+			var returnedReleases []MinimalRelease
 			err = json.Unmarshal([]byte(textContent.Text), &returnedReleases)
 			require.NoError(t, err)
 			assert.Len(t, returnedReleases, len(tc.expectedResult))
-			for i, rel := range returnedReleases {
-				assert.Equal(t, *tc.expectedResult[i].TagName, *rel.TagName)
+			for i := range returnedReleases {
+				assert.Equal(t, *tc.expectedResult[i].TagName, returnedReleases[i].TagName)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

Reduces context usage for `list_releases` by adding a `convertToMinimalRelease` function for the existing `MinimalRelease` type.

### Field preserved

`id`, `tag_name`, `name`, `body`, `html_url`, `published_at`, `prerelease`, `draft`, `author` (`MinimalUser`)

### Fields dropped

`node_id`, `url`, `assets_url`, `upload_url`, `zipball_url`, `tarball_url`, `target_commitish`, `created_at`, `assets` (full array with nested objects), `immutable`, full `User` object (-> `MinimalUser`)

### Single Item Payload Diff

<details>
  <summary>Before</summary>

```json
	{
		"tag_name": "v19.2.4",
		"target_commitish": "main",
		"name": "19.2.4 (January 26th, 2026)",
		"body": "## React Server Components\r\n\r\n- Add more DoS mitigations to Server Actions, and harden Server Components ([#35632](https://github.com/facebook/react/pull/35632) by @gnoff, @lubieowoce, @sebmarkbage, @unstubbable)",
		"draft": false,
		"prerelease": false,
		"id": 279999398,
		"created_at": "2026-01-26T17:04:55Z",
		"published_at": "2026-01-26T18:29:43Z",
		"url": "https://api.github.com/repos/facebook/react/releases/279999398",
		"html_url": "https://github.com/facebook/react/releases/tag/v19.2.4",
		"assets_url": "https://api.github.com/repos/facebook/react/releases/279999398/assets",
		"upload_url": "https://uploads.github.com/repos/facebook/react/releases/279999398/assets{?name,label}",
		"zipball_url": "https://api.github.com/repos/facebook/react/zipball/v19.2.4",
		"tarball_url": "https://api.github.com/repos/facebook/react/tarball/v19.2.4",
		"author": {
			"login": "eps1lon",
			"id": 12292047,
			"node_id": "MDQ6VXNlcjEyMjkyMDQ3",
			"avatar_url": "https://avatars.githubusercontent.com/u/12292047?v=4",
			"html_url": "https://github.com/eps1lon",
			"gravatar_id": "",
			"type": "User",
			"site_admin": false,
			"url": "https://api.github.com/users/eps1lon",
			"events_url": "https://api.github.com/users/eps1lon/events{/privacy}",
			"following_url": "https://api.github.com/users/eps1lon/following{/other_user}",
			"followers_url": "https://api.github.com/users/eps1lon/followers",
			"gists_url": "https://api.github.com/users/eps1lon/gists{/gist_id}",
			"organizations_url": "https://api.github.com/users/eps1lon/orgs",
			"received_events_url": "https://api.github.com/users/eps1lon/received_events",
			"repos_url": "https://api.github.com/users/eps1lon/repos",
			"starred_url": "https://api.github.com/users/eps1lon/starred{/owner}{/repo}",
			"subscriptions_url": "https://api.github.com/users/eps1lon/subscriptions"
		},
		"node_id": "RE_kwDOAJy2Ks4QsHOm",
		"immutable": false
	}
```

</details>

<details>
  <summary>After</summary>

```json
	{
		"id": 279999398,
		"tag_name": "v19.2.4",
		"name": "19.2.4 (January 26th, 2026)",
		"body": "## React Server Components\r\n\r\n- Add more DoS mitigations to Server Actions, and harden Server Components ([#35632](https://github.com/facebook/react/pull/35632) by @gnoff, @lubieowoce, @sebmarkbage, @unstubbable)",
		"html_url": "https://github.com/facebook/react/releases/tag/v19.2.4",
		"published_at": "2026-01-26T18:29:43Z",
		"prerelease": false,
		"draft": false,
		"author": {
			"login": "eps1lon",
			"id": 12292047,
			"profile_url": "https://github.com/eps1lon",
			"avatar_url": "https://avatars.githubusercontent.com/u/12292047?v=4"
		}
	}
```

</details>

### Token Reduction

Measured using a script that makes use of OAI's `tiktoken` library (`o200k_base`) at 2 and 25 items.

| Items | Baseline | Optimised | Reduction |
|-------|----------|-----------|-----------|
| 2 | 1,348 | 480 | 64.4% |
| 25 | 44,912 | 33,996 | 24.3% |

## Why
<!-- Why is this change needed? Link issues or discussions. -->

`list_releases` was returning raw `*github.RepositoryRelease` objects with ~20+ fields including nested assets arrays, API URLs, and full user objects. Most of this is noise not useful for model reasoning. Details are available via `get_latest_release` or `get_release_by_tag`.

## What changed
<!-- Bullet list of concrete changes. -->
- Added `convertToMinimalRelease` conversion function
- Wired `convertToMinimalRelease` in `list_releases`
- Updated relevant tests

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- `List the last 2 releases in facebook/react`
- `List the last 25 releases in facebook/react`

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
