### PR TITLE
Add collision-resistant request and operation IDs for MCP handling

### DIFF
--- a/pkg/context/request_ids.go
+++ b/pkg/context/request_ids.go
@@ -1,0 +1,44 @@
+package context
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+)
+
+type requestIDCtxKey struct{}
+type operationIDCtxKey struct{}
+
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, requestIDCtxKey{}, requestID)
+}
+
+func RequestID(ctx context.Context) (string, bool) {
+	requestID, ok := ctx.Value(requestIDCtxKey{}).(string)
+	return requestID, ok
+}
+
+func WithOperationID(ctx context.Context, operationID string) context.Context {
+	return context.WithValue(ctx, operationIDCtxKey{}, operationID)
+}
+
+func OperationID(ctx context.Context) (string, bool) {
+	operationID, ok := ctx.Value(operationIDCtxKey{}).(string)
+	return operationID, ok
+}
+
+func GenerateRequestID() (string, error) {
+	return generateID("req")
+}
+
+func GenerateOperationID() (string, error) {
+	return generateID("op")
+}
+
+func generateID(prefix string) (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate %s id: %w", prefix, err)
+	}
+	return fmt.Sprintf("%s_%x", prefix, buf), nil
+}

--- a/pkg/github/server_operation_id_test.go
+++ b/pkg/github/server_operation_id_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"context"
+	"testing"
+
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithOperationID_PreservesRequestIDAndAddsOperationID(t *testing.T) {
+	t.Parallel()
+
+	var capturedRequestID string
+	var capturedOperationID string
+	handler := withOperationID(func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		var ok bool
+		capturedRequestID, ok = ghcontext.RequestID(ctx)
+		require.True(t, ok)
+
+		capturedOperationID, ok = ghcontext.OperationID(ctx)
+		require.True(t, ok)
+		return nil, nil
+	})
+
+	_, err := handler(ghcontext.WithRequestID(context.Background(), "req_client"), "tools/call", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "req_client", capturedRequestID)
+	assert.Regexp(t, `^op_[0-9a-f]+$`, capturedOperationID)
+}
+
+func TestWithOperationID_GeneratesUniqueOperationIDs(t *testing.T) {
+	t.Parallel()
+
+	var operationIDs []string
+	handler := withOperationID(func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		operationID, ok := ghcontext.OperationID(ctx)
+		require.True(t, ok)
+		operationIDs = append(operationIDs, operationID)
+		return nil, nil
+	})
+
+	_, err := handler(context.Background(), "tools/call", nil)
+	require.NoError(t, err)
+	_, err = handler(context.Background(), "tools/call", nil)
+	require.NoError(t, err)
+
+	require.Len(t, operationIDs, 2)
+	assert.NotEqual(t, operationIDs[0], operationIDs[1])
+}

--- a/pkg/http/headers/headers.go
+++ b/pkg/http/headers/headers.go
@@ -25,6 +25,8 @@ const (
 	ForwardedHostHeader = "X-Forwarded-Host"
 	// ForwardedProtoHeader is a standard HTTP Header for preserving the original protocol when proxying.
 	ForwardedProtoHeader = "X-Forwarded-Proto"
+	// RequestIDHeader is a standard request-correlation header.
+	RequestIDHeader = "X-Request-ID"
 
 	// RequestHmacHeader is used to authenticate requests to the Raw API.
 	RequestHmacHeader = "Request-Hmac"

--- a/pkg/http/middleware/request_config_test.go
+++ b/pkg/http/middleware/request_config_test.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
+	"github.com/github/github-mcp-server/pkg/http/headers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithRequestConfig_PreservesProvidedRequestID(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set(headers.RequestIDHeader, "client-request-id")
+
+	var requestID string
+	handler := WithRequestConfig(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var ok bool
+		requestID, ok = ghcontext.RequestID(r.Context())
+		require.True(t, ok)
+	}))
+
+	handler.ServeHTTP(recorder, request)
+
+	assert.Equal(t, "client-request-id", requestID)
+	assert.Equal(t, "client-request-id", recorder.Header().Get(headers.RequestIDHeader))
+}
+
+func TestWithRequestConfig_GeneratesRequestIDWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	var requestID string
+	handler := WithRequestConfig(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var ok bool
+		requestID, ok = ghcontext.RequestID(r.Context())
+		require.True(t, ok)
+	}))
+
+	handler.ServeHTTP(recorder, request)
+
+	assert.NotEmpty(t, requestID)
+	assert.Equal(t, requestID, recorder.Header().Get(headers.RequestIDHeader))
+	assert.Regexp(t, `^req_[0-9a-f]+$`, requestID)
+}


### PR DESCRIPTION
## Problem
Request/operation correlation IDs are not guaranteed to exist or be collision-resistant across MCP middleware/server handling paths, which weakens observability and audit correlation.

## Why now
Issue #2099 requests stable, collision-resistant request/operation IDs for tool invocation flow.

## What changed
- Added request/operation ID context helpers with cryptographically random ID generation.
- Added request ID propagation in HTTP request config middleware using `X-Request-ID` (preserve-or-generate behavior).
- Added server middleware to ensure operation IDs are generated per request and bound to context.
- Added tests for request ID propagation and operation ID generation behavior.

## Validation
- `go test ./pkg/http/middleware ./pkg/github -run 'TestWithRequestConfig|TestWithOperationID'` (pass)

Refs #2099
