### PR TITLE
Classify GitHub secondary and abuse rate limits

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -19,11 +19,15 @@ Used for REST API errors from the GitHub API:
 
 ```go
 type GitHubAPIError struct {
-    Message  string           `json:"message"`
-    Response *github.Response `json:"-"`
-    Err      error            `json:"-"`
+    Message           string           `json:"message"`
+    Code              string           `json:"code,omitempty"`
+    RetryAfterSeconds *int             `json:"retry_after_seconds,omitempty"`
+    Response          *github.Response `json:"-"`
+    Err               error            `json:"-"`
 }
 ```
+
+Current HTTP classifications include authentication/scope failures plus distinct rate-limit codes such as `rate_limited`, `secondary_rate_limited`, and `abuse_rate_limited` when the upstream response provides that signal.
 
 ### GitHubGraphQLError
 

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/google/go-github/v82/github"
@@ -11,17 +13,21 @@ import (
 )
 
 type GitHubAPIError struct {
-	Message  string           `json:"message"`
-	Response *github.Response `json:"-"`
-	Err      error            `json:"-"`
+	Message           string           `json:"message"`
+	Code              string           `json:"code,omitempty"`
+	RetryAfterSeconds *int             `json:"retry_after_seconds,omitempty"`
+	Response          *github.Response `json:"-"`
+	Err               error            `json:"-"`
 }
 
 // NewGitHubAPIError creates a new GitHubAPIError with the provided message, response, and error.
 func newGitHubAPIError(message string, resp *github.Response, err error) *GitHubAPIError {
 	return &GitHubAPIError{
-		Message:  message,
-		Response: resp,
-		Err:      err,
+		Message:           message,
+		Code:              classifyHTTPErrorCode(resp.Response, message, err),
+		RetryAfterSeconds: parseRetryAfterSeconds(resp.Response),
+		Response:          resp,
+		Err:               err,
 	}
 }
 
@@ -46,21 +52,101 @@ func (e *GitHubGraphQLError) Error() string {
 }
 
 type GitHubRawAPIError struct {
-	Message  string         `json:"message"`
-	Response *http.Response `json:"-"`
-	Err      error          `json:"-"`
+	Message           string         `json:"message"`
+	Code              string         `json:"code,omitempty"`
+	RetryAfterSeconds *int           `json:"retry_after_seconds,omitempty"`
+	Response          *http.Response `json:"-"`
+	Err               error          `json:"-"`
 }
 
 func newGitHubRawAPIError(message string, resp *http.Response, err error) *GitHubRawAPIError {
 	return &GitHubRawAPIError{
-		Message:  message,
-		Response: resp,
-		Err:      err,
+		Message:           message,
+		Code:              classifyHTTPErrorCode(resp, message, err),
+		RetryAfterSeconds: parseRetryAfterSeconds(resp),
+		Response:          resp,
+		Err:               err,
 	}
 }
 
 func (e *GitHubRawAPIError) Error() string {
 	return fmt.Errorf("%s: %w", e.Message, e.Err).Error()
+}
+
+func classifyHTTPErrorCode(resp *http.Response, message string, err error) string {
+	if resp == nil {
+		return ""
+	}
+
+	combined := strings.ToLower(strings.TrimSpace(strings.Join([]string{
+		message,
+		errorString(err),
+		resp.Status,
+	}, " ")))
+
+	if code := classifyRateLimitCode(resp, combined); code != "" {
+		return code
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return "invalid_token"
+	case http.StatusForbidden:
+		if strings.Contains(combined, "scope") || strings.Contains(combined, "permission") {
+			return "insufficient_scope"
+		}
+	}
+
+	return ""
+}
+
+func classifyRateLimitCode(resp *http.Response, combined string) string {
+	if resp == nil {
+		return ""
+	}
+
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+		return ""
+	}
+
+	switch {
+	case strings.Contains(combined, "secondary rate limit"):
+		return "secondary_rate_limited"
+	case strings.Contains(combined, "abuse") || strings.Contains(combined, "abuse detection"):
+		return "abuse_rate_limited"
+	case resp.Header.Get("X-RateLimit-Remaining") == "0":
+		return "rate_limited"
+	case strings.Contains(combined, "rate limit exceeded"):
+		return "rate_limited"
+	default:
+		return ""
+	}
+}
+
+func parseRetryAfterSeconds(resp *http.Response) *int {
+	if resp == nil {
+		return nil
+	}
+
+	retryAfter := strings.TrimSpace(resp.Header.Get("Retry-After"))
+	if retryAfter == "" {
+		return nil
+	}
+
+	seconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		return nil
+	}
+
+	return &seconds
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return err.Error()
 }
 
 type GitHubErrorKey struct{}

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -36,6 +36,8 @@ func TestGitHubErrorContext(t *testing.T) {
 
 		apiError := apiErrors[0]
 		assert.Equal(t, "failed to fetch resource", apiError.Message)
+		assert.Empty(t, apiError.Code)
+		assert.Nil(t, apiError.RetryAfterSeconds)
 		assert.Equal(t, resp, apiError.Response)
 		assert.Equal(t, originalErr, apiError.Err)
 		assert.Equal(t, "failed to fetch resource: resource not found", apiError.Error())
@@ -86,6 +88,8 @@ func TestGitHubErrorContext(t *testing.T) {
 
 		rawError := rawErrors[0]
 		assert.Equal(t, "failed to fetch raw content", rawError.Message)
+		assert.Empty(t, rawError.Code)
+		assert.Nil(t, rawError.RetryAfterSeconds)
 		assert.Equal(t, resp, rawError.Response)
 		assert.Equal(t, originalErr, rawError.Err)
 	})
