### PR TITLE
fix: handle lightweight tags in get_tag tool

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1592,7 +1592,58 @@ func GetTag(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get tag reference", resp, body), nil, nil
 			}
 
-			// Then get the tag object
+			// Handle both annotated and lightweight tags.
+			// Annotated tags have ref.Object.Type == "tag" and point to a tag object.
+			// Lightweight tags have ref.Object.Type == "commit" and point directly to a commit.
+			if ref.Object.Type != nil && *ref.Object.Type == "commit" {
+				// Lightweight tag — resolve the commit directly
+				commit, resp, err := client.Git.GetCommit(ctx, owner, repo, *ref.Object.SHA)
+				if err != nil {
+					return ghErrors.NewGitHubAPIErrorResponse(ctx,
+						"failed to get commit for lightweight tag",
+						resp,
+						err,
+					), nil, nil
+				}
+				defer func() { _ = resp.Body.Close() }()
+
+				if resp.StatusCode != http.StatusOK {
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+					}
+					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get commit for lightweight tag", resp, body), nil, nil
+				}
+
+				// Return a tag-like structure for consistency
+				lightweightTag := &github.Tag{
+					SHA: ref.Object.SHA,
+					Tag: github.Ptr(tag),
+					Object: &github.GitObject{
+						Type: github.Ptr("commit"),
+						SHA:  ref.Object.SHA,
+					},
+				}
+				if commit.Message != nil {
+					lightweightTag.Message = commit.Message
+				}
+				if commit.Author != nil {
+					lightweightTag.Tagger = &github.CommitAuthor{
+						Name:  commit.Author.Name,
+						Email: commit.Author.Email,
+						Date:  commit.Author.Date,
+					}
+				}
+
+				r, err := json.Marshal(lightweightTag)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+				}
+
+				return utils.NewToolResultText(string(r)), nil, nil
+			}
+
+			// Annotated tag — fetch the tag object
 			tagObj, resp, err := client.Git.GetTag(ctx, owner, repo, *ref.Object.SHA)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1574,22 +1574,22 @@ func GetTag(t translations.TranslationHelperFunc) inventory.ServerTool {
 			}
 
 			// First get the tag reference
-			ref, resp, err := client.Git.GetRef(ctx, owner, repo, "refs/tags/"+tag)
+			ref, refResp, err := client.Git.GetRef(ctx, owner, repo, "refs/tags/"+tag)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,
 					"failed to get tag reference",
-					resp,
+					refResp,
 					err,
 				), nil, nil
 			}
-			defer func() { _ = resp.Body.Close() }()
+			defer func() { _ = refResp.Body.Close() }()
 
-			if resp.StatusCode != http.StatusOK {
-				body, err := io.ReadAll(resp.Body)
+			if refResp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(refResp.Body)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 				}
-				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get tag reference", resp, body), nil, nil
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get tag reference", refResp, body), nil, nil
 			}
 
 			// Handle both annotated and lightweight tags.
