### PR TITLE
add dependabot tools for #1921

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,10 +719,33 @@ The following sets of tools are available:
 - **list_dependabot_alerts** - List dependabot alerts
   - **Required OAuth Scopes**: `security_events`
   - **Accepted OAuth Scopes**: `repo`, `security_events`
+  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
   - `owner`: The owner of the repository. (string, required)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
   - `repo`: The name of the repository. (string, required)
   - `severity`: Filter dependabot alerts by severity (string, optional)
   - `state`: Filter dependabot alerts by state. Defaults to open (string, optional)
+
+- **list_org_dependabot_alerts** - List org Dependabot alerts
+  - **Required OAuth Scopes**: `security_events`
+  - **Accepted OAuth Scopes**: `repo`, `security_events`
+  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `ecosystem`: Filter Dependabot alerts by package ecosystem (e.g. npm, pip, maven) (string, optional)
+  - `org`: The organization name. (string, required)
+  - `package`: Filter Dependabot alerts by package name (string, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `severity`: Filter Dependabot alerts by severity (string, optional)
+  - `state`: Filter Dependabot alerts by state. Defaults to open (string, optional)
+
+- **update_dependabot_alert** - Update Dependabot alert
+  - **Required OAuth Scopes**: `security_events`
+  - **Accepted OAuth Scopes**: `repo`, `security_events`
+  - `alertNumber`: The number of the alert. (number, required)
+  - `dismissedComment`: An optional comment associated with dismissing the alert. Maximum 280 characters. (string, optional)
+  - `dismissedReason`: Required when state is dismissed. The reason for dismissing the alert. (string, optional)
+  - `owner`: The owner of the repository. (string, required)
+  - `repo`: The name of the repository. (string, required)
+  - `state`: The state to set for the alert. (string, required)
 
 </details>
 

--- a/pkg/github/__toolsnaps__/list_org_dependabot_alerts.snap
+++ b/pkg/github/__toolsnaps__/list_org_dependabot_alerts.snap
@@ -1,17 +1,25 @@
 {
   "annotations": {
     "readOnlyHint": true,
-    "title": "List dependabot alerts"
+    "title": "List org Dependabot alerts"
   },
-  "description": "List dependabot alerts in a GitHub repository.",
+  "description": "List Dependabot alerts for a GitHub organization.",
   "inputSchema": {
     "properties": {
       "after": {
         "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.",
         "type": "string"
       },
-      "owner": {
-        "description": "The owner of the repository.",
+      "ecosystem": {
+        "description": "Filter Dependabot alerts by package ecosystem (e.g. npm, pip, maven)",
+        "type": "string"
+      },
+      "org": {
+        "description": "The organization name.",
+        "type": "string"
+      },
+      "package": {
+        "description": "Filter Dependabot alerts by package name",
         "type": "string"
       },
       "perPage": {
@@ -20,12 +28,8 @@
         "minimum": 1,
         "type": "number"
       },
-      "repo": {
-        "description": "The name of the repository.",
-        "type": "string"
-      },
       "severity": {
-        "description": "Filter dependabot alerts by severity",
+        "description": "Filter Dependabot alerts by severity",
         "enum": [
           "low",
           "medium",
@@ -36,7 +40,7 @@
       },
       "state": {
         "default": "open",
-        "description": "Filter dependabot alerts by state. Defaults to open",
+        "description": "Filter Dependabot alerts by state. Defaults to open",
         "enum": [
           "open",
           "fixed",
@@ -47,10 +51,9 @@
       }
     },
     "required": [
-      "owner",
-      "repo"
+      "org"
     ],
     "type": "object"
   },
-  "name": "list_dependabot_alerts"
+  "name": "list_org_dependabot_alerts"
 }

--- a/pkg/github/__toolsnaps__/update_dependabot_alert.snap
+++ b/pkg/github/__toolsnaps__/update_dependabot_alert.snap
@@ -1,0 +1,54 @@
+{
+  "annotations": {
+    "title": "Update Dependabot alert"
+  },
+  "description": "Update the state of a Dependabot alert in a GitHub repository.",
+  "inputSchema": {
+    "properties": {
+      "alertNumber": {
+        "description": "The number of the alert.",
+        "type": "number"
+      },
+      "dismissedComment": {
+        "description": "An optional comment associated with dismissing the alert. Maximum 280 characters.",
+        "maxLength": 280,
+        "type": "string"
+      },
+      "dismissedReason": {
+        "description": "Required when state is dismissed. The reason for dismissing the alert.",
+        "enum": [
+          "fix_started",
+          "inaccurate",
+          "no_bandwidth",
+          "not_used",
+          "tolerable_risk"
+        ],
+        "type": "string"
+      },
+      "owner": {
+        "description": "The owner of the repository.",
+        "type": "string"
+      },
+      "repo": {
+        "description": "The name of the repository.",
+        "type": "string"
+      },
+      "state": {
+        "description": "The state to set for the alert.",
+        "enum": [
+          "open",
+          "dismissed"
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "alertNumber",
+      "state"
+    ],
+    "type": "object"
+  },
+  "name": "update_dependabot_alert"
+}

--- a/pkg/github/dependabot.go
+++ b/pkg/github/dependabot.go
@@ -94,6 +94,233 @@ func GetDependabotAlert(t translations.TranslationHelperFunc) inventory.ServerTo
 	)
 }
 
+func ListOrgDependabotAlerts(t translations.TranslationHelperFunc) inventory.ServerTool {
+	return NewTool(
+		ToolsetMetadataDependabot,
+		mcp.Tool{
+			Name:        "list_org_dependabot_alerts",
+			Description: t("TOOL_LIST_ORG_DEPENDABOT_ALERTS_DESCRIPTION", "List Dependabot alerts for a GitHub organization."),
+			Annotations: &mcp.ToolAnnotations{
+				Title:        t("TOOL_LIST_ORG_DEPENDABOT_ALERTS_USER_TITLE", "List org Dependabot alerts"),
+				ReadOnlyHint: true,
+			},
+			InputSchema: WithCursorPagination(&jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"org": {
+						Type:        "string",
+						Description: "The organization name.",
+					},
+					"state": {
+						Type:        "string",
+						Description: "Filter Dependabot alerts by state. Defaults to open",
+						Enum:        []any{"open", "fixed", "dismissed", "auto_dismissed"},
+						Default:     json.RawMessage(`"open"`),
+					},
+					"severity": {
+						Type:        "string",
+						Description: "Filter Dependabot alerts by severity",
+						Enum:        []any{"low", "medium", "high", "critical"},
+					},
+					"ecosystem": {
+						Type:        "string",
+						Description: "Filter Dependabot alerts by package ecosystem (e.g. npm, pip, maven)",
+					},
+					"package": {
+						Type:        "string",
+						Description: "Filter Dependabot alerts by package name",
+					},
+				},
+				Required: []string{"org"},
+			}),
+		},
+		[]scopes.Scope{scopes.SecurityEvents},
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			org, err := RequiredParam[string](args, "org")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := OptionalParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			severity, err := OptionalParam[string](args, "severity")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			ecosystem, err := OptionalParam[string](args, "ecosystem")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pkg, err := OptionalParam[string](args, "package")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			cursor, err := OptionalCursorPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, err
+			}
+
+			alerts, resp, err := client.Dependabot.ListOrgAlerts(ctx, org, &github.ListAlertsOptions{
+				State:     ToStringPtr(state),
+				Severity:  ToStringPtr(severity),
+				Ecosystem: ToStringPtr(ecosystem),
+				Package:   ToStringPtr(pkg),
+				ListCursorOptions: github.ListCursorOptions{
+					PerPage: cursor.PerPage,
+					After:   cursor.After,
+				},
+			})
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					fmt.Sprintf("failed to list alerts for organisation '%s'", org),
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, err
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
+			}
+
+			minimal := make([]MinimalDependabotAlert, 0, len(alerts))
+			for _, a := range alerts {
+				minimal = append(minimal, convertToMinimalDependabotAlert(a))
+			}
+
+			response := map[string]any{
+				"alerts":   minimal,
+				"pageInfo": buildPageInfo(resp),
+			}
+
+			r, err := json.Marshal(response)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, err
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
+		},
+	)
+}
+
+func UpdateDependabotAlert(t translations.TranslationHelperFunc) inventory.ServerTool {
+	return NewTool(
+		ToolsetMetadataDependabot,
+		mcp.Tool{
+			Name:        "update_dependabot_alert",
+			Description: t("TOOL_UPDATE_DEPENDABOT_ALERT_DESCRIPTION", "Update the state of a Dependabot alert in a GitHub repository."),
+			Annotations: &mcp.ToolAnnotations{
+				Title:        t("TOOL_UPDATE_DEPENDABOT_ALERT_USER_TITLE", "Update Dependabot alert"),
+				ReadOnlyHint: false,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"owner": {
+						Type:        "string",
+						Description: "The owner of the repository.",
+					},
+					"repo": {
+						Type:        "string",
+						Description: "The name of the repository.",
+					},
+					"alertNumber": {
+						Type:        "number",
+						Description: "The number of the alert.",
+					},
+					"state": {
+						Type:        "string",
+						Description: "The state to set for the alert.",
+						Enum:        []any{"open", "dismissed"},
+					},
+					"dismissedReason": {
+						Type:        "string",
+						Description: "Required when state is dismissed. The reason for dismissing the alert.",
+						Enum:        []any{"fix_started", "inaccurate", "no_bandwidth", "not_used", "tolerable_risk"},
+					},
+					"dismissedComment": {
+						Type:        "string",
+						Description: "An optional comment associated with dismissing the alert. Maximum 280 characters.",
+						MaxLength:   jsonschema.Ptr(280),
+					},
+				},
+				Required: []string{"owner", "repo", "alertNumber", "state"},
+			},
+		},
+		[]scopes.Scope{scopes.SecurityEvents},
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			alertNumber, err := RequiredInt(args, "alertNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			state, err := RequiredParam[string](args, "state")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			dismissedReason, err := OptionalParam[string](args, "dismissedReason")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			dismissedComment, err := OptionalParam[string](args, "dismissedComment")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, err
+			}
+
+			alert, resp, err := client.Dependabot.UpdateAlert(ctx, owner, repo, alertNumber, &github.DependabotAlertState{
+				State:            state,
+				DismissedReason:  ToStringPtr(dismissedReason),
+				DismissedComment: ToStringPtr(dismissedComment),
+			})
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx,
+					fmt.Sprintf("failed to update alert with number '%d'", alertNumber),
+					resp,
+					err,
+				), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, err
+				}
+				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to update alert", resp, body), nil, nil
+			}
+
+			r, err := json.Marshal(alert)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal alert", err), nil, err
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
+		},
+	)
+}
+
 func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.ServerTool {
 	return NewTool(
 		ToolsetMetadataDependabot,
@@ -104,7 +331,7 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 				Title:        t("TOOL_LIST_DEPENDABOT_ALERTS_USER_TITLE", "List dependabot alerts"),
 				ReadOnlyHint: true,
 			},
-			InputSchema: &jsonschema.Schema{
+			InputSchema: WithCursorPagination(&jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
 					"owner": {
@@ -128,7 +355,7 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 					},
 				},
 				Required: []string{"owner", "repo"},
-			},
+			}),
 		},
 		[]scopes.Scope{scopes.SecurityEvents},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
