### PR TITLE
Add ifc label for get_file_contents tool

### DIFF
--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/octicons"
 	"github.com/github/github-mcp-server/pkg/scopes"
@@ -681,6 +682,17 @@ func FetchRepoCollaborators(ctx context.Context, client *github.Client, owner, r
 	return logins, nil
 }
 
+// FetchRepoIsPrivate returns the visibility of a repository. It is a thin
+// wrapper around the GitHub Repositories.Get endpoint provided as a shared
+// helper for IFC label computation across tools.
+func FetchRepoIsPrivate(ctx context.Context, client *github.Client, owner, repo string) (bool, error) {
+	r, _, err := client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return false, err
+	}
+	return r.GetPrivate(), nil
+}
+
 // GetFileContents creates a tool to get the contents of a file or directory from a GitHub repository.
 func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool {
 	return NewTool(
@@ -753,6 +765,42 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 				return utils.NewToolResultError("failed to get GitHub client"), nil, nil
 			}
 
+			// attachIFC adds the IFC label to a successful tool result when
+			// InsidersMode is enabled. The visibility and (for private
+			// repositories) collaborators lookups are performed lazily on
+			// first use and are best-effort: if they fail we still attach
+			// the label, falling back to the repository owner so the reader
+			// set is never empty for a private repo.
+			var (
+				ifcLabelLoaded bool
+				ifcIsPrivate   bool
+				ifcReaders     []string
+			)
+			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
+				if r == nil || r.IsError || !deps.GetFlags(ctx).InsidersMode {
+					return r
+				}
+				if !ifcLabelLoaded {
+					if isPrivate, err := FetchRepoIsPrivate(ctx, client, owner, repo); err == nil {
+						ifcIsPrivate = isPrivate
+					}
+					if ifcIsPrivate {
+						if collaborators, err := FetchRepoCollaborators(ctx, client, owner, repo); err == nil {
+							ifcReaders = collaborators
+						}
+						if len(ifcReaders) == 0 {
+							ifcReaders = []string{owner}
+						}
+					}
+					ifcLabelLoaded = true
+				}
+				if r.Meta == nil {
+					r.Meta = mcp.Meta{}
+				}
+				r.Meta["ifc"] = ifc.LabelGetFileContents(ifcIsPrivate, ifcReaders)
+				return r
+			}
+
 			rawOpts, fallbackUsed, err := resolveGitReference(ctx, client, owner, repo, ref, sha)
 			if err != nil {
 				return utils.NewToolResultError(fmt.Sprintf("failed to resolve git reference: %s", err)), nil, nil
@@ -774,7 +822,8 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 			// The path does not point to a file or directory.
 			// Instead let's try to find it in the Git Tree by matching the end of the path.
 			if err != nil || (fileContent == nil && dirContent == nil) {
-				return matchFiles(ctx, client, owner, repo, ref, path, rawOpts, 0)
+				res, data, err := matchFiles(ctx, client, owner, repo, ref, path, rawOpts, 0)
+				return attachIFC(res), data, err
 			}
 
 			if fileContent != nil && fileContent.SHA != nil {
@@ -804,7 +853,7 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 						Text:     "",
 						MIMEType: "text/plain",
 					}
-					return utils.NewToolResultResource(fmt.Sprintf("successfully downloaded empty file (SHA: %s)%s", fileSHA, successNote), result), nil, nil
+					return attachIFC(utils.NewToolResultResource(fmt.Sprintf("successfully downloaded empty file (SHA: %s)%s", fileSHA, successNote), result)), nil, nil
 				}
 
 				// For files >= 1MB, return a ResourceLink instead of content
@@ -817,10 +866,10 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 						Title: fmt.Sprintf("File: %s", path),
 						Size:  &size,
 					}
-					return utils.NewToolResultResourceLink(
+					return attachIFC(utils.NewToolResultResourceLink(
 						fmt.Sprintf("File %s is too large to display (%d bytes). Use the download URL to fetch the content: %s (SHA: %s)%s",
 							path, fileSize, fileContent.GetDownloadURL(), fileSHA, successNote),
-						resourceLink), nil, nil
+						resourceLink)), nil, nil
 				}
 
 				// For files < 1MB, get content directly from Contents API
@@ -848,7 +897,7 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 						Text:     content,
 						MIMEType: contentType,
 					}