@@ -1597,22 +1597,22 @@ func GetTag(t translations.TranslationHelperFunc) inventory.ServerTool {
 			// Lightweight tags have ref.Object.Type == "commit" and point directly to a commit.
 			if ref.Object.Type != nil && *ref.Object.Type == "commit" {
 				// Lightweight tag — resolve the commit directly
-				commit, resp, err := client.Git.GetCommit(ctx, owner, repo, *ref.Object.SHA)
+				commit, commitResp, err := client.Git.GetCommit(ctx, owner, repo, *ref.Object.SHA)
 				if err != nil {
 					return ghErrors.NewGitHubAPIErrorResponse(ctx,
 						"failed to get commit for lightweight tag",
-						resp,
+						commitResp,
 						err,
 					), nil, nil
 				}
-				defer func() { _ = resp.Body.Close() }()
+				defer func() { _ = commitResp.Body.Close() }()
 
-				if resp.StatusCode != http.StatusOK {
-					body, err := io.ReadAll(resp.Body)
+				if commitResp.StatusCode != http.StatusOK {
+					body, err := io.ReadAll(commitResp.Body)
 					if err != nil {
 						return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 					}
-					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get commit for lightweight tag", resp, body), nil, nil
+					return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get commit for lightweight tag", commitResp, body), nil, nil
 				}
 
 				// Return a tag-like structure for consistency
@@ -1644,22 +1644,22 @@ func GetTag(t translations.TranslationHelperFunc) inventory.ServerTool {
 			}
 
 			// Annotated tag — fetch the tag object
-			tagObj, resp, err := client.Git.GetTag(ctx, owner, repo, *ref.Object.SHA)
+			tagObj, tagResp, err := client.Git.GetTag(ctx, owner, repo, *ref.Object.SHA)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,
 					"failed to get tag object",
-					resp,
+					tagResp,
 					err,
 				), nil, nil
 			}
-			defer func() { _ = resp.Body.Close() }()
+			defer func() { _ = tagResp.Body.Close() }()
 
-			if resp.StatusCode != http.StatusOK {
-				body, err := io.ReadAll(resp.Body)
+			if tagResp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(tagResp.Body)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 				}
-				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get tag object", resp, body), nil, nil
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get tag object", tagResp, body), nil, nil
 			}
 
 			r, err := json.Marshal(tagObj)

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2840,7 +2840,16 @@ func Test_GetTag(t *testing.T) {
 	mockTagRef := &github.Reference{
 		Ref: github.Ptr("refs/tags/v1.0.0"),
 		Object: &github.GitObject{
-			SHA: github.Ptr("v1.0.0-tag-sha"),
+			SHA:  github.Ptr("v1.0.0-tag-sha"),
+			Type: github.Ptr("tag"),
+		},
+	}
+
+	mockLightweightTagRef := &github.Reference{
+		Ref: github.Ptr("refs/tags/v2.0.0"),
+		Object: &github.GitObject{
+			SHA:  github.Ptr("lightweight-commit-sha"),
+			Type: github.Ptr("commit"),
 		},
 	}
 
@@ -2851,6 +2860,15 @@ func Test_GetTag(t *testing.T) {
 		Object: &github.GitObject{
 			Type: github.Ptr("commit"),
 			SHA:  github.Ptr("abc123"),
+		},
+	}
+
+	mockCommit := &github.Commit{
+		SHA:     github.Ptr("lightweight-commit-sha"),
+		Message: github.Ptr("Initial commit"),
+		Author: &github.CommitAuthor{
+			Name:  github.Ptr("Test User"),
+			Email: github.Ptr("test@example.com"),
 		},
 	}
 
@@ -2891,6 +2909,44 @@ func Test_GetTag(t *testing.T) {
 			},
 			expectError: false,
 			expectedTag: mockTagObj,
+		},
+		{
+			name: "successful lightweight tag retrieval",
+			mockedClient: NewMockedHTTPClient(
+				WithRequestMatchHandler(
+					GetReposGitRefByOwnerByRepoByRef,
+					expectPath(
+						t,
+						"/repos/owner/repo/git/ref/tags/v2.0.0",
+					).andThen(
+						mockResponse(t, http.StatusOK, mockLightweightTagRef),
+					),
+				),
+				WithRequestMatchHandler(
+					GetReposGitCommitsByOwnerByRepoByCommitSHA,
+					expectPath(
+						t,
+						"/repos/owner/repo/git/commits/lightweight-commit-sha",
+					).andThen(
+						mockResponse(t, http.StatusOK, mockCommit),
+					),
+				),
+			),
+			requestArgs: map[string]any{
+				"owner": "owner",
+				"repo":  "repo",
+				"tag":   "v2.0.0",
+			},
+			expectError: false,
+			expectedTag: &github.Tag{
+				SHA:     github.Ptr("lightweight-commit-sha"),
+				Tag:     github.Ptr("v2.0.0"),
+				Message: github.Ptr("Initial commit"),
+				Object: &github.GitObject{
+					Type: github.Ptr("commit"),
+					SHA:  github.Ptr("lightweight-commit-sha"),
+				},
+			},
 		},
 		{
 			name: "tag reference not found",

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2942,6 +2942,10 @@ func Test_GetTag(t *testing.T) {
 				SHA:     github.Ptr("lightweight-commit-sha"),
 				Tag:     github.Ptr("v2.0.0"),
 				Message: github.Ptr("Initial commit"),
+				Tagger: &github.CommitAuthor{
+					Name:  github.Ptr("Test User"),
+					Email: github.Ptr("test@example.com"),
+				},
 				Object: &github.GitObject{
 					Type: github.Ptr("commit"),
 					SHA:  github.Ptr("lightweight-commit-sha"),
@@ -2966,6 +2970,29 @@ func Test_GetTag(t *testing.T) {
 			},
 			expectError:    true,
 			expectedErrMsg: "failed to get tag reference",
+		},
+		{
+			name: "lightweight tag commit not found",
+			mockedClient: NewMockedHTTPClient(
+				WithRequestMatch(
+					GetReposGitRefByOwnerByRepoByRef,
+					mockLightweightTagRef,
+				),
+				WithRequestMatchHandler(
+					GetReposGitCommitsByOwnerByRepoByCommitSHA,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"message": "Commit does not exist"}`))
+					}),
+				),
+			),
+			requestArgs: map[string]any{
+				"owner": "owner",
+				"repo":  "repo",
+				"tag":   "v2.0.0",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to get commit for lightweight tag",
 		},
 		{
 			name: "tag object not found",
@@ -3032,6 +3059,11 @@ func Test_GetTag(t *testing.T) {
 			assert.Equal(t, *tc.expectedTag.Message, *returnedTag.Message)
 			assert.Equal(t, *tc.expectedTag.Object.Type, *returnedTag.Object.Type)
 			assert.Equal(t, *tc.expectedTag.Object.SHA, *returnedTag.Object.SHA)
+			if tc.expectedTag.Tagger != nil {
+				require.NotNil(t, returnedTag.Tagger, "expected Tagger to be set")
+				assert.Equal(t, *tc.expectedTag.Tagger.Name, *returnedTag.Tagger.Name)
+				assert.Equal(t, *tc.expectedTag.Tagger.Email, *returnedTag.Tagger.Email)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

The `get_tag` tool returns a 404 error when used with lightweight tags because it unconditionally calls the Git Tag Object API, which only works for annotated tags.

- Adds `ref.Object.Type` check after resolving the tag reference
- Lightweight tags (`"commit"` type): resolves via `Git.GetCommit()` and returns a `github.Tag`-compatible structure
- Annotated tags (`"tag"` type): unchanged behavior via `Git.GetTag()`

## Bug

In `pkg/github/repositories.go`, the `GetTag` handler resolves a tag reference via `client.Git.GetRef()`, then always calls `client.Git.GetTag()` with the ref's SHA. This works for annotated tags (where the SHA points to a tag object), but fails for lightweight tags (where the SHA points directly to a commit — the Git Tag Object API returns 404).

**Reproduce:** Create a lightweight tag (`git tag v1.0.0 && git push --tags`), then call `get_tag` → 404.

## Changes

**`pkg/github/repositories.go`**
- After getting the tag reference, check `ref.Object.Type`
- If `"commit"` (lightweight): call `client.Git.GetCommit()`, return a `github.Tag` struct with commit message and author mapped to tagger
- If `"tag"` (annotated): proceed with existing `client.Git.GetTag()` call (no behavior change)

**`pkg/github/repositories_test.go`**
- Added `mockLightweightTagRef` and `mockCommit` fixtures
- Added `"successful lightweight tag retrieval"` test case
- Updated existing `mockTagRef` to include `Type: github.Ptr("tag")` for accuracy

## Notes

- No schema change — the tool returns the same `github.Tag` JSON structure for both tag types
- Backward compatible — annotated tag responses are identical to before
- No toolsnap update needed (schema unchanged)
