### PR TITLE
improve search_code query parameter description (fixes #2390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1276,7 +1276,7 @@ The following sets of tools are available:
   - `order`: Sort order for results (string, optional)
   - `page`: Page number for pagination (min 1) (number, optional)
   - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
-  - `query`: Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more. (string, required)
+  - `query`: Search query using GitHub code search syntax. Qualifiers: repo:owner/repo, org:name, language:Go, path:src/*.js, path:/regex/, symbol:Name, content:term, is:archived|fork. Boolean: AND, OR, NOT, parentheses. Regex: surround with slashes e.g. /sparse.*index/. Glob in path: path:*.ts, path:/src/**/*.js. Examples: 'MyFunc language:go repo:owner/repo', 'symbol:WithContext language:go', '/GetAttributes|SetAttributes/ repo:owner/repo', '(Foo OR Bar) path:src repo:owner/repo'. (string, required)
   - `sort`: Sort field ('indexed' only) (string, optional)
 
 - **search_repositories** - Search repositories

--- a/pkg/github/__toolsnaps__/search_code.snap
+++ b/pkg/github/__toolsnaps__/search_code.snap
@@ -26,7 +26,7 @@
         "type": "number"
       },
       "query": {
-        "description": "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more.",
+        "description": "Search query using GitHub code search syntax. Qualifiers: repo:owner/repo, org:name, language:Go, path:src/*.js, path:/regex/, symbol:Name, content:term, is:archived|fork. Boolean: AND, OR, NOT, parentheses. Regex: surround with slashes e.g. /sparse.*index/. Glob in path: path:*.ts, path:/src/**/*.js. Examples: 'MyFunc language:go repo:owner/repo', 'symbol:WithContext language:go', '/GetAttributes|SetAttributes/ repo:owner/repo', '(Foo OR Bar) path:src repo:owner/repo'.",
         "type": "string"
       },
       "sort": {

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -173,7 +173,7 @@ func SearchCode(t translations.TranslationHelperFunc) inventory.ServerTool {
 		Properties: map[string]*jsonschema.Schema{
 			"query": {
 				Type:        "string",
-				Description: "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more.",
+				Description: "Search query using GitHub code search syntax. Qualifiers: repo:owner/repo, org:name, language:Go, path:src/*.js, path:/regex/, symbol:Name, content:term, is:archived|fork. Boolean: AND, OR, NOT, parentheses. Regex: surround with slashes e.g. /sparse.*index/. Glob in path: path:*.ts, path:/src/**/*.js. Examples: 'MyFunc language:go repo:owner/repo', 'symbol:WithContext language:go', '/GetAttributes|SetAttributes/ repo:owner/repo', '(Foo OR Bar) path:src repo:owner/repo'.",
 			},
 			"sort": {
 				Type:        "string",


### PR DESCRIPTION
## Summary

Fixes #2390.

The current `query` parameter description for the `search_code` tool gives the model very little useful guidance on GitHub code search syntax, which (per analysis across thousands of agent sessions in #2390) leads to repeated `422 ERROR_TYPE_QUERY_PARSING_FATAL` responses from agents that guess at plausible-looking but invalid syntax — for example:

- `\"foo\\|bar\"` instead of regex `/foo|bar/`
- `filename:*review*.md` instead of `path:*review*.md`
- `path:docs OR path:.github` without parentheses (surprising precedence)

This PR replaces the description with one that explicitly enumerates the qualifiers, boolean operators, regex form (slashes), and path globs, plus realistic examples covering each. The new wording is the one suggested by the issue author.

### Before

> Search query using GitHub's powerful code search syntax. Examples: `content:Skill language:Java org:github`, `NOT is:archived language:Python OR language:go`, `repo:github/github-mcp-server`. Supports exact matching, language filters, path filters, and more.

### After

> Search query using GitHub code search syntax. Qualifiers: repo:owner/repo, org:name, language:Go, path:src/*.js, path:/regex/, symbol:Name, content:term, is:archived|fork. Boolean: AND, OR, NOT, parentheses. Regex: surround with slashes e.g. /sparse.*index/. Glob in path: path:*.ts, path:/src/**/*.js. Examples: 'MyFunc language:go repo:owner/repo', 'symbol:WithContext language:go', '/GetAttributes|SetAttributes/ repo:owner/repo', '(Foo OR Bar) path:src repo:owner/repo'.

## Files changed (3 files / 3 lines)

- `pkg/github/search.go` — the description string
- `pkg/github/__toolsnaps__/search_code.snap` — regenerated via `UPDATE_TOOLSNAPS=true go test ./pkg/github -run Test_SearchCode`
- `README.md` — regenerated via `go run ./cmd/github-mcp-server generate-docs`

## Validation

- `Test_SearchCode` (and all subtests) pass
- `go test ./...` passes for all 22 packages
- Toolsnap diff is exactly the description string change — nothing else
- README diff is exactly the description string change — nothing else

Note: I was unable to run `script/lint` locally (no `golangci-lint` available in my environment) or `-race` (no CGO toolchain). CI should validate both. Happy to iterate if it surfaces anything.