### PR TITLE
Add Xcode installation guide for Codex and Claude Agent

### DIFF
--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -13,6 +13,7 @@ This directory contains detailed installation instructions for the GitHub MCP Se
 - **[OpenAI Codex](install-codex.md)** - Installation guide for OpenAI Codex
 - **[Roo Code](install-roo-code.md)** - Installation guide for Roo Code
 - **[Windsurf](install-windsurf.md)** - Installation guide for Windsurf IDE
+- **[Xcode (Codex & Claude Agent)](install-xcode.md)** - Installation guide for Codex and Claude Agent within Xcode
 
 ## Support by Host Application
 
@@ -32,6 +33,8 @@ This directory contains detailed installation instructions for the GitHub MCP Se
 | Windsurf | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Copilot in Xcode | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: Copilot for Xcode 0.41.0+ | Easy |
 | Copilot in Eclipse | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: Eclipse Plug-in for Copilot 0.10.0+ | Easy |
+| Xcode (Codex) | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker (full path required), GitHub PAT<br>Remote: GitHub PAT + env var | Easy |
+| Xcode (Claude Agent) | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker (full path required), GitHub PAT<br>Remote: GitHub PAT | Easy |
 
 **Legend:**
 - ✅ = Fully supported

--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -33,7 +33,7 @@ This directory contains detailed installation instructions for the GitHub MCP Se
 | Windsurf | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Copilot in Xcode | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: Copilot for Xcode 0.41.0+ | Easy |
 | Copilot in Eclipse | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: Eclipse Plug-in for Copilot 0.10.0+ | Easy |
-| Xcode (Codex) | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker (full path required), GitHub PAT<br>Remote: GitHub PAT + env var | Easy |
+| Xcode (Codex) | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker (full path required), GitHub PAT<br>Remote: GitHub PAT via `GITHUB_PAT_TOKEN` env var (`bearer_token_env_var`) | Easy |
 | Xcode (Claude Agent) | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker (full path required), GitHub PAT<br>Remote: GitHub PAT | Easy |
 
 **Legend:**

--- a/docs/installation-guides/install-claude.md
+++ b/docs/installation-guides/install-claude.md
@@ -164,7 +164,75 @@ Add this codeblock to your `claude_desktop_config.json`:
 
 ---
 
