### PR TITLE
docs(search): improve search_code query description to prevent 422 errors

### DIFF
--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -173,7 +173,7 @@ func SearchCode(t translations.TranslationHelperFunc) inventory.ServerTool {
 		Properties: map[string]*jsonschema.Schema{
 			"query": {
 				Type:        "string",
-				Description: "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more.",
+				Description: "Search query using GitHub code search syntax. Qualifiers: repo:owner/repo, org:name, language:Go, path:src/*.js, path:/regex/, symbol:Name, content:term, is:archived|fork. Boolean: AND, OR, NOT, parentheses. Regex: surround with slashes e.g. /sparse.*index/. Glob in path: path:*.ts, path:/src/**/*.js. Examples: 'MyFunc language:go repo:owner/repo', 'symbol:WithContext language:go', '/GetAttributes|SetAttributes/ repo:owner/repo', '(Foo OR Bar) path:src repo:owner/repo'.",
 			},
 			"sort": {
 				Type:        "string",


### PR DESCRIPTION
## Summary

The previous `search_code` query description gave AI models insufficient guidance on GitHub code search syntax, leading agents to make common mistakes that result in 422 errors.

## Changes

Updated the `query` parameter description in `pkg/github/search.go` to explicitly document:

- **Qualifiers**: repo:, org:, language:, path:, path:/regex/, symbol:, content:, is:
- **Boolean operators**: AND, OR, NOT, parentheses
- **Regex syntax**: surround with slashes e.g. `/foo|bar/`
- **Glob patterns in path**: `path:*.ts`, `path:/src/**/*.js`

## Problem examples (from real agent sessions)

These queries all caused `422 ERROR_TYPE_QUERY_PARSING_FATAL`:
- `\\"foo\\|bar\\"` — used \\| for regex OR; correct: `/foo|bar/`
- `path:docs OR path:.github` — surprising precedence without parentheses
- `filename:*review*.md` — filename: is not valid; correct: `path:*review*.md`

## Fixes

Fixes #2390