### PR TITLE
Fix set_issue_fields mutation: use correct inline fragments for IssueFieldValue union

### DIFF
--- a/pkg/github/granular_tools_test.go
+++ b/pkg/github/granular_tools_test.go
@@ -810,9 +810,18 @@ func TestGranularSetIssueFields(t *testing.T) {
 							URL    githubv4.String
 						}
 						IssueFieldValues []struct {
-							Field struct {
+							TextValue struct {
+								Value string
+							} `graphql:"... on IssueFieldTextValue"`
+							SingleSelectValue struct {
 								Name string
+							} `graphql:"... on IssueFieldSingleSelectValue"`
+							DateValue struct {
+								Value string
 							} `graphql:"... on IssueFieldDateValue"`
+							NumberValue struct {
+								Value float64
+							} `graphql:"... on IssueFieldNumberValue"`
 						}
 					} `graphql:"setIssueFieldValue(input: $input)"`
 				}{},

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -793,9 +793,18 @@ func GranularSetIssueFields(t translations.TranslationHelperFunc) inventory.Serv
 						URL    githubv4.String
 					}
 					IssueFieldValues []struct {
-						Field struct {
+						TextValue struct {
+							Value string
+						} `graphql:"... on IssueFieldTextValue"`
+						SingleSelectValue struct {
 							Name string
+						} `graphql:"... on IssueFieldSingleSelectValue"`
+						DateValue struct {
+							Value string
 						} `graphql:"... on IssueFieldDateValue"`
+						NumberValue struct {
+							Value float64
+						} `graphql:"... on IssueFieldNumberValue"`
 					}
 				} `graphql:"setIssueFieldValue(input: $input)"`
 			}

--- a/pkg/http/handler_test.go
+++ b/pkg/http/handler_test.go
@@ -639,33 +639,33 @@ func TestStaticConfigEnforcement(t *testing.T) {
 // and rejects requests with "application/json; charset=utf-8".
 func TestContentTypeHandling(t *testing.T) {
 	tests := []struct {
-		name                 string
-		contentType          string
+		name                   string
+		contentType            string
 		expectUnsupportedMedia bool
 	}{
 		{
-			name:                 "exact application/json is accepted",
-			contentType:          "application/json",
+			name:                   "exact application/json is accepted",
+			contentType:            "application/json",
 			expectUnsupportedMedia: false,
 		},
 		{
-			name:                 "application/json with charset=utf-8 should be accepted",
-			contentType:          "application/json; charset=utf-8",
+			name:                   "application/json with charset=utf-8 should be accepted",
+			contentType:            "application/json; charset=utf-8",
 			expectUnsupportedMedia: false,
 		},
 		{
-			name:                 "application/json with charset=UTF-8 should be accepted",
-			contentType:          "application/json; charset=UTF-8",
+			name:                   "application/json with charset=UTF-8 should be accepted",
+			contentType:            "application/json; charset=UTF-8",
 			expectUnsupportedMedia: false,
 		},
 		{
-			name:                 "completely wrong content type is rejected",
-			contentType:          "text/plain",
+			name:                   "completely wrong content type is rejected",
+			contentType:            "text/plain",
 			expectUnsupportedMedia: true,
 		},
 		{
-			name:                 "empty content type is rejected",
-			contentType:          "",
+			name:                   "empty content type is rejected",
+			contentType:            "",
 			expectUnsupportedMedia: true,
 		},
 	}


### PR DESCRIPTION
## Summary

Fix the `set_issue_fields` MCP tool's GraphQL mutation: calls failed with:

```
Field 'name' doesn't exist on type 'IssueFieldDateValue'
```

## Root Cause

The mutation response struct used a single inline fragment `... on IssueFieldDateValue` with a `Name` field, but `IssueFieldDateValue` doesn't have a `name` field — only `IssueFieldSingleSelectValue` does.

Since GraphQL validates the **entire document** (including response selection sets) before executing any operation, the invalid fragment caused GraphQL to reject the entire request. The mutation never fired at all — no fields were ever set, regardless of input.

## Fix

Replace the single broken inline fragment with correct fragments for all four `IssueFieldValue` union types:

- `IssueFieldTextValue` → `value`
- `IssueFieldSingleSelectValue` → `name`
- `IssueFieldDateValue` → `value`
- `IssueFieldNumberValue` → `value`

The response still uses `MinimalResponse` (issue ID + URL), so the additional fragments are purely for GraphQL validation correctness and future-proofing.

## Testing

- All existing unit tests pass
- Updated test mock to match the corrected mutation struct