-## Troubleshooting
+## Xcode (Claude Agent)
+
+Xcode's Claude Agent uses the same `.claude.json` configuration format as the Claude Code CLI, but reads it from an Xcode-specific directory rather than the global config location.
+
+### Configuration File Location
+
+```
+~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/.claude.json
+```
+
+> Configurations placed here only affect Claude Agent when launched from Xcode. See [Apple's documentation](https://developer.apple.com/documentation/xcode/setting-up-coding-intelligence#Customize-the-Claude-Agent-and-Codex-environments) for more details.
+
+### Remote Server Setup (Recommended)
+
+Run the following command in Terminal to add the remote GitHub MCP server:
+
+```bash
+claude mcp add-json github '{"type":"http","url":"https://api.githubcopilot.com/mcp/","headers":{"Authorization":"Bearer YOUR_GITHUB_PAT"}}' --config ~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/.claude.json
+```
+
+Or open the file in a text editor and add the `mcpServers` block manually:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+### Local Server Setup (Docker)
+
+> **macOS note**: Xcode runs with a minimal `PATH` that typically excludes `/usr/local/bin` (Intel) and `/opt/homebrew/bin` (Apple Silicon). Use the full path to `docker` to ensure it can be found. Run `which docker` in Terminal to find the correct path on your system.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "/usr/local/bin/docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+### Setup Steps
+1. Create or open `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/.claude.json`
+2. Add the configuration block above
+3. Replace `YOUR_GITHUB_PAT` with your actual token
+4. Restart Xcode
+
+---
+
 
 **Authentication Failed:**
 - Verify PAT has `repo` scope

--- a/docs/installation-guides/install-xcode.md
+++ b/docs/installation-guides/install-xcode.md
@@ -1,0 +1,43 @@
+# Install GitHub MCP Server in Xcode
+
+Xcode currently supports two built-in coding agents: **Codex** (powered by OpenAI) and **Claude Agent** (powered by Anthropic). Follow the standard installation guide for each agent, with one important difference: Xcode uses its own isolated configuration directories for each agent, separate from your global config.
+
+> Configurations placed in these directories only affect agents when launched from Xcode. See [Apple's documentation](https://developer.apple.com/documentation/xcode/setting-up-coding-intelligence#Customize-the-Claude-Agent-and-Codex-environments) for more details.
+
+## Configuration Directories
+
+| Agent | Configuration Directory |
+|-------|------------------------|
+| Codex | `~/Library/Developer/Xcode/CodingAssistant/codex/` |
+| Claude Agent | `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/` |
+
+Place your MCP server configuration in the relevant directory above rather than the default location used by the standalone CLI.
+
+## Setup Guides
+
+- **[Codex](install-codex.md)** — configure `config.toml` inside `~/Library/Developer/Xcode/CodingAssistant/codex/`
+- **[Claude Agent](install-claude.md#claude-desktop)** — configure `.claude.json` inside `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/`
+
+## macOS Path Note
+
+Xcode runs with a minimal `PATH` that typically excludes `/usr/local/bin`. If you are using a local STDIO server (e.g. Docker or a pre-built binary), use the **full path** to the command in your config:
+
+```
+/usr/local/bin/docker
+/usr/local/bin/github-mcp-server
+```
+
+## Troubleshooting
+
+| Issue | Possible Cause | Fix |
+|-------|----------------|-----|
+| Tools not loading | Config placed in wrong directory | Ensure config is in the Xcode-specific path above, not `~/.codex/` or `~/.claude.json` |
+| Command not found (STDIO) | Xcode's PATH excludes `/usr/local/bin` | Use the full path to the command |
+| Docker not found | Docker not running | Start Docker Desktop and restart Xcode |
+| Authentication failed | Invalid or expired PAT | Regenerate PAT and update config |
+
+## References
+
+- [Apple Developer Documentation — Setting up coding intelligence](https://developer.apple.com/documentation/xcode/setting-up-coding-intelligence#Customize-the-Claude-Agent-and-Codex-environments)
+- [Codex MCP documentation](https://developers.openai.com/codex/mcp)
+- Main project README: [Advanced configuration options](../../README.md)

--- a/docs/installation-guides/install-xcode.md
+++ b/docs/installation-guides/install-xcode.md
@@ -16,23 +16,25 @@ Place your MCP server configuration in the relevant directory above rather than 
 ## Setup Guides
 
 - **[Codex](install-codex.md)** — configure `config.toml` inside `~/Library/Developer/Xcode/CodingAssistant/codex/`
-- **[Claude Agent](install-claude.md#claude-desktop)** — configure `.claude.json` inside `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/`
+- **[Claude Agent](install-claude.md#xcode-claude-agent)** — configure `.claude.json` inside `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig/`
 
 ## macOS Path Note
 
-Xcode runs with a minimal `PATH` that typically excludes `/usr/local/bin`. If you are using a local STDIO server (e.g. Docker or a pre-built binary), use the **full path** to the command in your config:
+Xcode runs with a minimal `PATH` that typically excludes common binary locations. If you are using a local STDIO server (e.g. Docker or a pre-built binary), use the **full path** to the command in your config. Run `which docker` (or `which github-mcp-server`) in Terminal to find the correct path on your system. Common locations:
 
-```
-/usr/local/bin/docker
-/usr/local/bin/github-mcp-server
-```
+| Installation | Typical path |
+|---|---|
+| Docker (Intel Mac) | `/usr/local/bin/docker` |
+| Docker (Apple Silicon) | `/usr/local/bin/docker` |
+| Homebrew (Intel Mac) | `/usr/local/bin/` |
+| Homebrew (Apple Silicon) | `/opt/homebrew/bin/` |
 
 ## Troubleshooting
 
 | Issue | Possible Cause | Fix |
 |-------|----------------|-----|
 | Tools not loading | Config placed in wrong directory | Ensure config is in the Xcode-specific path above, not `~/.codex/` or `~/.claude.json` |
-| Command not found (STDIO) | Xcode's PATH excludes `/usr/local/bin` | Use the full path to the command |
+| Command not found (STDIO) | Xcode's PATH excludes binary location | Use the full path (e.g. `/usr/local/bin/docker` or `/opt/homebrew/bin/docker`); run `which docker` in Terminal to confirm |
 | Docker not found | Docker not running | Start Docker Desktop and restart Xcode |
 | Authentication failed | Invalid or expired PAT | Regenerate PAT and update config |
 


### PR DESCRIPTION
## Summary
 Adds a new `install-xcode.md` installation guide covering how to add the GitHub MCP server to Xcode's built-in coding agents (Codex and Claude Agent).
 
 ## Why
 There was no documentation for adding the GitHub MCP server to Xcode's native coding agents, making setup unclear for users. This addresses the request raised in #2120.
 
 Fixes #2120
 
 ## What changed
 - Added `docs/installation-guides/install-xcode.md` — a focused guide explaining Xcode's agent-specific config directories, linking to existing `install-codex.md` and `install-claude.md` for setup steps, and noting the macOS PATH requirement for local STDIO servers
 - Updated `docs/installation-guides/README.md` — added `install-xcode.md` to the guides list and updated the support table to show both Xcode (Codex) and Xcode (Claude Agent) with local and remote support
 
 ## MCP impact
 - [x] No tool or API changes
 
 ## Prompts tested (tool changes only)
 - N/A — documentation only
 
 ## Security / limits
 - [x] No security or limits impact
 
 ## Tool renaming
 - [x] I am not renaming tools as part of this PR
 
 ## Lint & tests
 - [ ] Linted locally with `./script/lint`
 - [ ] Tested locally with `./script/test`
 
 ## Docs
 - [x] Updated (README / docs / examples)