### PR TITLE
feat(errors): improve rate limit error messages for AI agents

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -2,8 +2,10 @@ package errors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/google/go-github/v82/github"
@@ -159,6 +161,27 @@ func NewGitHubAPIErrorResponse(ctx context.Context, message string, resp *github
 	if ctx != nil {
 		_, _ = addGitHubAPIErrorToContext(ctx, apiErr) // Explicitly ignore error for graceful handling
 	}
+
+	var rateLimitErr *github.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		retryIn := time.Until(rateLimitErr.Rate.Reset.Time).Round(time.Second)
+		return utils.NewToolResultError(fmt.Sprintf(
+			"%s: GitHub API rate limit exceeded. Retry after %v.",
+			message, retryIn))
+	}
+
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) {
+		if abuseErr.RetryAfter != nil {
+			return utils.NewToolResultError(fmt.Sprintf(
+				"%s: GitHub secondary rate limit exceeded. Retry after %v.",
+				message, abuseErr.RetryAfter.Round(time.Second)))
+		}
+		return utils.NewToolResultError(fmt.Sprintf(
+			"%s: GitHub secondary rate limit exceeded. Wait before retrying.",
+			message))
+	}
+
 	return utils.NewToolResultErrorFromErr(message, err)
 }
 


### PR DESCRIPTION
## Summary

When the GitHub API returns a rate limit error, surface clear retry duration to the agent instead of burying it in raw HTTP strings.

- For `RateLimitError`: show "Retry after Xs" with exact reset time  
- For `AbuseRateLimitError`: show "Retry after Xs" when `RetryAfter` is set, otherwise show "Wait before retrying"

## Changes

Modified `NewGitHubAPIErrorResponse` in `pkg/errors/error.go` to detect rate limit error types using `errors.As` and return agent-friendly messages.

## Example output

Before:
```
search code: GET https://api.github.com/search/code: 403 API rate limit exceeded for user ID 12345. [rate reset in 47s]
```

After:
```
search code: GitHub API rate limit exceeded. Retry after 47s.
```

Fixes #2385