### PR TITLE
Add deterministic default+custom toolset resolution regression

### DIFF
--- a/pkg/inventory/registry_test.go
+++ b/pkg/inventory/registry_test.go
@@ -180,6 +180,27 @@ func TestWithToolsets(t *testing.T) {
 	}
 }
 
+func TestWithToolsets_DefaultAndCustomOrderIsDeterministic(t *testing.T) {
+	tools := []ServerTool{
+		mockToolWithDefault("tool-alpha", "alpha", true, true),
+		mockToolWithDefault("tool-beta", "beta", true, true),
+		mockToolWithDefault("tool-gamma", "gamma", true, false),
+	}
+
+	reg := mustBuild(t, NewBuilder().
+		SetTools(tools).
+		WithToolsets([]string{"gamma", "default", "gamma"}))
+
+	enabledIDs := reg.EnabledToolsetIDs()
+	require.Equal(t, []ToolsetID{"alpha", "beta", "gamma"}, enabledIDs)
+
+	available := reg.AvailableTools(context.Background())
+	require.Len(t, available, 3)
+	require.Equal(t, "tool-alpha", available[0].Tool.Name)
+	require.Equal(t, "tool-beta", available[1].Tool.Name)
+	require.Equal(t, "tool-gamma", available[2].Tool.Name)
+}
+
 func TestWithToolsetsTrimsWhitespace(t *testing.T) {
 	tools := []ServerTool{
 		mockTool("tool1", "toolset1", true),


### PR DESCRIPTION
## Problem
When `default` and explicit toolset selections overlap, ordering and deduplication behavior must remain deterministic to keep exposed toolsets and resulting inventories stable.

## Why now
Issue #2104 tracks deterministic toolset resolution ordering for default/custom combinations.

## What changed
- Added `TestWithToolsets_DefaultAndCustomOrderIsDeterministic` in `pkg/inventory/registry_test.go`.
- The test asserts deterministic enabled toolset order and deterministic available tool ordering for overlapping `default` + explicit toolset inputs.

## Validation
- `go test ./pkg/inventory -run 'TestWithToolsets_DefaultAndCustomOrderIsDeterministic|TestWithToolsets'`

Refs #2104
