### PR TITLE
Prevent inputs param from being stripped from actions_run_trigger tool schema

### DIFF
--- a/pkg/github/__toolsnaps__/actions_run_trigger.snap
+++ b/pkg/github/__toolsnaps__/actions_run_trigger.snap
@@ -8,6 +8,7 @@
     "properties": {
       "inputs": {
         "description": "Inputs the workflow accepts. Only used for 'run_workflow' method.",
+        "properties": {},
         "type": "object"
       },
       "method": {

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -544,6 +544,7 @@ func ActionsRunTrigger(t translations.TranslationHelperFunc) inventory.ServerToo
 					"inputs": {
 						Type:        "object",
 						Description: "Inputs the workflow accepts. Only used for 'run_workflow' method.",
+						Properties:  map[string]*jsonschema.Schema{},
 					},
 					"run_id": {
 						Type:        "number",
@@ -574,11 +575,9 @@ func ActionsRunTrigger(t translations.TranslationHelperFunc) inventory.ServerToo
 			runID, _ := OptionalIntParam(args, "run_id")
 
 			// Get optional inputs parameter
-			var inputs map[string]any
-			if requestInputs, ok := args["inputs"]; ok {
-				if inputsMap, ok := requestInputs.(map[string]any); ok {
-					inputs = inputsMap
-				}
+			inputs, err := OptionalParam[map[string]any](args, "inputs")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
 			// Validate required parameters based on action type

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -377,6 +377,37 @@ func Test_ActionsRunTrigger_RunWorkflow(t *testing.T) {
 			expectError:    true,
 			expectedErrMsg: "ref is required for run_workflow action",
 		},
+		{
+			name: "successful workflow run with inputs",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PostReposActionsWorkflowsDispatchesByOwnerByRepoByWorkflowID: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}),
+			}),
+			requestArgs: map[string]any{
+				"method":      "run_workflow",
+				"owner":       "owner",
+				"repo":        "repo",
+				"workflow_id": "12345",
+				"ref":         "main",
+				"inputs":      map[string]any{"FIELD1": "value1", "FIELD2": "value2"},
+			},
+			expectError: false,
+		},
+		{
+			name:         "invalid inputs type returns error",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{}),
+			requestArgs: map[string]any{
+				"method":      "run_workflow",
+				"owner":       "owner",
+				"repo":        "repo",
+				"workflow_id": "12345",
+				"ref":         "main",
+				"inputs":      "not a map",
+			},
+			expectError:    true,
+			expectedErrMsg: "parameter inputs is not of type map[string]interface {}, is string",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Adds a `properties` field to the `inputs` param schema in `actions_run_trigger` so it is not dropped from the tool schema due to OAI strict mode schema requirements. Also replaces a silent type assertion with `OptionalParam` for proper error handling on malformed inputs.

## Why

Fixes #1877 

The `inputs` parameter was defined as `type: "object"` with no `properties` field, and OAI strict mode requires object types to include a `properties` field. Without it, the parameter is not visible to GPT models.

## What changed

- Added `Properties: map[string]*jsonschema.Schema{}` to the `inputs` param schema
- Replaced manual type assertion for `inputs` with `OptionalParam[map[string]any]`, which returns an error on type mismatch instead of silently dropping the value

## MCP impact

- [ ] No tool or API changes
- [x] Tool schema or behavior changed - `inputs` param now serialises with an empty `properties` field
- [ ] New tool added

## Prompts tested (tool changes only)

- "Run the X workflow in OWNER/REPO on Y branch with these inputs: FIELD1=value1, ..."
- "Trigger the X workflow in OWNER/REPO, ref: Y. Pass these workflow inputs: FIELD1=value1, ..."

All testing was done against a mock workflow with optional params - verified across multiple models.

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
