### PR TITLE
Stricter matching for github.com and ghe.com URLs

### DIFF
--- a/pkg/utils/api.go
+++ b/pkg/utils/api.go
@@ -235,11 +235,11 @@ func parseAPIHost(s string) (APIHost, error) {
 		return APIHost{}, fmt.Errorf("host must have a scheme (http or https): %s", s)
 	}
 
-	if strings.HasSuffix(u.Hostname(), "github.com") {
+	if u.Hostname() == "github.com" || strings.HasSuffix(u.Hostname(), ".github.com") {
 		return newDotcomHost()
 	}
 
-	if strings.HasSuffix(u.Hostname(), "ghe.com") {
+	if u.Hostname() == "ghe.com" || strings.HasSuffix(u.Hostname(), ".ghe.com") {
 		return newGHECHost(s)
 	}
 

--- a/pkg/utils/api_test.go
+++ b/pkg/utils/api_test.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAPIHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantRestURL string
+		wantErr     bool
+	}{
+		{
+			name:        "empty string defaults to dotcom",
+			input:       "",
+			wantRestURL: "https://api.github.com/",
+		},
+		{
+			name:        "github.com hostname",
+			input:       "https://github.com",
+			wantRestURL: "https://api.github.com/",
+		},
+		{
+			name:        "subdomain of github.com",
+			input:       "https://foo.github.com",
+			wantRestURL: "https://api.github.com/",
+		},
+		{
+			name:        "hostname ending in github.com but not a subdomain",
+			input:       "https://mycompanygithub.com",
+			wantRestURL: "https://mycompanygithub.com/api/v3/",
+		},
+		{
+			name:        "hostname ending in notgithub.com",
+			input:       "https://notgithub.com",
+			wantRestURL: "https://notgithub.com/api/v3/",
+		},
+		{
+			name:        "ghe.com hostname",
+			input:       "https://ghe.com",
+			wantRestURL: "https://api.ghe.com/",
+		},
+		{
+			name:        "subdomain of ghe.com",
+			input:       "https://mycompany.ghe.com",
+			wantRestURL: "https://api.mycompany.ghe.com/",
+		},
+		{
+			name:        "hostname ending in ghe.com but not a subdomain",
+			input:       "https://myghe.com",
+			wantRestURL: "https://myghe.com/api/v3/",
+		},
+		{
+			name:    "missing scheme",
+			input:   "github.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host, err := parseAPIHost(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantRestURL, host.restURL.String())
+		})
+	}
+}


### PR DESCRIPTION

## Summary

GHES hostnames ending on github.com and ghe.com (like mycompanygithub.com) shouldn't be detected as dotcom/ghe hostnames.

## Why

Fixes https://github.com/github/github-mcp-server/issues/2000

## What changed
<!-- Bullet list of concrete changes. -->
- 
- 

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [ ] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [ ] Linted locally with `./script/lint`
- [ ] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [ ] Updated (README / docs / examples)
