### PR TITLE
Fix push_files schema missing AdditionalProperties for Visual Studio 2026

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1233,7 +1233,8 @@ func PushFiles(t translations.TranslationHelperFunc) inventory.ServerTool {
 						Type:        "array",
 						Description: "Array of file objects to push, each object with path (string) and content (string)",
 						Items: &jsonschema.Schema{
-							Type: "object",
+							Type:                "object",
+							AdditionalProperties: jsonschema.BoolPtr(false),
 							Properties: map[string]*jsonschema.Schema{
 								"path": {
 									Type:        "string",


### PR DESCRIPTION
Fixes #2011. Visual Studio 2026 requires array item schemas to explicitly set additionalProperties to false. The push_files tool's files array was missing this, causing HTTP 400 errors when the tool was invoked from VS 2026 Insiders.

This adds AdditionalProperties: false to the files array items schema to indicate only path and content properties are allowed.