@@ -260,6 +264,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 		apiError := apiErrors[0]
 		assert.Equal(t, "API call failed", apiError.Message)
+		assert.Empty(t, apiError.Code)
 		assert.Equal(t, resp, apiError.Response)
 		assert.Equal(t, originalErr, apiError.Err)
 	})
@@ -308,6 +313,7 @@ func TestGitHubErrorContext(t *testing.T) {
 
 		apiError := apiErrors[0]
 		assert.Equal(t, "failed to create issue", apiError.Message)
+		assert.Empty(t, apiError.Code)
 		assert.Equal(t, resp, apiError.Response)
 		// The synthetic error should contain the status code and body
 		assert.Contains(t, apiError.Err.Error(), "unexpected status 422")
@@ -383,6 +389,71 @@ func TestGitHubErrorTypes(t *testing.T) {
 		// Should implement error interface
 		var err error = gqlErr
 		assert.Equal(t, "test message: query failed", err.Error())
+	})
+
+	t.Run("GitHubAPIError classifies rate limit variants and preserves retry metadata", func(t *testing.T) {
+		t.Run("secondary rate limit", func(t *testing.T) {
+			resp := &github.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusForbidden,
+					Status:     "403 Forbidden",
+					Header: http.Header{
+						"Retry-After": []string{"60"},
+					},
+				},
+			}
+
+			apiErr := newGitHubAPIError("failed to search", resp, fmt.Errorf("secondary rate limit exceeded"))
+
+			require.NotNil(t, apiErr.RetryAfterSeconds)
+			assert.Equal(t, "secondary_rate_limited", apiErr.Code)
+			assert.Equal(t, 60, *apiErr.RetryAfterSeconds)
+		})
+
+		t.Run("abuse rate limit", func(t *testing.T) {
+			resp := &github.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusForbidden,
+					Status:     "403 Forbidden",
+					Header:     http.Header{},
+				},
+			}
+
+			apiErr := newGitHubAPIError("failed to create issue", resp, fmt.Errorf("You have triggered an abuse detection mechanism"))
+
+			assert.Equal(t, "abuse_rate_limited", apiErr.Code)
+			assert.Nil(t, apiErr.RetryAfterSeconds)
+		})
+
+		t.Run("primary rate limit", func(t *testing.T) {
+			resp := &github.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusForbidden,
+					Status:     "403 Forbidden",
+					Header: http.Header{
+						"X-RateLimit-Remaining": []string{"0"},
+					},
+				},
+			}
+
+			apiErr := newGitHubAPIError("failed to list issues", resp, fmt.Errorf("API rate limit exceeded"))
+
+			assert.Equal(t, "rate_limited", apiErr.Code)
+			assert.Nil(t, apiErr.RetryAfterSeconds)
+		})
+
+		t.Run("invalid token still classified", func(t *testing.T) {
+			resp := &github.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Status:     "401 Unauthorized",
+				},
+			}
+
+			apiErr := newGitHubAPIError("failed to authenticate", resp, fmt.Errorf("bad credentials"))
+
+			assert.Equal(t, "invalid_token", apiErr.Code)
+		})
 	})
 }
 


### PR DESCRIPTION
Problem
The shared GitHub error layer classified invalid tokens and some scope failures, but it left primary, secondary, and abuse-limit responses effectively untyped.

Why now
Rate limits are a routine operational condition for this server. Downstream tooling needs to distinguish quota exhaustion from auth/policy failures without parsing transport-specific text.

What changed
- added shared HTTP error classification for `rate_limited`, `secondary_rate_limited`, and `abuse_rate_limited`
- preserved `Retry-After` metadata when GitHub provides it
- extended unit coverage for the new classifications and documented the rate-limit codes in `docs/error-handling.md`

Validation
- `go test ./pkg/errors` ✅

Refs #2219