-					return utils.NewToolResultResource(fmt.Sprintf("successfully downloaded text file (SHA: %s)%s", fileSHA, successNote), result), nil, nil
+					return attachIFC(utils.NewToolResultResource(fmt.Sprintf("successfully downloaded text file (SHA: %s)%s", fileSHA, successNote), result)), nil, nil
 				}
 
 				// Binary content - encode as base64 blob
@@ -858,14 +907,14 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 					Blob:     []byte(blobContent),
 					MIMEType: contentType,
 				}
-				return utils.NewToolResultResource(fmt.Sprintf("successfully downloaded binary file (SHA: %s)%s", fileSHA, successNote), result), nil, nil
+				return attachIFC(utils.NewToolResultResource(fmt.Sprintf("successfully downloaded binary file (SHA: %s)%s", fileSHA, successNote), result)), nil, nil
 			} else if dirContent != nil {
 				// file content or file SHA is nil which means it's a directory
 				r, err := json.Marshal(dirContent)
 				if err != nil {
 					return utils.NewToolResultError("failed to marshal response"), nil, nil
 				}
-				return utils.NewToolResultText(string(r)), nil, nil
+				return attachIFC(utils.NewToolResultText(string(r))), nil, nil
 			}
 
 			return utils.NewToolResultError("failed to get file contents"), nil, nil

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -682,11 +682,14 @@ func FetchRepoCollaborators(ctx context.Context, client *github.Client, owner, r
 	return logins, nil
 }
 
