### PR TITLE
feat: add create_project and create_iteration_field methods to projects_write

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,22 +1028,26 @@ The following sets of tools are available:
   - `project_number`: The project's number. Required for 'list_project_fields', 'list_project_items', and 'list_project_status_updates' methods. (number, optional)
   - `query`: Filter/query string. For list_projects: filter by title text and state (e.g. "roadmap is:open"). For list_project_items: advanced filtering using GitHub's project filtering syntax. (string, optional)
 
-- **projects_write** - Modify GitHub Project items
+- **projects_write** - Manage GitHub Projects
   - **Required OAuth Scopes**: `project`
   - `body`: The body of the status update (markdown). Used for 'create_project_status_update' method. (string, optional)
+  - `field_name`: The name of the iteration field (e.g. 'Sprint'). Required for 'create_iteration_field' method. (string, optional)
   - `issue_number`: The issue number (use when item_type is 'issue' for 'add_project_item' method). Provide either issue_number or pull_request_number. (number, optional)
   - `item_id`: The project item ID. Required for 'update_project_item' and 'delete_project_item' methods. (number, optional)
   - `item_owner`: The owner (user or organization) of the repository containing the issue or pull request. Required for 'add_project_item' method. (string, optional)
   - `item_repo`: The name of the repository containing the issue or pull request. Required for 'add_project_item' method. (string, optional)
   - `item_type`: The item's type, either issue or pull_request. Required for 'add_project_item' method. (string, optional)
+  - `iteration_duration`: Duration in days for iterations of the field (e.g. 7 for weekly, 14 for bi-weekly). Required for 'create_iteration_field' method. (number, optional)
+  - `iterations`: Custom iterations for 'create_iteration_field' method. Only set this when you need iterations with varying durations, breaks between them, or specific titles. Otherwise omit it: GitHub auto-creates three iterations of 'iteration_duration' days starting on 'start_date', which is the right choice for most cases. (object[], optional)
   - `method`: The method to execute (string, required)
   - `owner`: The project owner (user or organization login). The name is not case sensitive. (string, required)
-  - `owner_type`: Owner type (user or org). If not provided, will be automatically detected. (string, optional)
-  - `project_number`: The project's number. (number, required)
+  - `owner_type`: Owner type (user or org). Required for 'create_project' method. If not provided for other methods, will be automatically detected. (string, optional)
+  - `project_number`: The project's number. Required for all methods except 'create_project'. (number, optional)
   - `pull_request_number`: The pull request number (use when item_type is 'pull_request' for 'add_project_item' method). Provide either issue_number or pull_request_number. (number, optional)
-  - `start_date`: The start date of the status update in YYYY-MM-DD format. Used for 'create_project_status_update' method. (string, optional)
+  - `start_date`: Start date in YYYY-MM-DD format. Used for 'create_project_status_update' and 'create_iteration_field' methods. (string, optional)
   - `status`: The status of the project. Used for 'create_project_status_update' method. (string, optional)
   - `target_date`: The target date of the status update in YYYY-MM-DD format. Used for 'create_project_status_update' method. (string, optional)
+  - `title`: The project title. Required for 'create_project' method. (string, optional)
   - `updated_field`: Object consisting of the ID of the project field to update and the new value for the field. To clear the field, set value to null. Example: {"id": 123456, "value": "New Value"}. Required for 'update_project_item' method. (object, optional)
 
 </details>

