### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -1,0 +1,32 @@
+name: Validate Skill
+
+on:
+  pull_request:
+    paths:
+      - 'SKILL.md'
+      - 'skill.json'
+  push:
+    branches:
+      - main
+    paths:
+      - 'SKILL.md'
+      - 'skill.json'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate skill definition
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Validate skill
+        uses: hashgraph-online/skill-publish@v1
+        with:
+          mode: validate
+          skill-dir: .


### PR DESCRIPTION
I opened this as a small validate-only check for the skill metadata in the repo.

A couple of repo-specific details I checked first:
- GitHub's official MCP Server
- Issue & PR Automation: Create, update, and manage issues and pull requests. Let AI help triage bugs, review code changes, and maintain project boards
- CI/CD & Workflow Intelligence: Monitor GitHub Actions workflow runs, analyze build failures, manage releases, and get insights into your development pipeline

This adds one workflow for `.` and leaves the runtime code alone.
It only runs the schema and trust checks for the skill metadata in validate mode.

If you would rather place the workflow under a different filename or point it at a different skill directory, I can adjust the branch.