### PR TITLE
Add middleware to normalize Content-Type header

### DIFF
--- a/pkg/http/handler.go
+++ b/pkg/http/handler.go
@@ -127,6 +127,7 @@ func NewHTTPMcpHandler(
 
 func (h *Handler) RegisterMiddleware(r chi.Router) {
 	r.Use(
+		middleware.NormalizeContentType,
 		middleware.ExtractUserToken(h.oauthCfg),
 		middleware.WithRequestConfig,
 		middleware.WithMCPParse(),

--- a/pkg/http/middleware/content_type.go
+++ b/pkg/http/middleware/content_type.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"mime"
+	"net/http"
+
+	"github.com/github/github-mcp-server/pkg/http/headers"
+)
+
+// NormalizeContentType strips MIME parameters from the Content-Type header so
+// "application/json; charset=utf-8" is treated as "application/json".
+func NormalizeContentType(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get(headers.ContentTypeHeader); ct != "" {
+			mediaType, _, err := mime.ParseMediaType(ct)
+			if err == nil && mediaType != ct {
+				r = r.Clone(r.Context())
+				r.Header.Set(headers.ContentTypeHeader, mediaType)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/http/middleware/content_type_test.go
+++ b/pkg/http/middleware/content_type_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/http/headers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeContentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no parameters unchanged",
+			input:    "application/json",
+			expected: "application/json",
+		},
+		{
+			name:     "charset parameter stripped",
+			input:    "application/json; charset=utf-8",
+			expected: "application/json",
+		},
+		{
+			name:     "multiple parameters stripped",
+			input:    "application/json; charset=utf-8; boundary=foo",
+			expected: "application/json",
+		},
+		{
+			name:     "empty header unchanged",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "other content type with params stripped",
+			input:    "text/plain; charset=utf-8",
+			expected: "text/plain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			handler := NormalizeContentType(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get(headers.ContentTypeHeader)
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			if tt.input != "" {
+				req.Header.Set(headers.ContentTypeHeader, tt.input)
+			}
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2333

## Summary
Added middleware that normalizes the Content-Type header by stripping MIME parameters like charset.

## Why
The API was rejecting requests with `Content-Type: application/json; charset=utf-8` because downstream validation expected exactly `application/json`. This middleware strips those extra parameters so handlers see the clean media type.

## What changed
Created a new middleware that uses mime.ParseMediaType to extract just the media type, then rewrites the header if parameters were present. Registered it early in the handler's middleware chain so all downstream handlers get the normalized version. Included tests covering cases with no parameters, charset parameter, multiple parameters, and empty headers.

## MCP impact
MCP clients that send Content-Type headers with charset parameters will now work correctly. The normalized header is transparent to downstream handlers and doesn't change behavior for anything else.

## Prompts tested
N/A

## Security/limits consideration
No security implications. The middleware only parses and normalizes the header, it doesn't validate or reject anything.

## Tool renaming considerations
N/A

## Checklist
- [x] Ran `./script/lint`
- [x] Ran `./script/test`
- [ ] Updated docs