--- a/pkg/github/__toolsnaps__/projects_write.snap
+++ b/pkg/github/__toolsnaps__/projects_write.snap
@@ -1,13 +1,17 @@
 {
   "annotations": {
     "destructiveHint": true,
-    "title": "Modify GitHub Project items"
+    "title": "Manage GitHub Projects"
   },
-  "description": "Add, update, or delete project items, or create status updates in a GitHub Project.",
+  "description": "Create and manage GitHub Projects: create projects, add/update/delete items, create status updates, and add iteration fields.",
   "inputSchema": {
     "properties": {
       "body": {
         "description": "The body of the status update (markdown). Used for 'create_project_status_update' method.",
+        "type": "string"
+      },
+      "field_name": {
+        "description": "The name of the iteration field (e.g. 'Sprint'). Required for 'create_iteration_field' method.",
         "type": "string"
       },
       "issue_number": {
@@ -34,13 +38,46 @@
         ],
         "type": "string"
       },
+      "iteration_duration": {
+        "description": "Duration in days for iterations of the field (e.g. 7 for weekly, 14 for bi-weekly). Required for 'create_iteration_field' method.",
+        "type": "number"
+      },
+      "iterations": {
+        "description": "Custom iterations for 'create_iteration_field' method. Only set this when you need iterations with varying durations, breaks between them, or specific titles. Otherwise omit it: GitHub auto-creates three iterations of 'iteration_duration' days starting on 'start_date', which is the right choice for most cases.",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "duration": {
+              "description": "Duration in days",
+              "type": "number"
+            },
+            "start_date": {
+              "description": "Start date in YYYY-MM-DD format",
+              "type": "string"
+            },
+            "title": {
+              "description": "Iteration title (e.g. 'Sprint 1')",
+              "type": "string"
+            }
+          },
+          "required": [
+            "title",
+            "start_date",
+            "duration"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
       "method": {
         "description": "The method to execute",
         "enum": [
           "add_project_item",
           "update_project_item",
           "delete_project_item",
-          "create_project_status_update"
+          "create_project_status_update",
+          "create_project",
+          "create_iteration_field"
         ],
         "type": "string"
       },
@@ -49,7 +86,7 @@
         "type": "string"
       },
       "owner_type": {
-        "description": "Owner type (user or org). If not provided, will be automatically detected.",
+        "description": "Owner type (user or org). Required for 'create_project' method. If not provided for other methods, will be automatically detected.",
         "enum": [
           "user",
           "org"
@@ -57,7 +94,7 @@
         "type": "string"
       },
       "project_number": {
-        "description": "The project's number.",
+        "description": "The project's number. Required for all methods except 'create_project'.",
         "type": "number"
       },
       "pull_request_number": {
@@ -65,7 +102,7 @@
         "type": "number"
       },
       "start_date": {
-        "description": "The start date of the status update in YYYY-MM-DD format. Used for 'create_project_status_update' method.",
+        "description": "Start date in YYYY-MM-DD format. Used for 'create_project_status_update' and 'create_iteration_field' methods.",
         "type": "string"
       },
       "status": {
@@ -83,6 +120,10 @@
         "description": "The target date of the status update in YYYY-MM-DD format. Used for 'create_project_status_update' method.",
         "type": "string"
       },
+      "title": {
+        "description": "The project title. Required for 'create_project' method.",
+        "type": "string"
+      },
       "updated_field": {
         "description": "Object consisting of the ID of the project field to update and the new value for the field. To clear the field, set value to null. Example: {\"id\": 123456, \"value\": \"New Value\"}. Required for 'update_project_item' method.",
         "type": "object"
@@ -90,8 +131,7 @@
     },
     "required": [
       "method",
-      "owner",
-      "project_number"
+      "owner"
     ],
     "type": "object"
   },

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -45,6 +45,8 @@ const (
 	projectsMethodListProjectStatusUpdates  = "list_project_status_updates"
 	projectsMethodGetProjectStatusUpdate    = "get_project_status_update"
 	projectsMethodCreateProjectStatusUpdate = "create_project_status_update"
+	projectsMethodCreateProject             = "create_project"
+	projectsMethodCreateIterationField      = "create_iteration_field"
 )
 
 // GraphQL types for ProjectV2 status updates
@@ -403,9 +405,9 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 		ToolsetMetadataProjects,
 		mcp.Tool{
 			Name:        "projects_write",
-			Description: t("TOOL_PROJECTS_WRITE_DESCRIPTION", "Add, update, or delete project items, or create status updates in a GitHub Project."),
+			Description: t("TOOL_PROJECTS_WRITE_DESCRIPTION", "Create and manage GitHub Projects: create projects, add/update/delete items, create status updates, and add iteration fields."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:           t("TOOL_PROJECTS_WRITE_USER_TITLE", "Modify GitHub Project items"),
+				Title:           t("TOOL_PROJECTS_WRITE_USER_TITLE", "Manage GitHub Projects"),
 				ReadOnlyHint:    false,
 				DestructiveHint: jsonschema.Ptr(true),
 			},
@@ -420,11 +422,13 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 							projectsMethodUpdateProjectItem,
 							projectsMethodDeleteProjectItem,
 							projectsMethodCreateProjectStatusUpdate,
+							projectsMethodCreateProject,
+							projectsMethodCreateIterationField,
 						},
 					},
 					"owner_type": {
 						Type:        "string",
-						Description: "Owner type (user or org). If not provided, will be automatically detected.",
+						Description: "Owner type (user or org). Required for 'create_project' method. If not provided for other methods, will be automatically detected.",
 						Enum:        []any{"user", "org"},
 					},
 					"owner": {
@@ -433,7 +437,11 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 					},
 					"project_number": {
 						Type:        "number",
-						Description: "The project's number.",
+						Description: "The project's number. Required for all methods except 'create_project'.",
+					},
+					"title": {
+						Type:        "string",
+						Description: "The project title. Required for 'create_project' method.",
 					},
 					"item_id": {
 						Type:        "number",
@@ -475,14 +483,45 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 					},
 					"start_date": {
 						Type:        "string",
-						Description: "The start date of the status update in YYYY-MM-DD format. Used for 'create_project_status_update' method.",
+						Description: "Start date in YYYY-MM-DD format. Used for 'create_project_status_update' and 'create_iteration_field' methods.",
 					},
 					"target_date": {
 						Type:        "string",
 						Description: "The target date of the status update in YYYY-MM-DD format. Used for 'create_project_status_update' method.",
 					},
+					"field_name": {
+						Type:        "string",
+						Description: "The name of the iteration field (e.g. 'Sprint'). Required for 'create_iteration_field' method.",
+					},
+					"iteration_duration": {
+						Type:        "number",
+						Description: "Duration in days for iterations of the field (e.g. 7 for weekly, 14 for bi-weekly). Required for 'create_iteration_field' method.",
+					},
+					"iterations": {
+						Type:        "array",
+						Description: "Custom iterations for 'create_iteration_field' method. Only set this when you need iterations with varying durations, breaks between them, or specific titles. Otherwise omit it: GitHub auto-creates three iterations of 'iteration_duration' days starting on 'start_date', which is the right choice for most cases.",
+						Items: &jsonschema.Schema{
+							Type:                 "object",
+							AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+							Properties: map[string]*jsonschema.Schema{
+								"title": {
+									Type:        "string",
+									Description: "Iteration title (e.g. 'Sprint 1')",
+								},
+								"start_date": {
+									Type:        "string",
+									Description: "Start date in YYYY-MM-DD format",
+								},
+								"duration": {
+									Type:        "number",
+									Description: "Duration in days",
+								},
+							},
+							Required: []string{"title", "start_date", "duration"},
+						},
+					},
 				},
