### PR TITLE
docs(codex): include PAT binding in install guide

### DIFF
--- a/docs/installation-guides/install-codex.md
+++ b/docs/installation-guides/install-codex.md
@@ -21,8 +21,10 @@ bearer_token_env_var = "GITHUB_PAT_TOKEN"
 You can also add it via the Codex CLI:
 
 ```cli
-codex mcp add github --url https://api.githubcopilot.com/mcp/  
+codex mcp add github --url https://api.githubcopilot.com/mcp/ --bearer-token-env-var GITHUB_PAT_TOKEN
 ```
+
+Using `codex mcp add ... --url ...` without `--bearer-token-env-var` only stores the remote server URL. For the hosted GitHub MCP server, you also need to bind a PAT environment variable so Codex can send the `Authorization` header.
 
 <details>
 <summary><b>Storing Your PAT Securely</b></summary>


### PR DESCRIPTION
## Summary
- update the Codex CLI example to include `--bearer-token-env-var GITHUB_PAT_TOKEN`
- explain that `codex mcp add ... --url ...` alone only stores the remote URL
- keep the fix scoped to `install-codex.md`

## Verification
- reproduced the issue locally before the docs change
- `git diff --check`
- reviewed the final rendered section in `docs/installation-guides/install-codex.md`

Closes #2421.