@@ -148,6 +375,10 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			cursor, err := OptionalCursorPaginationParams(args)
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
 			client, err := deps.GetClient(ctx)
 			if err != nil {
@@ -157,6 +388,10 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 			alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, owner, repo, &github.ListAlertsOptions{
 				State:    ToStringPtr(state),
 				Severity: ToStringPtr(severity),
+				ListCursorOptions: github.ListCursorOptions{
+					PerPage: cursor.PerPage,
+					After:   cursor.After,
+				},
 			})
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,
@@ -175,7 +410,17 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
 			}
 
-			r, err := json.Marshal(alerts)
+			minimal := make([]MinimalDependabotAlert, 0, len(alerts))
+			for _, a := range alerts {
+				minimal = append(minimal, convertToMinimalDependabotAlert(a))
+			}
+
+			response := map[string]any{
+				"alerts":   minimal,
+				"pageInfo": buildPageInfo(resp),
+			}
+
+			r, err := json.Marshal(response)
 			if err != nil {
 				return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, err
 			}

--- a/pkg/github/dependabot_test.go
+++ b/pkg/github/dependabot_test.go
@@ -109,6 +109,150 @@ func Test_GetDependabotAlert(t *testing.T) {
 	}
 }
 
+func Test_UpdateDependabotAlert(t *testing.T) {
+	// Verify tool definition
+	toolDef := UpdateDependabotAlert(translations.NullTranslationHelper)
+	tool := toolDef.Tool
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
+	assert.Equal(t, "update_dependabot_alert", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.False(t, tool.Annotations.ReadOnlyHint, "update_dependabot_alert tool should not be read-only")
+
+	mockDismissedAlert := &github.DependabotAlert{
+		Number:           github.Ptr(42),
+		State:            github.Ptr("dismissed"),
+		DismissedReason:  github.Ptr("tolerable_risk"),
+		DismissedComment: github.Ptr(""),
+		HTMLURL:          github.Ptr("https://github.com/owner/repo/security/dependabot/42"),
+	}
+	mockOpenAlert := &github.DependabotAlert{
+		Number:  github.Ptr(42),
+		State:   github.Ptr("open"),
+		HTMLURL: github.Ptr("https://github.com/owner/repo/security/dependabot/42"),
+	}
+	mockDismissedAlertWithComment := &github.DependabotAlert{
+		Number:           github.Ptr(42),
+		State:            github.Ptr("dismissed"),
+		DismissedReason:  github.Ptr("tolerable_risk"),
+		DismissedComment: github.Ptr("Acceptable risk in this context"),
+		HTMLURL:          github.Ptr("https://github.com/owner/repo/security/dependabot/42"),
+	}
+
+	tests := []struct {
+		name           string
+		mockedClient   *http.Client
+		requestArgs    map[string]any
+		expectError    bool
+		expectedAlert  *github.DependabotAlert
+		expectedErrMsg string
+	}{
+		{
+			name: "successfully dismiss alert",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PatchReposDependabotAlertsByOwnerByRepoByAlertNumber: expectRequestBody(t, map[string]any{
+					"state":            "dismissed",
+					"dismissed_reason": "tolerable_risk",
+				}).andThen(mockResponse(t, http.StatusOK, mockDismissedAlert)),
+			}),
+			requestArgs: map[string]any{
+				"owner":           "owner",
+				"repo":            "repo",
+				"alertNumber":     float64(42),
+				"state":           "dismissed",
+				"dismissedReason": "tolerable_risk",
+			},
+			expectError:   false,
+			expectedAlert: mockDismissedAlert,
+		},
+		{
+			name: "successfully reopen alert",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PatchReposDependabotAlertsByOwnerByRepoByAlertNumber: expectRequestBody(t, map[string]any{
+					"state": "open",
+				}).andThen(mockResponse(t, http.StatusOK, mockOpenAlert)),
+			}),
+			requestArgs: map[string]any{
+				"owner":       "owner",
+				"repo":        "repo",
+				"alertNumber": float64(42),
+				"state":       "open",
+			},
+			expectError:   false,
+			expectedAlert: mockOpenAlert,
+		},
+		{
+			name: "dismiss alert with comment",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PatchReposDependabotAlertsByOwnerByRepoByAlertNumber: expectRequestBody(t, map[string]any{
+					"state":             "dismissed",
+					"dismissed_reason":  "tolerable_risk",
+					"dismissed_comment": "Acceptable risk in this context",
+				}).andThen(mockResponse(t, http.StatusOK, mockDismissedAlertWithComment)),
+			}),
+			requestArgs: map[string]any{
+				"owner":            "owner",
+				"repo":             "repo",
+				"alertNumber":      float64(42),
+				"state":            "dismissed",
+				"dismissedReason":  "tolerable_risk",
+				"dismissedComment": "Acceptable risk in this context",
+			},
+			expectError:   false,
+			expectedAlert: mockDismissedAlertWithComment,
+		},
+		{
+			name: "failed request",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PatchReposDependabotAlertsByOwnerByRepoByAlertNumber: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"message": "Forbidden"}`))
+				}),
+			}),
+			requestArgs: map[string]any{
+				"owner":       "owner",
+				"repo":        "repo",
+				"alertNumber": float64(42),
+				"state":       "dismissed",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to update alert",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := github.NewClient(tc.mockedClient)
+			deps := BaseDeps{Client: client}
+			handler := toolDef.Handler(deps)
+
+			request := createMCPRequest(tc.requestArgs)
+
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+			if tc.expectError {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				errorContent := getErrorResult(t, result)
+				assert.Contains(t, errorContent.Text, tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.False(t, result.IsError)
+
+			textContent := getTextResult(t, result)
+
+			var returnedAlert github.DependabotAlert
+			err = json.Unmarshal([]byte(textContent.Text), &returnedAlert)
+			assert.NoError(t, err)
+			assert.Equal(t, *tc.expectedAlert.Number, *returnedAlert.Number)
+			assert.Equal(t, *tc.expectedAlert.State, *returnedAlert.State)
+			assert.Equal(t, *tc.expectedAlert.HTMLURL, *returnedAlert.HTMLURL)
+		})
+	}
+}
+
 func Test_ListDependabotAlerts(t *testing.T) {
 	// Verify tool definition once
 	toolDef := ListDependabotAlerts(translations.NullTranslationHelper)
@@ -149,7 +293,8 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			name: "successful open alerts listing",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
-					"state": "open",
+					"state":    "open",
+					"per_page": "30",
 				}).andThen(
 					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&criticalAlert}),
 				),
@@ -167,6 +312,7 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
 					"severity": "high",
+					"per_page": "30",
 				}).andThen(
 					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&highSeverityAlert}),
 				),
@@ -182,7 +328,9 @@ func Test_ListDependabotAlerts(t *testing.T) {
 		{
 			name: "successful all alerts listing",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
-				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{}).andThen(
+				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
+					"per_page": "30",
+				}).andThen(
 					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&criticalAlert, &highSeverityAlert}),
 				),
 			}),
@@ -234,17 +382,164 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			textContent := getTextResult(t, result)
 
 			// Unmarshal and verify the result
-			var returnedAlerts []*github.DependabotAlert
-			err = json.Unmarshal([]byte(textContent.Text), &returnedAlerts)
+			var response struct {
+				Alerts   []MinimalDependabotAlert `json:"alerts"`
+				PageInfo pageInfo                 `json:"pageInfo"`
+			}
+			err = json.Unmarshal([]byte(textContent.Text), &response)
 			assert.NoError(t, err)
-			assert.Len(t, returnedAlerts, len(tc.expectedAlerts))
-			for i, alert := range returnedAlerts {
-				assert.Equal(t, *tc.expectedAlerts[i].Number, *alert.Number)
-				assert.Equal(t, *tc.expectedAlerts[i].HTMLURL, *alert.HTMLURL)
-				assert.Equal(t, *tc.expectedAlerts[i].State, *alert.State)
-				if tc.expectedAlerts[i].SecurityAdvisory != nil && tc.expectedAlerts[i].SecurityAdvisory.Severity != nil &&
-					alert.SecurityAdvisory != nil && alert.SecurityAdvisory.Severity != nil {
-					assert.Equal(t, *tc.expectedAlerts[i].SecurityAdvisory.Severity, *alert.SecurityAdvisory.Severity)
+			assert.Len(t, response.Alerts, len(tc.expectedAlerts))
+			for i, alert := range response.Alerts {
+				assert.Equal(t, *tc.expectedAlerts[i].Number, alert.Number)
+				assert.Equal(t, *tc.expectedAlerts[i].HTMLURL, alert.HTMLURL)
+				assert.Equal(t, *tc.expectedAlerts[i].State, alert.State)
+				if tc.expectedAlerts[i].SecurityAdvisory != nil && tc.expectedAlerts[i].SecurityAdvisory.Severity != nil {
+					assert.Equal(t, *tc.expectedAlerts[i].SecurityAdvisory.Severity, alert.SecurityAdvisory.Severity)
+				}
+			}
+		})
+	}
+}
+
+func Test_ListOrgDependabotAlerts(t *testing.T) {
+	// Verify tool definition once
+	toolDef := ListOrgDependabotAlerts(translations.NullTranslationHelper)
+	tool := toolDef.Tool
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
+	assert.Equal(t, "list_org_dependabot_alerts", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.True(t, tool.Annotations.ReadOnlyHint, "list_org_dependabot_alerts tool should be read-only")
+
+	// Setup mock alerts for success case
+	criticalAlert := github.DependabotAlert{
+		Number:  github.Ptr(1),
+		HTMLURL: github.Ptr("https://github.com/myorg/repo1/security/dependabot/1"),
+		State:   github.Ptr("open"),
+		SecurityAdvisory: &github.DependabotSecurityAdvisory{
+			Severity: github.Ptr("critical"),
+		},
+	}
+	highSeverityAlert := github.DependabotAlert{
+		Number:  github.Ptr(2),
+		HTMLURL: github.Ptr("https://github.com/myorg/repo2/security/dependabot/2"),
+		State:   github.Ptr("open"),
+		SecurityAdvisory: &github.DependabotSecurityAdvisory{
+			Severity: github.Ptr("high"),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		mockedClient   *http.Client
+		requestArgs    map[string]any
+		expectError    bool
+		expectedAlerts []*github.DependabotAlert
+		expectedErrMsg string
+	}{
+		{
+			name: "successful listing with state filter",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				GetOrgsDependabotAlertsByOrg: expectQueryParams(t, map[string]string{
+					"state":    "open",
+					"per_page": "30",
+				}).andThen(
+					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&criticalAlert, &highSeverityAlert}),
+				),
+			}),
+			requestArgs: map[string]any{
+				"org":   "myorg",
+				"state": "open",
+			},
+			expectError:    false,
+			expectedAlerts: []*github.DependabotAlert{&criticalAlert, &highSeverityAlert},
+		},
+		{
+			name: "successful listing with severity filter",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				GetOrgsDependabotAlertsByOrg: expectQueryParams(t, map[string]string{
+					"severity": "critical",
+					"per_page": "30",
+				}).andThen(
+					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&criticalAlert}),
+				),
+			}),
+			requestArgs: map[string]any{
+				"org":      "myorg",
+				"severity": "critical",
+			},
+			expectError:    false,
+			expectedAlerts: []*github.DependabotAlert{&criticalAlert},
+		},
+		{
+			name: "successful listing with ecosystem filter",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				GetOrgsDependabotAlertsByOrg: expectQueryParams(t, map[string]string{
+					"ecosystem": "npm",
+					"per_page":  "30",
+				}).andThen(
+					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&highSeverityAlert}),
+				),
+			}),
+			requestArgs: map[string]any{
+				"org":       "myorg",
+				"ecosystem": "npm",
+			},
+			expectError:    false,
+			expectedAlerts: []*github.DependabotAlert{&highSeverityAlert},
+		},
+		{
+			name: "alerts listing fails",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				GetOrgsDependabotAlertsByOrg: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte(`{"message": "Unauthorized access"}`))
+				}),
+			}),
+			requestArgs: map[string]any{
+				"org": "myorg",
+			},
+			expectError:    true,
+			expectedErrMsg: "failed to list alerts",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := github.NewClient(tc.mockedClient)
+			deps := BaseDeps{Client: client}
+			handler := toolDef.Handler(deps)
+
+			request := createMCPRequest(tc.requestArgs)
+
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+			if tc.expectError {
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+				errorContent := getErrorResult(t, result)
+				assert.Contains(t, errorContent.Text, tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.False(t, result.IsError)
+
+			textContent := getTextResult(t, result)
+
+			var response struct {
+				Alerts   []MinimalDependabotAlert `json:"alerts"`
+				PageInfo pageInfo                 `json:"pageInfo"`
+			}
+			err = json.Unmarshal([]byte(textContent.Text), &response)
+			assert.NoError(t, err)
+			assert.Len(t, response.Alerts, len(tc.expectedAlerts))
+			for i, alert := range response.Alerts {
+				assert.Equal(t, *tc.expectedAlerts[i].Number, alert.Number)
+				assert.Equal(t, *tc.expectedAlerts[i].HTMLURL, alert.HTMLURL)
+				assert.Equal(t, *tc.expectedAlerts[i].State, alert.State)
+				if tc.expectedAlerts[i].SecurityAdvisory != nil && tc.expectedAlerts[i].SecurityAdvisory.Severity != nil {
+					assert.Equal(t, *tc.expectedAlerts[i].SecurityAdvisory.Severity, alert.SecurityAdvisory.Severity)
 				}
 			}
 		})

--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -107,8 +107,10 @@ const (
 	GetReposSecretScanningAlertsByOwnerByRepoByAlertNumber = "GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}" //nolint:gosec // False positive - this is an API endpoint pattern, not a credential
 
 	// Dependabot endpoints
-	GetReposDependabotAlertsByOwnerByRepo              = "GET /repos/{owner}/{repo}/dependabot/alerts"
-	GetReposDependabotAlertsByOwnerByRepoByAlertNumber = "GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"
+	GetReposDependabotAlertsByOwnerByRepo                = "GET /repos/{owner}/{repo}/dependabot/alerts"
+	GetReposDependabotAlertsByOwnerByRepoByAlertNumber   = "GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"
+	PatchReposDependabotAlertsByOwnerByRepoByAlertNumber = "PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"
+	GetOrgsDependabotAlertsByOrg                         = "GET /orgs/{org}/dependabot/alerts"
 
 	// Security advisories endpoints
 	GetAdvisories                           = "GET /advisories"

--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -883,3 +883,111 @@ func convertToMinimalReviewComment(c reviewCommentNode) MinimalReviewComment {
 
 	return m
 }
+
+// MinimalDependabotAdvisory is the trimmed output type for the security advisory embedded in a Dependabot alert.
+// It omits the full description, references, and inner vulnerabilities list to reduce verbosity.
+type MinimalDependabotAdvisory struct {
+	GHSAID    string  `json:"ghsa_id,omitempty"`
+	CVEID     string  `json:"cve_id,omitempty"`
+	Summary   string  `json:"summary,omitempty"`
+	Severity  string  `json:"severity,omitempty"`
+	CVSSScore float64 `json:"cvss_score,omitempty"`
+}
+
+// MinimalDependabotAlert is the trimmed output type for Dependabot alerts.
+// It replaces the full Repository and User objects with minimal equivalents and
+// drops verbose advisory fields (description, references) not needed for triage.
+type MinimalDependabotAlert struct {
+	Number                int                            `json:"number"`
+	State                 string                         `json:"state,omitempty"`
+	HTMLURL               string                         `json:"html_url,omitempty"`
+	CreatedAt             string                         `json:"created_at,omitempty"`
+	UpdatedAt             string                         `json:"updated_at,omitempty"`
+	DismissedAt           string                         `json:"dismissed_at,omitempty"`
+	DismissedBy           *MinimalUser                   `json:"dismissed_by,omitempty"`
+	DismissedReason       string                         `json:"dismissed_reason,omitempty"`
+	DismissedComment      string                         `json:"dismissed_comment,omitempty"`
+	FixedAt               string                         `json:"fixed_at,omitempty"`
+	AutoDismissedAt       string                         `json:"auto_dismissed_at,omitempty"`
+	Dependency            *github.Dependency             `json:"dependency,omitempty"`
+	SecurityAdvisory      *MinimalDependabotAdvisory     `json:"security_advisory,omitempty"`
+	SecurityVulnerability *github.AdvisoryVulnerability  `json:"security_vulnerability,omitempty"`
+	Repository            *MinimalRepository             `json:"repository,omitempty"`
+}
+
+// convertToMinimalDependabotAlert converts a full DependabotAlert to a MinimalDependabotAlert.
+func convertToMinimalDependabotAlert(alert *github.DependabotAlert) MinimalDependabotAlert {
+	m := MinimalDependabotAlert{
+		Number:                alert.GetNumber(),
+		State:                 alert.GetState(),
+		HTMLURL:               alert.GetHTMLURL(),
+		DismissedBy:           convertToMinimalUser(alert.GetDismissedBy()),
+		DismissedReason:       alert.GetDismissedReason(),
+		DismissedComment:      alert.GetDismissedComment(),
+		Dependency:            alert.GetDependency(),
+		SecurityVulnerability: alert.GetSecurityVulnerability(),
+		Repository:            convertToMinimalRepository(alert.GetRepository()),
+	}
+
+	if alert.SecurityAdvisory != nil {
+		a := alert.SecurityAdvisory
+		minimal := &MinimalDependabotAdvisory{
+			GHSAID:   a.GetGHSAID(),
+			CVEID:    a.GetCVEID(),
+			Summary:  a.GetSummary(),
+			Severity: a.GetSeverity(),
+		}
+		if a.CVSS != nil && a.CVSS.Score != nil {
+			minimal.CVSSScore = *a.CVSS.Score
+		}
+		m.SecurityAdvisory = minimal
+	}
+
+	if alert.CreatedAt != nil {
+		m.CreatedAt = alert.CreatedAt.Format(time.RFC3339)
+	}
+	if alert.UpdatedAt != nil {
+		m.UpdatedAt = alert.UpdatedAt.Format(time.RFC3339)
+	}
+	if alert.DismissedAt != nil {
+		m.DismissedAt = alert.DismissedAt.Format(time.RFC3339)
+	}
+	if alert.FixedAt != nil {
+		m.FixedAt = alert.FixedAt.Format(time.RFC3339)
+	}
+	if alert.AutoDismissedAt != nil {
+		m.AutoDismissedAt = alert.AutoDismissedAt.Format(time.RFC3339)
+	}
+
+	return m
+}
+
+// convertToMinimalRepository converts a full github.Repository to a MinimalRepository.
+func convertToMinimalRepository(repo *github.Repository) *MinimalRepository {
+	if repo == nil {
+		return nil
+	}
+	m := &MinimalRepository{
+		ID:            repo.GetID(),
+		Name:          repo.GetName(),
+		FullName:      repo.GetFullName(),
+		Description:   repo.GetDescription(),
+		HTMLURL:       repo.GetHTMLURL(),
+		Language:      repo.GetLanguage(),
+		Stars:         repo.GetStargazersCount(),
+		Forks:         repo.GetForksCount(),
+		OpenIssues:    repo.GetOpenIssuesCount(),
+		Topics:        repo.Topics,
+		Private:       repo.GetPrivate(),
+		Fork:          repo.GetFork(),
+		Archived:      repo.GetArchived(),
+		DefaultBranch: repo.GetDefaultBranch(),
+	}
+	if repo.CreatedAt != nil {
+		m.CreatedAt = repo.CreatedAt.Format(time.RFC3339)
+	}
+	if repo.UpdatedAt != nil {
+		m.UpdatedAt = repo.UpdatedAt.Format(time.RFC3339)
+	}
+	return m
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -245,6 +245,8 @@ func AllTools(t translations.TranslationHelperFunc) []inventory.ServerTool {
 		// Dependabot tools
 		GetDependabotAlert(t),
 		ListDependabotAlerts(t),
+		ListOrgDependabotAlerts(t),
+		UpdateDependabotAlert(t),
 
 		// Notification tools
 		ListNotifications(t),


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->
Add additional tools for managing dependabot `list_org_dependabot_alerts` `update_dependabot_alert`

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes #1921

## What changed
<!-- Bullet list of concrete changes. -->
- Add `update_dependabot_alert` tool
- Add `list_org_dependabot_alerts` tool

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [x] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [x] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [x] Updated (README / docs / examples)