-				Required: []string{"method", "owner", "project_number"},
+				Required: []string{"method", "owner"},
 			},
 		},
 		[]scopes.Scope{scopes.Project},
@@ -502,17 +541,22 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
+			gqlClient, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// create_project does not require project_number or a REST client
+			if method == projectsMethodCreateProject {
+				return createProject(ctx, gqlClient, owner, ownerType, args)
+			}
+
 			projectNumber, err := RequiredInt(args, "project_number")
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
 			client, err := deps.GetClient(ctx)
-			if err != nil {
-				return utils.NewToolResultError(err.Error()), nil, nil
-			}
-
-			gqlClient, err := deps.GetGQLClient(ctx)
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
@@ -595,6 +639,8 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
 				return createProjectStatusUpdate(ctx, gqlClient, owner, ownerType, projectNumber, body, status, startDate, targetDate)
+			case projectsMethodCreateIterationField:
+				return createIterationField(ctx, gqlClient, owner, ownerType, projectNumber, args)
 			default:
 				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}
@@ -1436,6 +1482,265 @@ func resolvePullRequestNodeID(ctx context.Context, gqlClient *githubv4.Client, o
 	}
 
 	return query.Repository.PullRequest.ID, nil
+}
+
+// createProject handles the create_project method for ProjectsWrite.
+func createProject(ctx context.Context, gqlClient *githubv4.Client, owner, ownerType string, args map[string]any) (*mcp.CallToolResult, any, error) {
+	if ownerType == "" {
+		return utils.NewToolResultError("owner_type is required for create_project"), nil, nil
+	}
+	if ownerType != "user" && ownerType != "org" {
+		return utils.NewToolResultError(fmt.Sprintf("invalid owner_type %q: must be \"user\" or \"org\"", ownerType)), nil, nil
+	}
+
+	title, err := RequiredParam[string](args, "title")
+	if err != nil {
+		return utils.NewToolResultError(err.Error()), nil, nil
+	}
+
+	ownerID, err := getOwnerNodeID(ctx, gqlClient, owner, ownerType)
+	if err != nil {
+		return utils.NewToolResultError(fmt.Sprintf("failed to get owner ID: %v", err)), nil, nil
+	}
+
+	var mutation struct {
+		CreateProjectV2 struct {
+			ProjectV2 struct {
+				ID     string
+				Number int
+				Title  string
+				URL    string
+			}
+		} `graphql:"createProjectV2(input: $input)"`
+	}
+
+	input := githubv4.CreateProjectV2Input{
+		OwnerID: githubv4.ID(ownerID),
+		Title:   githubv4.String(title),
+	}
+
+	err = gqlClient.Mutate(ctx, &mutation, input, nil)
+	if err != nil {
+		return utils.NewToolResultError(fmt.Sprintf("failed to create project: %v", err)), nil, nil
+	}
+
+	result := struct {
+		ID     string `json:"id"`
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		URL    string `json:"url"`
+	}{
+		ID:     mutation.CreateProjectV2.ProjectV2.ID,
+		Number: mutation.CreateProjectV2.ProjectV2.Number,
+		Title:  mutation.CreateProjectV2.ProjectV2.Title,
+		URL:    mutation.CreateProjectV2.ProjectV2.URL,
+	}
+
+	return MarshalledTextResult(result), nil, nil
+}
+
+// createIterationField handles the create_iteration_field method for ProjectsWrite.
+//
+// GitHub's GraphQL API requires two mutations to fully configure an iteration field:
+//  1. createProjectV2Field creates the field with DataType=ITERATION (no schedule yet).
+//  2. updateProjectV2Field sets the start date, duration, and optional named iterations.
+//
+// If step 2 fails, the field already exists with default settings and can be reconfigured
+// by calling this method again (the create will fail with a duplicate-name error, which
+// surfaces clearly) or by deleting the field via the GitHub UI.
+func createIterationField(ctx context.Context, gqlClient *githubv4.Client, owner, ownerType string, projectNumber int, args map[string]any) (*mcp.CallToolResult, any, error) {
+	fieldName, err := RequiredParam[string](args, "field_name")
+	if err != nil {
+		return utils.NewToolResultError(err.Error()), nil, nil
+	}
+	duration, err := RequiredInt(args, "iteration_duration")
+	if err != nil {
+		return utils.NewToolResultError(err.Error()), nil, nil
+	}
+	startDateStr, err := RequiredParam[string](args, "start_date")
+	if err != nil {
+		return utils.NewToolResultError(err.Error()), nil, nil
+	}
+
+	projectID, err := resolveProjectNodeID(ctx, gqlClient, owner, ownerType, projectNumber)
+	if err != nil {
+		return utils.NewToolResultError(fmt.Sprintf("failed to get project ID: %v", err)), nil, nil
+	}
+
+	// Step 1: Create the iteration field.
+	var createMutation struct {
+		CreateProjectV2Field struct {
+			ProjectV2Field struct {
+				ProjectV2IterationField struct {
+					ID   string
+					Name string
+				} `graphql:"... on ProjectV2IterationField"`
+			}
+		} `graphql:"createProjectV2Field(input: $input)"`
+	}
+
+	createInput := githubv4.CreateProjectV2FieldInput{
+		ProjectID: githubv4.ID(projectID),
+		DataType:  githubv4.ProjectV2CustomFieldType("ITERATION"),
+		Name:      githubv4.String(fieldName),
+	}
+
+	err = gqlClient.Mutate(ctx, &createMutation, createInput, nil)
+	if err != nil {
+		return utils.NewToolResultError(fmt.Sprintf("failed to create iteration field: %v", err)), nil, nil
+	}
+
+	fieldID := createMutation.CreateProjectV2Field.ProjectV2Field.ProjectV2IterationField.ID
+
+	// Step 2: Configure the iteration field with start date and duration.
+	var updateMutation struct {
+		UpdateProjectV2Field struct {
+			ProjectV2Field struct {
+				ProjectV2IterationField struct {
+					ID            string
+					Name          string
+					Configuration struct {
+						Iterations []struct {
+							ID        string
+							Title     string
+							StartDate string
+							Duration  int
+						}
+					}
+				} `graphql:"... on ProjectV2IterationField"`
+			}
+		} `graphql:"updateProjectV2Field(input: $input)"`
+	}
+
+	parsedStartDate, err := time.Parse("2006-01-02", startDateStr)
+	if err != nil {
+		return utils.NewToolResultError(fmt.Sprintf("failed to parse start_date %s: %v", startDateStr, err)), nil, nil
+	}
+
+	// GitHub's ProjectV2IterationFieldConfigurationInput requires `iterations` as a
+	// non-null array, so we always send at least an empty slice. When omitted, GitHub
+	// generates a default set of iterations from start_date and duration.
+	iterationsInput := []ProjectV2IterationFieldIterationInput{}
+
+	if rawIterations, ok := args["iterations"].([]any); ok && len(rawIterations) > 0 {
+		for i, item := range rawIterations {
+			iterMap, ok := item.(map[string]any)
+			if !ok {
+				return utils.NewToolResultError(fmt.Sprintf("iterations[%d] must be an object", i)), nil, nil
+			}
+			iterTitle, ok := iterMap["title"].(string)
+			if !ok || iterTitle == "" {
+				return utils.NewToolResultError(fmt.Sprintf("iterations[%d]: title is required and must be a non-empty string", i)), nil, nil
+			}
+			iterStartDate, ok := iterMap["start_date"].(string)
+			if !ok || iterStartDate == "" {
+				return utils.NewToolResultError(fmt.Sprintf("iterations[%d]: start_date is required and must be a non-empty string", i)), nil, nil
+			}
+			iterDuration, ok := iterMap["duration"].(float64)
+			if !ok || iterDuration <= 0 {
+				return utils.NewToolResultError(fmt.Sprintf("iterations[%d]: duration is required and must be a positive number", i)), nil, nil
+			}
+
+			parsedIterStartDate, err := time.Parse("2006-01-02", iterStartDate)
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("iterations[%d]: failed to parse start_date %q: %v", i, iterStartDate, err)), nil, nil
+			}
+
+			iterationsInput = append(iterationsInput, ProjectV2IterationFieldIterationInput{
+				Title:     githubv4.String(iterTitle),
+				StartDate: githubv4.Date{Time: parsedIterStartDate},
+				Duration:  githubv4.Int(int32(iterDuration)), //nolint:gosec // Iteration durations are small day counts
+			})
+		}
+	}
+
+	configInput := ProjectV2IterationFieldConfigurationInput{
+		Duration:   githubv4.Int(int32(duration)), //nolint:gosec // Iteration durations are small day counts
+		StartDate:  githubv4.Date{Time: parsedStartDate},
+		Iterations: iterationsInput,
+	}
+
+	updateInput := UpdateProjectV2FieldInput{
+		FieldID:                githubv4.ID(fieldID),
+		IterationConfiguration: &configInput,
+	}
+
+	err = gqlClient.Mutate(ctx, &updateMutation, updateInput, nil)
+	if err != nil {
+		return utils.NewToolResultError(fmt.Sprintf("failed to update iteration configuration: %v", err)), nil, nil
+	}
+
+	field := updateMutation.UpdateProjectV2Field.ProjectV2Field.ProjectV2IterationField
+	iterResults := make([]map[string]any, 0, len(field.Configuration.Iterations))
+	for _, iter := range field.Configuration.Iterations {
+		iterResults = append(iterResults, map[string]any{
+			"id":         iter.ID,
+			"title":      iter.Title,
+			"start_date": iter.StartDate,
+			"duration":   iter.Duration,
+		})
+	}
+
+	result := map[string]any{
+		"id":   field.ID,
+		"name": field.Name,
+		"configuration": map[string]any{
+			"iterations": iterResults,
+		},
+	}
+
+	return MarshalledTextResult(result), nil, nil
+}
+
+// getOwnerNodeID resolves a GitHub user or organization login to its GraphQL node ID.
+func getOwnerNodeID(ctx context.Context, gqlClient *githubv4.Client, owner, ownerType string) (string, error) {
+	if ownerType == "org" {
+		var query struct {
+			Organization struct {
+				ID string
+			} `graphql:"organization(login: $login)"`
+		}
+		variables := map[string]any{
+			"login": githubv4.String(owner),
+		}
+		err := gqlClient.Query(ctx, &query, variables)
+		return query.Organization.ID, err
+	}
+
+	var query struct {
+		User struct {
+			ID string
+		} `graphql:"user(login: $login)"`
+	}
+	variables := map[string]any{
+		"login": githubv4.String(owner),
+	}
+	err := gqlClient.Query(ctx, &query, variables)
+	return query.User.ID, err
+}
+
+// UpdateProjectV2FieldInput is the GraphQL input for the updateProjectV2Field mutation.
+// These types are defined locally because the pinned shurcooL/githubv4 release
+// (v0.0.0-20240727222349) does not yet expose them. Upstream master now generates
+// equivalent types, so this block can be removed when the dependency is next bumped.
+type UpdateProjectV2FieldInput struct {
+	FieldID                githubv4.ID                                `json:"fieldId"`
+	IterationConfiguration *ProjectV2IterationFieldConfigurationInput `json:"iterationConfiguration,omitempty"`
+}
+
+// ProjectV2IterationFieldConfigurationInput is the GraphQL input for configuring an iteration field.
+// GitHub's schema marks iterations as a required non-null list, so the field is not omitempty.
+type ProjectV2IterationFieldConfigurationInput struct {
+	Duration   githubv4.Int                            `json:"duration"`
+	StartDate  githubv4.Date                           `json:"startDate"`
+	Iterations []ProjectV2IterationFieldIterationInput `json:"iterations"`
+}
+
+// ProjectV2IterationFieldIterationInput is the GraphQL input for a single iteration definition.
+type ProjectV2IterationFieldIterationInput struct {
+	StartDate githubv4.Date   `json:"startDate"`
+	Duration  githubv4.Int    `json:"duration"`
+	Title     githubv4.String `json:"title"`
 }
 
 // detectOwnerType attempts to detect the owner type by trying both user and org

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -569,7 +569,7 @@ func Test_ProjectsWrite(t *testing.T) {
 	assert.Contains(t, inputSchema.Properties, "issue_number")
 	assert.Contains(t, inputSchema.Properties, "pull_request_number")
 	assert.Contains(t, inputSchema.Properties, "updated_field")
-	assert.ElementsMatch(t, inputSchema.Required, []string{"method", "owner", "project_number"})
+	assert.ElementsMatch(t, inputSchema.Required, []string{"method", "owner"})
 
 	// Verify DestructiveHint is set
 	assert.NotNil(t, toolDef.Tool.Annotations)

--- a/pkg/github/projects_v2_test.go
+++ b/pkg/github/projects_v2_test.go
@@ -1,0 +1,457 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ProjectsWrite_CreateProject(t *testing.T) {
+	t.Parallel()
+
+	toolDef := ProjectsWrite(translations.NullTranslationHelper)
+
+	t.Run("success user project", func(t *testing.T) {
+		t.Parallel()
+
+		mockedClient := githubv4mock.NewMockedHTTPClient(
+			githubv4mock.NewQueryMatcher(
+				struct {
+					User struct {
+						ID string
+					} `graphql:"user(login: $login)"`
+				}{},
+				map[string]any{
+					"login": githubv4.String("octocat"),
+				},
+				githubv4mock.DataResponse(map[string]any{
+					"user": map[string]any{
+						"id": "U_octocat",
+					},
+				}),
+			),
+			githubv4mock.NewMutationMatcher(
+				struct {
+					CreateProjectV2 struct {
+						ProjectV2 struct {
+							ID     string
+							Number int
+							Title  string
+							URL    string
+						}
+					} `graphql:"createProjectV2(input: $input)"`
+				}{},
+				githubv4.CreateProjectV2Input{
+					OwnerID: githubv4.ID("U_octocat"),
+					Title:   githubv4.String("New Project"),
+				},
+				nil,
+				githubv4mock.DataResponse(map[string]any{
+					"createProjectV2": map[string]any{
+						"projectV2": map[string]any{
+							"id":     "PVT_project123",
+							"number": 1,
+							"title":  "New Project",
+							"url":    "https://github.com/users/octocat/projects/1",
+						},
+					},
+				}),
+			),
+		)
+
+		deps := BaseDeps{
+			GQLClient: githubv4.NewClient(mockedClient),
+			Obsv:      stubExporters(),
+		}
+		handler := toolDef.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"method":     "create_project",
+			"owner":      "octocat",
+			"owner_type": "user",
+			"title":      "New Project",
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		var response map[string]any
+		err = json.Unmarshal([]byte(textContent.Text), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "PVT_project123", response["id"])
+		assert.Equal(t, float64(1), response["number"])
+		assert.Equal(t, "New Project", response["title"])
+		assert.Equal(t, "https://github.com/users/octocat/projects/1", response["url"])
+	})
+
+	t.Run("missing owner_type returns error", func(t *testing.T) {
+		t.Parallel()
+
+		deps := BaseDeps{
+			GQLClient: githubv4.NewClient(githubv4mock.NewMockedHTTPClient()),
+			Obsv:      stubExporters(),
+		}
+		handler := toolDef.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"method": "create_project",
+			"owner":  "octocat",
+			"title":  "New Project",
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		assert.Contains(t, textContent.Text, "owner_type is required")
+	})
+
+	t.Run("invalid owner_type returns error", func(t *testing.T) {
+		t.Parallel()
+
+		deps := BaseDeps{
+			GQLClient: githubv4.NewClient(githubv4mock.NewMockedHTTPClient()),
+			Obsv:      stubExporters(),
+		}
+		handler := toolDef.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"method":     "create_project",
+			"owner":      "octocat",
+			"owner_type": "invalid",
+			"title":      "New Project",
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		assert.Contains(t, textContent.Text, "invalid owner_type")
+		assert.Contains(t, textContent.Text, "must be")
+	})
+}
+
+// resolveProjectNodeIDOrgMatcher returns a GraphQL query matcher for resolving
+// an org project node ID via resolveProjectNodeID.
+func resolveProjectNodeIDOrgMatcher(owner string, projectNumber int, nodeID string) githubv4mock.Matcher {
+	return githubv4mock.NewQueryMatcher(
+		struct {
+			Organization struct {
+				ProjectV2 struct {
+					ID githubv4.ID
+				} `graphql:"projectV2(number: $projectNumber)"`
+			} `graphql:"organization(login: $owner)"`
+		}{},
+		map[string]any{
+			"owner":         githubv4.String(owner),
+			"projectNumber": githubv4.Int(int32(projectNumber)), //nolint:gosec // test constant
+		},
+		githubv4mock.DataResponse(map[string]any{
+			"organization": map[string]any{
+				"projectV2": map[string]any{
+					"id": nodeID,
+				},
+			},
+		}),
+	)
+}
+
+func createFieldMatcher() githubv4mock.Matcher {
+	return githubv4mock.NewMutationMatcher(
+		struct {
+			CreateProjectV2Field struct {
+				ProjectV2Field struct {
+					ProjectV2IterationField struct {
+						ID   string
+						Name string
+					} `graphql:"... on ProjectV2IterationField"`
+				}
+			} `graphql:"createProjectV2Field(input: $input)"`
+		}{},
+		githubv4.CreateProjectV2FieldInput{
+			ProjectID: githubv4.ID("PVT_project1"),
+			DataType:  githubv4.ProjectV2CustomFieldType("ITERATION"),
+			Name:      githubv4.String("Sprint"),
+		},
+		nil,
+		githubv4mock.DataResponse(map[string]any{
+			"createProjectV2Field": map[string]any{
+				"projectV2Field": map[string]any{
+					"id":   "PVTIF_field1",
+					"name": "Sprint",
+				},
+			},
+		}),
+	)
+}
+
+func updateFieldIterationResponse() githubv4mock.GQLResponse {
+	return githubv4mock.DataResponse(map[string]any{
+		"updateProjectV2Field": map[string]any{
+			"projectV2Field": map[string]any{
+				"id":   "PVTIF_field1",
+				"name": "Sprint",
+				"configuration": map[string]any{
+					"iterations": []any{
+						map[string]any{
+							"id":        "PVTI_iter1",
+							"title":     "Sprint 1",
+							"startDate": "2025-01-20",
+							"duration":  7,
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func Test_ProjectsWrite_CreateIterationField(t *testing.T) {
+	t.Parallel()
+
+	toolDef := ProjectsWrite(translations.NullTranslationHelper)
+
+	t.Run("success with iterations", func(t *testing.T) {
+		t.Parallel()
+
+		mockGQLClient := githubv4mock.NewMockedHTTPClient(
+			resolveProjectNodeIDOrgMatcher("octo-org", 1, "PVT_project1"),
+			createFieldMatcher(),
+			githubv4mock.NewMutationMatcher(
+				struct {
+					UpdateProjectV2Field struct {
+						ProjectV2Field struct {
+							ProjectV2IterationField struct {
+								ID            string
+								Name          string
+								Configuration struct {
+									Iterations []struct {
+										ID        string
+										Title     string
+										StartDate string
+										Duration  int
+									}
+								}
+							} `graphql:"... on ProjectV2IterationField"`
+						}
+					} `graphql:"updateProjectV2Field(input: $input)"`
+				}{},
+				UpdateProjectV2FieldInput{
+					FieldID: githubv4.ID("PVTIF_field1"),
+					IterationConfiguration: &ProjectV2IterationFieldConfigurationInput{
+						Duration:  githubv4.Int(7),
+						StartDate: githubv4.Date{Time: time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC)},
+						Iterations: []ProjectV2IterationFieldIterationInput{
+							{
+								Title:     githubv4.String("Sprint 1"),
+								StartDate: githubv4.Date{Time: time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC)},
+								Duration:  githubv4.Int(7),
+							},
+						},
+					},
+				},
+				nil,
+				updateFieldIterationResponse(),
+			),
+		)
+
+		deps := BaseDeps{
+			GQLClient: githubv4.NewClient(mockGQLClient),
+			Obsv:      stubExporters(),
+		}
+		handler := toolDef.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"method":             "create_iteration_field",
+			"owner":              "octo-org",
+			"owner_type":         "org",
+			"project_number":     float64(1),
+			"field_name":         "Sprint",
+			"iteration_duration": float64(7),
+			"start_date":         "2025-01-20",
+			"iterations": []any{
+				map[string]any{
+					"title":      "Sprint 1",
+					"start_date": "2025-01-20",
+					"duration":   float64(7),
+				},
+			},
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		var response map[string]any
+		err = json.Unmarshal([]byte(textContent.Text), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "PVTIF_field1", response["id"])
+	})
+
+	t.Run("success without iterations", func(t *testing.T) {
+		t.Parallel()
+
+		mockGQLClient := githubv4mock.NewMockedHTTPClient(
+			resolveProjectNodeIDOrgMatcher("octo-org", 1, "PVT_project1"),
+			createFieldMatcher(),
+			githubv4mock.NewMutationMatcher(
+				struct {
+					UpdateProjectV2Field struct {
+						ProjectV2Field struct {
+							ProjectV2IterationField struct {
+								ID            string
+								Name          string
+								Configuration struct {
+									Iterations []struct {
+										ID        string
+										Title     string
+										StartDate string
+										Duration  int
+									}
+								}
+							} `graphql:"... on ProjectV2IterationField"`
+						}
+					} `graphql:"updateProjectV2Field(input: $input)"`
+				}{},
+				UpdateProjectV2FieldInput{
+					FieldID: githubv4.ID("PVTIF_field1"),
+					IterationConfiguration: &ProjectV2IterationFieldConfigurationInput{
+						Duration:   githubv4.Int(7),
+						StartDate:  githubv4.Date{Time: time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC)},
+						Iterations: []ProjectV2IterationFieldIterationInput{},
+					},
+				},
+				nil,
+				githubv4mock.DataResponse(map[string]any{
+					"updateProjectV2Field": map[string]any{
+						"projectV2Field": map[string]any{
+							"id":   "PVTIF_field1",
+							"name": "Sprint",
+							"configuration": map[string]any{
+								"iterations": []any{},
+							},
+						},
+					},
+				}),
+			),
+		)
+
+		deps := BaseDeps{
+			GQLClient: githubv4.NewClient(mockGQLClient),
+			Obsv:      stubExporters(),
+		}
+		handler := toolDef.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"method":             "create_iteration_field",
+			"owner":              "octo-org",
+			"owner_type":         "org",
+			"project_number":     float64(1),
+			"field_name":         "Sprint",
+			"iteration_duration": float64(7),
+			"start_date":         "2025-01-20",
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		var response map[string]any
+		err = json.Unmarshal([]byte(textContent.Text), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "PVTIF_field1", response["id"])
+	})
+
+	t.Run("success with auto-detected owner_type", func(t *testing.T) {
+		t.Parallel()
+
+		// detectOwnerType uses REST to probe user first, then org
+		mockRESTClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetUsersProjectsV2ByUsernameByProject: mockResponse(t, http.StatusNotFound, nil),
+			GetOrgsProjectsV2ByProject: mockResponse(t, http.StatusOK, map[string]any{
+				"id":      1,
+				"node_id": "PVT_project1",
+				"title":   "Org Project",
+			}),
+		})
+
+		mockGQLClient := githubv4mock.NewMockedHTTPClient(
+			resolveProjectNodeIDOrgMatcher("octo-org", 1, "PVT_project1"),
+			createFieldMatcher(),
+			githubv4mock.NewMutationMatcher(
+				struct {
+					UpdateProjectV2Field struct {
+						ProjectV2Field struct {
+							ProjectV2IterationField struct {
+								ID            string
+								Name          string
+								Configuration struct {
+									Iterations []struct {
+										ID        string
+										Title     string
+										StartDate string
+										Duration  int
+									}
+								}
+							} `graphql:"... on ProjectV2IterationField"`
+						}
+					} `graphql:"updateProjectV2Field(input: $input)"`
+				}{},
+				UpdateProjectV2FieldInput{
+					FieldID: githubv4.ID("PVTIF_field1"),
+					IterationConfiguration: &ProjectV2IterationFieldConfigurationInput{
+						Duration:   githubv4.Int(14),
+						StartDate:  githubv4.Date{Time: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)},
+						Iterations: []ProjectV2IterationFieldIterationInput{},
+					},
+				},
+				nil,
+				githubv4mock.DataResponse(map[string]any{
+					"updateProjectV2Field": map[string]any{
+						"projectV2Field": map[string]any{
+							"id":   "PVTIF_field1",
+							"name": "Sprint",
+							"configuration": map[string]any{
+								"iterations": []any{},
+							},
+						},
+					},
+				}),
+			),
+		)
+
+		deps := BaseDeps{
+			Client:    mustNewGHClient(t, mockRESTClient),
+			GQLClient: githubv4.NewClient(mockGQLClient),
+			Obsv:      stubExporters(),
+		}
+		handler := toolDef.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"method":             "create_iteration_field",
+			"owner":              "octo-org",
+			"project_number":     float64(1),
+			"field_name":         "Sprint",
+			"iteration_duration": float64(14),
+			"start_date":         "2025-02-01",
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		var response map[string]any
+		err = json.Unmarshal([]byte(textContent.Text), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "PVTIF_field1", response["id"])
+	})
+}

--- a/pkg/github/toolset_instructions.go
+++ b/pkg/github/toolset_instructions.go
@@ -39,6 +39,10 @@ func generateProjectsToolsetInstructions(_ *inventory.Inventory) string {
 
 Workflow: 1) list_project_fields (get field IDs), 2) list_project_items (with pagination), 3) optional updates.
 
+Project lifecycle: Use create_project to create a new ProjectsV2 for a user or organization (requires owner_type and title). Returns the new project's id, number, title, and url; pass the returned number as project_number to subsequent project tools.
+
+Iteration fields: Use create_iteration_field to add a new ITERATION field (e.g. "Sprint") to an existing project. Required: field_name, iteration_duration (days), start_date (YYYY-MM-DD). Only pass the iterations array when iterations need varying durations, breaks between them, or specific titles; otherwise omit it and GitHub creates three default iterations of iteration_duration days starting on start_date.
+
 Status updates: Use list_project_status_updates to read recent project status updates (newest first). Use get_project_status_update with a node ID to get a single update. Use create_project_status_update to create a new status update for a project.
 
 Field usage:


### PR DESCRIPTION
## Summary

Adds two new methods to the consolidated `projects_write` tool enabling programmatic sprint planning:

- **`create_project`** — creates a new GitHub ProjectsV2 for a user or org; returns project ID, number, title, URL
- **`create_iteration_field`** — adds an iteration field to an existing project with configurable duration and start date; optionally accepts named iteration definitions

Supersedes #2227 and #1864. Closes #1854.

## Why

Enables AI agents to automate sprint planning workflows — creating projects and defining iteration cycles — without manual GitHub UI interaction.

## Design decisions

- **Consolidated into `projects_write`** rather than standalone tools, following the strong existing pattern (`projects_list`, `projects_get`, `projects_write` all use method dispatch)
- **`iterations` is optional** — the basic use case is creating a field with `start_date` + `duration`; specific named sprints are a power-user option
- **`project_number` is conditionally required** — not needed for `create_project` (you don't have one yet); validated per-method in the handler
- **`owner_type` auto-detects** for `create_iteration_field` (uses `detectOwnerType` like other methods); required for `create_project` (no project to probe)

## What changed

- **`pkg/github/projects.go`** — Added `createProject` and `createIterationField` helper functions; added method constants; expanded `ProjectsWrite` schema and handler with two new methods; added `getOwnerNodeID` and `getProjectNodeID` helpers; local GraphQL input types for iteration configuration
- **`pkg/github/projects_test.go`** — Updated required fields assertion for schema change
- **`pkg/github/projects_v2_test.go`** — Unit tests for both methods (success with iterations, success without iterations, missing owner_type error)
- **`pkg/github/__toolsnaps__/projects_write.snap`** — Updated schema snapshot
- **`README.md`** — Auto-generated docs updated

## MCP impact

- [x] Existing tool modified (new methods added)

## Security / limits

- [x] Auth / permissions considered — both methods require the `project` write scope

## CI fixes from #2227

- Fixed `gosec G115` integer overflow (`int` → `int32`) with explicit casts and `//nolint` comments (iteration durations are small day counts)

## Lint & tests

- [x] `script/lint` — 0 issues
- [x] `script/test` — all passing
- [x] `script/generate-docs` — README up to date

---

Co-authored-by: João Doria de Souza <hi@joao.work>

Closes #1666.