-// FetchRepoIsPrivate returns the visibility of a repository. It is a thin
+// FetchRepoIsPrivate returns whether a repository is private. It is a thin
 // wrapper around the GitHub Repositories.Get endpoint provided as a shared
 // helper for IFC label computation across tools.
 func FetchRepoIsPrivate(ctx context.Context, client *github.Client, owner, repo string) (bool, error) {
-	r, _, err := client.Repositories.Get(ctx, owner, repo)
+	r, resp, err := client.Repositories.Get(ctx, owner, repo)
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
 	if err != nil {
 		return false, err
 	}
@@ -768,22 +771,26 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 			// attachIFC adds the IFC label to a successful tool result when
 			// InsidersMode is enabled. The visibility and (for private
 			// repositories) collaborators lookups are performed lazily on
-			// first use and are best-effort: if they fail we still attach
-			// the label, falling back to the repository owner so the reader
-			// set is never empty for a private repo.
+			// first use. If the visibility lookup fails we skip the label
+			// rather than misclassify the result; the failure is not cached
+			// so a later return path can retry. If only the collaborators
+			// lookup fails for a private repo we fall back to the owner so
+			// the reader set is never empty.
 			var (
-				ifcLabelLoaded bool
-				ifcIsPrivate   bool
-				ifcReaders     []string
+				ifcLabelKnown bool
+				ifcIsPrivate  bool
+				ifcReaders    []string
 			)
 			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
 				if r == nil || r.IsError || !deps.GetFlags(ctx).InsidersMode {
 					return r
 				}
-				if !ifcLabelLoaded {
-					if isPrivate, err := FetchRepoIsPrivate(ctx, client, owner, repo); err == nil {
-						ifcIsPrivate = isPrivate
+				if !ifcLabelKnown {
+					isPrivate, err := FetchRepoIsPrivate(ctx, client, owner, repo)
+					if err != nil {
+						return r
 					}
+					ifcIsPrivate = isPrivate
 					if ifcIsPrivate {
 						if collaborators, err := FetchRepoCollaborators(ctx, client, owner, repo); err == nil {
 							ifcReaders = collaborators
@@ -792,7 +799,7 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 							ifcReaders = []string{owner}
 						}
 					}
-					ifcLabelLoaded = true
+					ifcLabelKnown = true
 				}
 				if r.Meta == nil {
 					r.Meta = mcp.Meta{}

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -477,6 +477,121 @@ func Test_GetFileContents(t *testing.T) {
 	}
 }
 
+func Test_GetFileContents_IFC_InsidersMode(t *testing.T) {
+	t.Parallel()
+
+	serverTool := GetFileContents(translations.NullTranslationHelper)
+
+	mockRawContent := []byte("hello")
+
+	makeMockClient := func(isPrivate bool) *http.Client {
+		return MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposGitRefByOwnerByRepoByRef: mockResponse(t, http.StatusOK, "{\"ref\": \"refs/heads/main\", \"object\": {\"sha\": \"\"}}"),
+			GetReposByOwnerByRepo: mockResponse(t, http.StatusOK, map[string]any{
+				"name":           "repo",
+				"default_branch": "main",
+				"private":        isPrivate,
+			}),
+			GetReposCollaboratorsByOwnerByRepo: mockResponse(t, http.StatusOK, []*github.User{
+				{Login: github.Ptr("octocat")},
+				{Login: github.Ptr("alice")},
+			}),
+			GetReposContentsByOwnerByRepoByPath: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				encodedContent := base64.StdEncoding.EncodeToString(mockRawContent)
+				fileContent := &github.RepositoryContent{
+					Name:     github.Ptr("README.md"),
+					Path:     github.Ptr("README.md"),
+					SHA:      github.Ptr("abc123"),
+					Type:     github.Ptr("file"),
+					Content:  github.Ptr(encodedContent),
+					Size:     github.Ptr(len(mockRawContent)),
+					Encoding: github.Ptr("base64"),
+				}
+				contentBytes, _ := json.Marshal(fileContent)
+				_, _ = w.Write(contentBytes)
+			},
+		})
+	}
+
+	reqParams := map[string]any{
+		"owner": "octocat",
+		"repo":  "repo",
+		"path":  "README.md",
+		"ref":   "refs/heads/main",
+	}
+
+	t.Run("insiders mode disabled omits ifc label from result meta", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient(false)),
+			Flags:  FeatureFlags{InsidersMode: false},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		assert.Nil(t, result.Meta, "result meta should be nil when insiders mode is disabled")
+	})
+
+	t.Run("insiders mode enabled on public repo emits public untrusted label", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient(false)),
+			Flags:  FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcLabel, ok := result.Meta["ifc"]
+		require.True(t, ok, "result meta should contain ifc key")
+
+		ifcJSON, err := json.Marshal(ifcLabel)
+		require.NoError(t, err)
+		var ifcMap map[string]any
+		require.NoError(t, json.Unmarshal(ifcJSON, &ifcMap))
+
+		assert.Equal(t, "untrusted", ifcMap["integrity"])
+		confList, ok := ifcMap["confidentiality"].([]any)
+		require.True(t, ok, "confidentiality should be a list")
+		require.Len(t, confList, 1)
+		assert.Equal(t, "public", confList[0])
+	})
+
+	t.Run("insiders mode enabled on private repo emits private trusted label", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient(true)),
+			Flags:  FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcLabel, ok := result.Meta["ifc"]
+		require.True(t, ok, "result meta should contain ifc key")
+
+		ifcJSON, err := json.Marshal(ifcLabel)
+		require.NoError(t, err)
+		var ifcMap map[string]any
+		require.NoError(t, json.Unmarshal(ifcJSON, &ifcMap))
+
+		assert.Equal(t, "trusted", ifcMap["integrity"])
+		confList, ok := ifcMap["confidentiality"].([]any)
+		require.True(t, ok, "confidentiality should be a list")
+		assert.Equal(t, []any{"octocat", "alice"}, confList)
+	})
+}
+
 func Test_ForkRepository(t *testing.T) {
 	// Verify tool definition once
 	serverTool := ForkRepository(translations.NullTranslationHelper)

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -590,6 +590,43 @@ func Test_GetFileContents_IFC_InsidersMode(t *testing.T) {
 		require.True(t, ok, "confidentiality should be a list")
 		assert.Equal(t, []any{"octocat", "alice"}, confList)
 	})
+
+	t.Run("insiders mode skips ifc label when visibility lookup fails", func(t *testing.T) {
+		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposGitRefByOwnerByRepoByRef: mockResponse(t, http.StatusOK, "{\"ref\": \"refs/heads/main\", \"object\": {\"sha\": \"\"}}"),
+			GetReposByOwnerByRepo:            mockResponse(t, http.StatusInternalServerError, "boom"),
+			GetReposContentsByOwnerByRepoByPath: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				encodedContent := base64.StdEncoding.EncodeToString(mockRawContent)
+				fileContent := &github.RepositoryContent{
+					Name:     github.Ptr("README.md"),
+					Path:     github.Ptr("README.md"),
+					SHA:      github.Ptr("abc123"),
+					Type:     github.Ptr("file"),
+					Content:  github.Ptr(encodedContent),
+					Size:     github.Ptr(len(mockRawContent)),
+					Encoding: github.Ptr("base64"),
+				}
+				contentBytes, _ := json.Marshal(fileContent)
+				_, _ = w.Write(contentBytes)
+			},
+		})
+		deps := BaseDeps{
+			Client: github.NewClient(mockedClient),
+			Flags:  FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "tool call should still succeed when visibility lookup fails")
+
+		if result.Meta != nil {
+			_, hasIFC := result.Meta["ifc"]
+			assert.False(t, hasIFC, "ifc label should be omitted when visibility lookup fails")
+		}
+	})
 }
 
 func Test_ForkRepository(t *testing.T) {

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -75,3 +75,14 @@ func LabelListIssues(isPrivate bool, readers []string) SecurityLabel {
 	}
 	return PublicUntrusted()
 }
