### PR TITLE
fix(pull_requests): add author_association to MinimalPullRequest

### DIFF
--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -262,6 +262,7 @@ type MinimalPullRequest struct {
 	ClosedAt           string           `json:"closed_at,omitempty"`
 	MergedAt           string           `json:"merged_at,omitempty"`
 	Milestone          string           `json:"milestone,omitempty"`
+	AuthorAssociation  string           `json:"author_association,omitempty"`
 }
 
 // MinimalPRBranch is the trimmed output type for pull request branch references.
@@ -508,7 +509,8 @@ func convertToMinimalPullRequest(pr *github.PullRequest) MinimalPullRequest {
 		Deletions:      pr.GetDeletions(),
 		ChangedFiles:   pr.GetChangedFiles(),
 		Commits:        pr.GetCommits(),
-		Comments:       pr.GetComments(),
+		Comments:          pr.GetComments(),
+		AuthorAssociation: pr.GetAuthorAssociation(),
 	}
 
 	if pr.CreatedAt != nil {


### PR DESCRIPTION
## Summary
- Add `AuthorAssociation` field to `MinimalPullRequest` struct in REST API path
- Set field via `pr.GetAuthorAssociation()` in `convertToMinimalPullRequest()`
- Fixes REST path for `list_pull_requests` and `pull_request_read`

## Test plan
- [x] `go build ./...` passes
- [ ] Manual testing with REST API responses containing author_association

## Related
- Issue: github/github-mcp-server#2250
- PR #2265 fixed the GraphQL path (IssueFragment) but REST path was not addressed

🤖 Generated with [Claude Code](https://claude.ai/code)

Refs #2250
