### PR TITLE
feat(http): implement HeaderAllowedFeatureFlags for X-MCP-Features header validation

### DIFF
--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -160,6 +160,7 @@ var headerAllowedFeatureFlags = []string{
 func HeaderAllowedFeatureFlags() []string {
 	return slices.Clone(headerAllowedFeatureFlags)
 }
+
 var (
 	// Remote-only toolsets - these are only available in the remote MCP server
 	// but are documented here for consistency and to enable automated documentation.

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -145,7 +145,17 @@ var (
 	// When active, consolidated tools are replaced by single-purpose granular tools.
 	FeatureFlagIssuesGranular       = "issues_granular"
 	FeatureFlagPullRequestsGranular = "pull_requests_granular"
+)
 
+// HeaderAllowedFeatureFlags are the feature flags that clients may enable via the
+// X-MCP-Features header. Only these flags are accepted from headers; unknown flags
+// are silently ignored.
+var HeaderAllowedFeatureFlags = []string{
+	FeatureFlagIssuesGranular,
+	FeatureFlagPullRequestsGranular,
+}
+
+var (
 	// Remote-only toolsets - these are only available in the remote MCP server
 	// but are documented here for consistency and to enable automated documentation.
 	ToolsetMetadataCopilotSpaces = inventory.ToolsetMetadata{

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -147,14 +147,19 @@ var (
 	FeatureFlagPullRequestsGranular = "pull_requests_granular"
 )
 
-// HeaderAllowedFeatureFlags are the feature flags that clients may enable via the
+// headerAllowedFeatureFlags are the feature flags that clients may enable via the
 // X-MCP-Features header. Only these flags are accepted from headers; unknown flags
 // are silently ignored.
-var HeaderAllowedFeatureFlags = []string{
+var headerAllowedFeatureFlags = []string{
 	FeatureFlagIssuesGranular,
 	FeatureFlagPullRequestsGranular,
 }
 
+// HeaderAllowedFeatureFlags returns the feature flags that clients may enable via
+// the X-MCP-Features header.
+func HeaderAllowedFeatureFlags() []string {
+	return slices.Clone(headerAllowedFeatureFlags)
+}
 var (
 	// Remote-only toolsets - these are only available in the remote MCP server
 	// but are documented here for consistency and to enable automated documentation.

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -27,7 +27,7 @@ import (
 
 // knownFeatureFlags are the feature flags that can be enabled via X-MCP-Features header.
 // Only these flags are accepted from headers.
-var knownFeatureFlags = []string{}
+var knownFeatureFlags = github.HeaderAllowedFeatureFlags
 
 type ServerConfig struct {
 	// Version of the server

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -27,7 +27,7 @@ import (
 
 // knownFeatureFlags are the feature flags that can be enabled via X-MCP-Features header.
 // Only these flags are accepted from headers.
-var knownFeatureFlags = github.HeaderAllowedFeatureFlags
+var knownFeatureFlags = github.HeaderAllowedFeatureFlags()
 
 type ServerConfig struct {
 	// Version of the server

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -1,0 +1,86 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
+	"github.com/github/github-mcp-server/pkg/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateHTTPFeatureChecker_Whitelist(t *testing.T) {
+	checker := createHTTPFeatureChecker()
+
+	tests := []struct {
+		name           string
+		flagName       string
+		headerFeatures []string
+		wantEnabled    bool
+	}{
+		{
+			name:           "whitelisted issues_granular flag accepted from header",
+			flagName:       github.FeatureFlagIssuesGranular,
+			headerFeatures: []string{github.FeatureFlagIssuesGranular},
+			wantEnabled:    true,
+		},
+		{
+			name:           "whitelisted pull_requests_granular flag accepted from header",
+			flagName:       github.FeatureFlagPullRequestsGranular,
+			headerFeatures: []string{github.FeatureFlagPullRequestsGranular},
+			wantEnabled:    true,
+		},
+		{
+			name:           "unknown flag in header is ignored",
+			flagName:       "unknown_flag",
+			headerFeatures: []string{"unknown_flag"},
+			wantEnabled:    false,
+		},
+		{
+			name:           "whitelisted flag not in header returns false",
+			flagName:       github.FeatureFlagIssuesGranular,
+			headerFeatures: nil,
+			wantEnabled:    false,
+		},
+		{
+			name:           "whitelisted flag with different flag in header returns false",
+			flagName:       github.FeatureFlagIssuesGranular,
+			headerFeatures: []string{github.FeatureFlagPullRequestsGranular},
+			wantEnabled:    false,
+		},
+		{
+			name:           "multiple whitelisted flags in header",
+			flagName:       github.FeatureFlagIssuesGranular,
+			headerFeatures: []string{github.FeatureFlagIssuesGranular, github.FeatureFlagPullRequestsGranular},
+			wantEnabled:    true,
+		},
+		{
+			name:           "empty header features",
+			flagName:       github.FeatureFlagIssuesGranular,
+			headerFeatures: []string{},
+			wantEnabled:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if len(tt.headerFeatures) > 0 {
+				ctx = ghcontext.WithHeaderFeatures(ctx, tt.headerFeatures)
+			}
+
+			enabled, err := checker(ctx, tt.flagName)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnabled, enabled)
+		})
+	}
+}
+
+func TestKnownFeatureFlagsMatchesHeaderAllowed(t *testing.T) {
+	// Ensure knownFeatureFlags stays in sync with HeaderAllowedFeatureFlags
+	allowed := github.HeaderAllowedFeatureFlags()
+	assert.Equal(t, allowed, knownFeatureFlags,
+		"knownFeatureFlags should match github.HeaderAllowedFeatureFlags()")
+	assert.NotEmpty(t, knownFeatureFlags, "knownFeatureFlags should not be empty")
+}


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes #

## What changed
<!-- Bullet list of concrete changes. -->
- 
- 

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [ ] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [ ] Linted locally with `./script/lint`
- [ ] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [ ] Updated (README / docs / examples)