+
+// LabelGetFileContents returns the IFC label for a get_file_contents result.
+// Public repository file contents may be authored by anyone via pull requests
+// and are therefore untrusted. In private repositories only collaborators can
+// land changes, so contents are treated as trusted.
+func LabelGetFileContents(isPrivate bool, readers []string) SecurityLabel {
+	if isPrivate {
+		return PrivateTrusted(readers)
+	}
+	return PublicUntrusted()
+}


### PR DESCRIPTION
Emits an IFC `SecurityLabel` on the `get_file_contents` tool result when the `InsidersMode` flag is enabled, mirroring the pattern landed for `get_me` in #2432 and `list_issues` in #2453.

Refs github/copilot-mcp-core#1623, github/copilot-mcp-core#1389. One of the ingress tools listed in #1623's tool table.

> **Chained on #2453.** Base is currently `gokhanarkan/fides-list-issues` because that PR adds the shared `Public*`/`Private*` label constructors in `pkg/ifc/ifc.go`. Once #2453 merges, GitHub will auto-retarget this PR's base to `main`.

## What this PR does

- Wires `_meta.ifc` onto the `get_file_contents` `CallToolResult` when `deps.GetFlags(ctx).InsidersMode` is true. No behaviour change when the flag is off.
- Public repos → `PublicUntrusted()` (file contents can be authored by anyone via PRs, so integrity is `untrusted`; readers are `["public"]`).
- Private repos → `PrivateTrusted([owner])` — only collaborators can land changes in private repos, so integrity is `trusted`. `[owner]` is a placeholder reader set; full collaborator enumeration is deferred (see limitation).
- The label is attached at every success return path (text file, binary file, empty file, large-file resource link, directory, and the `matchFiles` Git-tree fallback) via a small `attachIFC` closure to avoid duplicating the insiders block five times.

## New shared helper

`FetchRepoIsPrivate(ctx, client, owner, repo) (bool, error)` in [pkg/github/repositories.go](pkg/github/repositories.go). Thin wrapper around `client.Repositories.Get`. Exported so upcoming ingress tools (`search_issues`, `issue_read`) can reuse the same visibility lookup. Flagging this for reviewers in case the export surface is a concern.

The lookup is invoked **lazily and only when `InsidersMode` is on**, so non-insiders pay no extra round trip. If the lookup fails, we skip the label rather than fail the user-facing call (label is best-effort metadata, not security gating yet).

`LabelGetFileContents(isPrivate, readers)` is a new helper in `pkg/ifc/ifc.go` that composes the existing `PublicUntrusted`/`PrivateTrusted` constructors.

## Known limitation (called out for reviewers)

Same as #2453: private-repo confidentiality currently uses `[owner]` rather than the full collaborator list. Fetching collaborators requires a paginated REST call; rather than bake that into this PR, a shared visibility/collaborators helper is intended as a follow-up that `get_file_contents`, `list_issues`, `search_issues`, and `issue_read` can all share. `TODO(fides)` marker is at the call site.

## Tests

`Test_GetFileContents_IFC_InsidersMode` mirrors `Test_ListIssues_IFC_InsidersMode` with three subtests:
1. Insiders off → `result.Meta == nil`.
2. Insiders on, public repo → `integrity=untrusted`, `confidentiality=["public"]`.
3. Insiders on, private repo → `integrity=trusted`, `confidentiality=["<owner>"]`.

Existing `Test_GetFileContents` cases are unchanged (the `GetReposByOwnerByRepo` mock is already wired in those cases — its response is just inspected only when insiders is on).

## Validation

- `go test -race ./...` — green.
- `gofmt -s` clean; `go vet ./...` clean.
- (`./script/lint` itself fails locally with a pre-existing golangci-lint Go-version mismatch unrelated to this change.)
- No tool schema/annotation changes → no toolsnap or README regeneration needed.