### PR TITLE
fix(sanitize): preserve angle brackets inside code blocks and inline code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/yosida95/uritemplate/v3 v3.0.2
+	github.com/yuin/goldmark v1.8.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/sanitize/sanitize.go
+++ b/pkg/sanitize/sanitize.go
@@ -12,7 +12,14 @@ var policy *bluemonday.Policy
 var policyOnce sync.Once
 
 func Sanitize(input string) string {
-	return FilterHTMLTags(FilterCodeFenceMetadata(FilterInvisibleCharacters(input)))
+	cleaned := FilterCodeFenceMetadata(FilterInvisibleCharacters(input))
+	// Protect angle brackets inside code blocks and inline code spans
+	// from being stripped by the HTML sanitizer. bluemonday treats <int>,
+	// <T>, etc. as unknown HTML tags and removes them.
+	// See https://github.com/github/github-mcp-server/issues/2202
+	protected := protectCodeAngleBrackets(cleaned)
+	sanitized := FilterHTMLTags(protected)
+	return restoreCodeAngleBrackets(sanitized)
 }
 
 // FilterInvisibleCharacters removes invisible or control characters that should not appear
@@ -143,6 +150,157 @@ func isSafeCodeFenceToken(token string) bool {
 		return false
 	}
 	return true
+}
+
+// Sentinels used to protect angle brackets inside code from HTML sanitization.
+// These are chosen to be unlikely to appear in real content.
+const (
+	ltSentinel = "\x00LT\x00"
+	gtSentinel = "\x00GT\x00"
+)
+
+// protectCodeAngleBrackets replaces < and > inside fenced code blocks and
+// inline code spans with sentinels so bluemonday does not strip them as HTML.
+func protectCodeAngleBrackets(input string) string {
+	var b strings.Builder
+	b.Grow(len(input))
+
+	runes := []rune(input)
+	i := 0
+	n := len(runes)
+
+	for i < n {
+		// Fenced code block: ``` ... ```
+		if i+2 < n && runes[i] == '`' && runes[i+1] == '`' && runes[i+2] == '`' {
+			// Find the fence length
+			fenceStart := i
+			fenceLen := 0
+			for i < n && runes[i] == '`' {
+				fenceLen++
+				i++
+			}
+			// Write opening fence + rest of line (info string)
+			for range fenceLen {
+				b.WriteRune('`')
+			}
+			for i < n && runes[i] != '\n' {
+				b.WriteRune(runes[i])
+				i++
+			}
+			if i < n {
+				b.WriteRune(runes[i]) // newline
+				i++
+			}
+			// Inside fence: protect angle brackets until closing fence
+			for i < n {
+				// Check for closing fence
+				if runes[i] == '`' {
+					closeLen := 0
+					j := i
+					for j < n && runes[j] == '`' {
+						closeLen++
+						j++
+					}
+					if closeLen >= fenceLen {
+						for range closeLen {
+							b.WriteRune('`')
+						}
+						i = j
+						break
+					}
+				}
+				switch runes[i] {
+				case '<':
+					b.WriteString(ltSentinel)
+				case '>':
+					b.WriteString(gtSentinel)
+				default:
+					b.WriteRune(runes[i])
+				}
+				i++
+			}
+			_ = fenceStart
+			continue
+		}
+
+		// Inline code: `...`
+		if runes[i] == '`' {
+			// Count opening backticks
+			openLen := 0
+			j := i
+			for j < n && runes[j] == '`' {
+				openLen++
+				j++
+			}
+			// Don't treat ``` as inline code (handled above for fenced blocks)
+			if openLen >= 3 {
+				for range openLen {
+					b.WriteRune('`')
+				}
+				i = j
+				continue
+			}
+			// Find matching closing backticks
+			closeStart := -1
+			for k := j; k <= n-openLen; k++ {
+				match := true
+				for m := range openLen {
+					if runes[k+m] != '`' {
+						match = false
+						break
+					}
+				}
+				if match {
+					// Verify it's exactly openLen backticks (not more)
+					if k+openLen < n && runes[k+openLen] == '`' {
+						continue
+					}
+					closeStart = k
+					break
+				}
+			}
+			if closeStart == -1 {
+				// No closing backticks found; treat as literal
+				for range openLen {
+					b.WriteRune('`')
+				}
+				i = j
+				continue
+			}
+			// Write opening backticks
+			for range openLen {
+				b.WriteRune('`')
+			}
+			// Protect content
+			for i = j; i < closeStart; i++ {
+				switch runes[i] {
+				case '<':
+					b.WriteString(ltSentinel)
+				case '>':
+					b.WriteString(gtSentinel)
+				default:
+					b.WriteRune(runes[i])
+				}
+			}
+			// Write closing backticks
+			for range openLen {
+				b.WriteRune('`')
+			}
+			i = closeStart + openLen
+			continue
+		}
+
+		b.WriteRune(runes[i])
+		i++
+	}
+
+	return b.String()
+}
+
+// restoreCodeAngleBrackets converts sentinels back to angle brackets.
+func restoreCodeAngleBrackets(input string) string {
+	s := strings.ReplaceAll(input, ltSentinel, "<")
+	return strings.ReplaceAll(s, gtSentinel, ">")
 }
 
 func getPolicy() *bluemonday.Policy {

--- a/pkg/sanitize/sanitize.go
+++ b/pkg/sanitize/sanitize.go
@@ -1,16 +1,38 @@
+// Package sanitize provides functions to sanitize untrusted user content from
+// GitHub (issue titles, PR bodies, search results, etc.) before display.
+//
+// Threat model:
+// - Input source: untrusted GitHub content that may contain malicious HTML/JS
+// - Goal: strip HTML tags from prose without corrupting code samples
+// - Defense: bluemonday HTML sanitizer + angle bracket protection in code blocks
+//
+// The sanitizer preserves angle brackets inside code (fenced blocks, inline spans,
+// and indented blocks) because bluemonday treats <int>, <T>, etc. as unknown HTML
+// tags and removes them. This would corrupt generic type syntax and other code.
 package sanitize
 
 import (
+	"bytes"
 	"strings"
 	"sync"
 	"unicode"
 
 	"github.com/microcosm-cc/bluemonday"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 )
 
 var policy *bluemonday.Policy
 var policyOnce sync.Once
 
+// Sanitize removes HTML tags and invisible characters from untrusted input.
+//
+// Ordering invariant: FilterInvisibleCharacters must run before
+// protectCodeAngleBrackets to prevent sentinel collision attacks.
+// FilterInvisibleCharacters strips NUL bytes (0x00), so an attacker cannot
+// inject literal "\x00LT\x00script\x00GT\x00" strings that would bypass
+// FilterHTMLTags and get restored to <script> by restoreCodeAngleBrackets.
 func Sanitize(input string) string {
 	cleaned := FilterCodeFenceMetadata(FilterInvisibleCharacters(input))
 	// Protect angle brackets inside code blocks and inline code spans
@@ -24,6 +46,7 @@ func Sanitize(input string) string {
 
 // FilterInvisibleCharacters removes invisible or control characters that should not appear
 // in user-facing titles or bodies. This includes:
+// - NUL bytes: U+0000 (prevents sentinel collision in protectCodeAngleBrackets)
 // - Unicode tag characters: U+E0001, U+E0020–U+E007F
 // - BiDi control characters: U+202A–U+202E, U+2066–U+2069
 // - Hidden modifier characters: U+200B, U+200C, U+200E, U+200F, U+00AD, U+FEFF, U+180E, U+2060–U+2064
@@ -153,153 +176,75 @@ func isSafeCodeFenceToken(token string) bool {
 }
 
 // Sentinels used to protect angle brackets inside code from HTML sanitization.
-// These are chosen to be unlikely to appear in real content.
+// NUL bytes are stripped by FilterInvisibleCharacters before protectCodeAngleBrackets
+// runs, preventing sentinel collision attacks where an attacker injects literal
+// "\x00LT\x00" strings to bypass FilterHTMLTags.
 const (
 	ltSentinel = "\x00LT\x00"
 	gtSentinel = "\x00GT\x00"
 )
 
-// protectCodeAngleBrackets replaces < and > inside fenced code blocks and
-// inline code spans with sentinels so bluemonday does not strip them as HTML.
+// protectCodeAngleBrackets replaces < and > inside code blocks and inline code
+// spans with sentinels so bluemonday does not strip them as HTML.
+//
+// Uses goldmark's CommonMark parser to identify code regions. This correctly
+// handles fenced blocks (```), inline spans (`), and indented (4-space) blocks.
 func protectCodeAngleBrackets(input string) string {
-	var b strings.Builder
-	b.Grow(len(input))
+	src := []byte(input)
+	doc := goldmark.DefaultParser().Parse(text.NewReader(src))
 
-	runes := []rune(input)
-	i := 0
-	n := len(runes)
+	type span struct{ start, stop int }
+	var spans []span
 
-	for i < n {
-		// Fenced code block: ``` ... ```
-		if i+2 < n && runes[i] == '`' && runes[i+1] == '`' && runes[i+2] == '`' {
-			// Find the fence length
-			fenceStart := i
-			fenceLen := 0
-			for i < n && runes[i] == '`' {
-				fenceLen++
-				i++
-			}
-			// Write opening fence + rest of line (info string)
-			for range fenceLen {
-				b.WriteRune('`')
-			}
-			for i < n && runes[i] != '\n' {
-				b.WriteRune(runes[i])
-				i++
-			}
-			if i < n {
-				b.WriteRune(runes[i]) // newline
-				i++
-			}
-			// Inside fence: protect angle brackets until closing fence.
-			// NOTE: CommonMark requires the closing fence to be on its own line
-			// with no info string. This implementation is more permissive: any
-			// run of >= fenceLen backticks ends the block, even mid-line. This
-			// is a soft-fail (some angle brackets may be unprotected) rather
-			// than a security issue.
-			for i < n {
-				// Check for closing fence
-				if runes[i] == '`' {
-					closeLen := 0
-					j := i
-					for j < n && runes[j] == '`' {
-						closeLen++
-						j++
-					}
-					if closeLen >= fenceLen {
-						for range closeLen {
-							b.WriteRune('`')
-						}
-						i = j
-						break
-					}
-				}
-				switch runes[i] {
-				case '<':
-					b.WriteString(ltSentinel)
-				case '>':
-					b.WriteString(gtSentinel)
-				default:
-					b.WriteRune(runes[i])
-				}
-				i++
-			}
-			_ = fenceStart
-			continue
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
 		}
-
-		// Inline code: `...`
-		if runes[i] == '`' {
-			// Count opening backticks
-			openLen := 0
-			j := i
-			for j < n && runes[j] == '`' {
-				openLen++
-				j++
+		switch n.Kind() {
+		case ast.KindFencedCodeBlock, ast.KindCodeBlock:
+			// Fenced (```) and indented (4-space) code blocks
+			lines := n.Lines()
+			for i := range lines.Len() {
+				seg := lines.At(i)
+				spans = append(spans, span{seg.Start, seg.Stop})
 			}
-			// Don't treat ``` as inline code (handled above for fenced blocks)
-			if openLen >= 3 {
-				for range openLen {
-					b.WriteRune('`')
-				}
-				i = j
-				continue
-			}
-			// Find matching closing backticks
-			closeStart := -1
-			for k := j; k <= n-openLen; k++ {
-				match := true
-				for m := range openLen {
-					if runes[k+m] != '`' {
-						match = false
-						break
-					}
-				}
-				if match {
-					// Verify it's exactly openLen backticks (not more)
-					if k+openLen < n && runes[k+openLen] == '`' {
-						continue
-					}
-					closeStart = k
-					break
+		case ast.KindCodeSpan:
+			// Inline code: `...`
+			for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+				if t, ok := c.(*ast.Text); ok {
+					seg := t.Segment
+					spans = append(spans, span{seg.Start, seg.Stop})
 				}
 			}
-			if closeStart == -1 {
-				// No closing backticks found; treat as literal
-				for range openLen {
-					b.WriteRune('`')
-				}
-				i = j
-				continue
-			}
-			// Write opening backticks
-			for range openLen {
-				b.WriteRune('`')
-			}
-			// Protect content
-			for i = j; i < closeStart; i++ {
-				switch runes[i] {
-				case '<':
-					b.WriteString(ltSentinel)
-				case '>':
-					b.WriteString(gtSentinel)
-				default:
-					b.WriteRune(runes[i])
-				}
-			}
-			// Write closing backticks
-			for range openLen {
-				b.WriteRune('`')
-			}
-			i = closeStart + openLen
-			continue
 		}
+		return ast.WalkContinue, nil
+	})
 
-		b.WriteRune(runes[i])
-		i++
+	if len(spans) == 0 {
+		return input
 	}
 
-	return b.String()
+	var out bytes.Buffer
+	out.Grow(len(src))
+	cursor := 0
+	for _, s := range spans {
+		// Write text before this code span
+		out.Write(src[cursor:s.start])
+		// Protect angle brackets in the code span
+		for _, b := range src[s.start:s.stop] {
+			switch b {
+			case '<':
+				out.WriteString(ltSentinel)
+			case '>':
+				out.WriteString(gtSentinel)
+			default:
+				out.WriteByte(b)
+			}
+		}
+		cursor = s.stop
+	}
+	out.Write(src[cursor:])
+	return out.String()
 }
 
 // restoreCodeAngleBrackets converts sentinels back to angle brackets.

--- a/pkg/sanitize/sanitize.go
+++ b/pkg/sanitize/sanitize.go
@@ -191,7 +191,12 @@ func protectCodeAngleBrackets(input string) string {
 				b.WriteRune(runes[i]) // newline
 				i++
 			}
-			// Inside fence: protect angle brackets until closing fence
+			// Inside fence: protect angle brackets until closing fence.
+			// NOTE: CommonMark requires the closing fence to be on its own line
+			// with no info string. This implementation is more permissive: any
+			// run of >= fenceLen backticks ends the block, even mid-line. This
+			// is a soft-fail (some angle brackets may be unprotected) rather
+			// than a security issue.
 			for i < n {
 				// Check for closing fence
 				if runes[i] == '`' {
@@ -333,7 +338,8 @@ func getPolicy() *bluemonday.Policy {
 
 func shouldRemoveRune(r rune) bool {
 	switch r {
-	case 0x200B, // ZERO WIDTH SPACE
+	case 0x0000, // NUL — stripped to prevent sentinel collision in protectCodeAngleBrackets
+		0x200B, // ZERO WIDTH SPACE
 		0x200C, // ZERO WIDTH NON-JOINER
 		0x200E, // LEFT-TO-RIGHT MARK
 		0x200F, // RIGHT-TO-LEFT MARK

--- a/pkg/sanitize/sanitize_test.go
+++ b/pkg/sanitize/sanitize_test.go
@@ -300,3 +300,49 @@ func TestSanitizeRemovesInvisibleCodeFenceMetadata(t *testing.T) {
 	result := Sanitize(input)
 	assert.Equal(t, expected, result)
 }
+
+func TestSanitizePreservesAngleBracketsInCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "fenced code block with angle brackets",
+			input:    "```\nlet ptr: mut_raw_ptr<int> = raw_new int;\n```",
+			expected: "```\nlet ptr: mut_raw_ptr<int> = raw_new int;\n```",
+		},
+		{
+			name:     "inline code with angle brackets",
+			input:    "Use `Vec<String>` for collections.",
+			expected: "Use `Vec<String>` for collections.",
+		},
+		{
+			name:     "angle brackets outside code are sanitized",
+			input:    "This has <script>alert('xss')</script> in it.",
+			expected: "This has  in it.",
+		},
+		{
+			name:     "fenced code block with generic types",
+			input:    "Example:\n```go\nfunc Foo[T comparable](x T) {}\n```\nDone.",
+			expected: "Example:\n```go\nfunc Foo[T comparable](x T) {}\n```\nDone.",
+		},
+		{
+			name:     "multiple inline code spans with angle brackets",
+			input:    "Compare `Map<K, V>` and `Set<T>`.",
+			expected: "Compare `Map<K, V>` and `Set<T>`.",
+		},
+		{
+			name:     "no code blocks passes through",
+			input:    "No code here, just text.",
+			expected: "No code here, just text.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Sanitize(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/sanitize/sanitize_test.go
+++ b/pkg/sanitize/sanitize_test.go
@@ -348,6 +348,11 @@ func TestSanitizePreservesAngleBracketsInCodeBlocks(t *testing.T) {
 			input:    "```\nfunc Foo\x00[T any]()\n```",
 			expected: "```\nfunc Foo[T any]()\n```",
 		},
+		{
+			name:     "indented code block with angle brackets",
+			input:    "Text\n\n    let x: Vec<u8> = vec![];\n\nMore text",
+			expected: "Text\n\n    let x: Vec<u8> = vec![];\n\nMore text",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sanitize/sanitize_test.go
+++ b/pkg/sanitize/sanitize_test.go
@@ -129,6 +129,7 @@ func TestShouldRemoveRune(t *testing.T) {
 		expected bool
 	}{
 		// Individual characters that should be removed
+		{name: "NUL byte", rune: 0x0000, expected: true},
 		{name: "zero width space", rune: 0x200B, expected: true},
 		{name: "zero width non-joiner", rune: 0x200C, expected: true},
 		{name: "left-to-right mark", rune: 0x200E, expected: true},
@@ -336,6 +337,16 @@ func TestSanitizePreservesAngleBracketsInCodeBlocks(t *testing.T) {
 			name:     "no code blocks passes through",
 			input:    "No code here, just text.",
 			expected: "No code here, just text.",
+		},
+		{
+			name:     "sentinel collision does not bypass sanitizer",
+			input:    "\x00LT\x00script\x00GT\x00alert(1)\x00LT\x00/script\x00GT\x00",
+			expected: "LTscriptGTalert(1)LT/scriptGT", // NUL bytes stripped; sentinels don't match; no <script> injected
+		},
+		{
+			name:     "NUL bytes stripped from input with code blocks",
+			input:    "```\nfunc Foo\x00[T any]()\n```",
+			expected: "```\nfunc Foo[T any]()\n```",
 		},
 	}
 


### PR DESCRIPTION
## Description

`bluemonday.StrictPolicy()` treats angle brackets inside markdown code blocks and inline code spans as HTML tags and strips them. This causes content like `mut_raw_ptr<int>` in issue/PR bodies to become `mut_raw_ptr` when read through MCP endpoints.

### Before

```
let ptr: mut_raw_ptr<int> = raw_new int;
```
Agent sees: `let ptr: mut_raw_ptr = raw_new int;`

### After

Agent sees: `let ptr: mut_raw_ptr<int> = raw_new int;`

## Root cause

`FilterHTMLTags` calls `bluemonday.Sanitize()` on the entire markdown body without distinguishing code from prose. Bluemonday treats `<int>`, `<T>`, `<String>`, etc. as unrecognized HTML tags and removes them.

## Fix

Before HTML sanitization, replace `<` and `>` inside fenced code blocks (` ``` `) and inline code spans (`` ` ``) with null-byte sentinels that bluemonday will not interpret as HTML. After sanitization, restore the sentinels to angle brackets.

This preserves XSS protection for angle brackets in prose (e.g. `<script>` is still stripped) while keeping angle brackets inside code intact.

## Testing

Added 6 test cases covering:
- Fenced code blocks with angle brackets (the reported bug)
- Inline code with generic types (`Vec<String>`)
- Angle brackets outside code still sanitized (XSS protection preserved)
- Multiple inline code spans
- Fenced code with language info string

Fixes #2202