### PR TITLE
fix: add authorAssociation to IssueFragment (GraphQL path)

### DIFF
--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -111,7 +111,8 @@ type IssueFragment struct {
 	DatabaseID int64
 
 	Author struct {
-		Login githubv4.String
+		Login               githubv4.String
+		Association         githubv4.String
 	}
 	CreatedAt githubv4.DateTime
 	UpdatedAt githubv4.DateTime

--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -387,16 +387,17 @@ func convertToMinimalIssue(issue *github.Issue) MinimalIssue {
 
 func fragmentToMinimalIssue(fragment IssueFragment) MinimalIssue {
 	m := MinimalIssue{
-		Number:    int(fragment.Number),
-		Title:     sanitize.Sanitize(string(fragment.Title)),
-		Body:      sanitize.Sanitize(string(fragment.Body)),
-		State:     string(fragment.State),
-		Comments:  int(fragment.Comments.TotalCount),
-		CreatedAt: fragment.CreatedAt.Format(time.RFC3339),
-		UpdatedAt: fragment.UpdatedAt.Format(time.RFC3339),
+		Number:            int(fragment.Number),
+		Title:             sanitize.Sanitize(string(fragment.Title)),
+		Body:              sanitize.Sanitize(string(fragment.Body)),
+		State:             string(fragment.State),
+		Comments:          int(fragment.Comments.TotalCount),
+		CreatedAt:         fragment.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:         fragment.UpdatedAt.Format(time.RFC3339),
 		User: &MinimalUser{
 			Login: string(fragment.Author.Login),
 		},
+		AuthorAssociation: string(fragment.Author.Association),
 	}
 
 	for _, label := range fragment.Labels.Nodes {


### PR DESCRIPTION
## Summary
Adds the missing \uthorAssociation\ field to the \IssueFragment\ GraphQL struct and populates it in \ragmentToMinimalIssue()\, fixing the missing \uthor_association\ field in \list_issues\ responses when using the GraphQL path.

## Changes
- \pkg/github/issues.go\: Added \Author.Association\ field to \IssueFragment\ struct (GraphQL)
- \pkg/github/minimal_types.go\: Set \AuthorAssociation\ in \ragmentToMinimalIssue()\ from \ragment.Author.Association\

## Note
The REST path (\convertToMinimalIssue()\) already correctly sets \AuthorAssociation\ from \issue.GetAuthorAssociation()\. The GraphQL path was missing this field.

Fixes #2250