### PR TITLE
fix: restore thread id in get_review_comments response

### DIFF
--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -1547,7 +1547,7 @@ type MinimalReviewComment struct {
 
 // MinimalReviewThread is the trimmed output type for PR review thread objects.
 type MinimalReviewThread struct {
-	ID          string
+	ID          string                 `json:"id"`
 	IsResolved  bool                   `json:"is_resolved"`
 	IsOutdated  bool                   `json:"is_outdated"`
 	IsCollapsed bool                   `json:"is_collapsed"`


### PR DESCRIPTION
## Summary
Restore the thread `id` field to `MinimalReviewThread` so that `pull_request_review_write` with `method: resolve_thread` / `unresolve_thread` is actually usable. 

## Why

#2062 dropped `id` from the minimized review-thread output, noting it was "not used for any subsequent tool call". While this was true at the time, #1919 later added `resolve_thread` / `unresolve_thread`, both of which require a thread node ID. The tool's own docstring reads: 

> Get thread IDs from `pull_request_read` with method `get_review_comments`.

…but that tool no longer returns them, so there's no way to resolve a thread without leaving the MCP server. **This results in callers of this tool being unable to resolve threads through the `resolve_thread` tool**. 

The GraphQL query (`reviewThreadNode` in `pkg/github/pullrequests.go`) already fetches `ID` — it's just dropped during minimization.

Also see: #2229

## What changed
- Add `ID string` to `MinimalReviewThread`
- Populate it in `convertToMinimalReviewThread` via `fmt.Sprintf("%v", thread.ID)` 

## MCP impact
- [ ] No tool or API changes
- [x] Tool schema or behavior changed — `pull_request_read` (`get_review_comments`) now includes `id` per thread
- [ ] New tool added

## Prompts tested (tool changes only)
- "List the review threads on PR #42 in owner/repo, then resolve the first one"

## Security / limits
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [x] Data exposure, filtering, or token/size limits considered — ~40 chars/thread (`"id":"PRRT_kwDO…",`), negligible impact on #2062's 14.5% savings

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

## Docs
- [x] Not needed
- [ ] Updated (README / docs / examples)

Fixes #2331
