### PR TITLE
Add ifc label for search_repositories tool

### DIFF
--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -161,9 +162,58 @@ func SearchRepositories(t translations.TranslationHelperFunc) inventory.ServerTo
 				}
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			callResult := utils.NewToolResultText(string(r))
+			if deps.GetFlags(ctx).InsidersMode {
+				attachSearchRepositoriesIFCLabel(ctx, client, result.Repositories, callResult)
+			}
+			return callResult, nil, nil
 		},
 	)
+}
+
+// attachSearchRepositoriesIFCLabel joins per-repository IFC labels across
+// every matched repository and attaches the result to callResult. Visibility
+// is read directly from the search response (no extra API call); collaborators
+// are fetched once per private repository. If any collaborators lookup fails
+// the label is omitted to avoid misclassifying the result. The join math is
+// shared with search_issues via ifc.LabelSearchIssues: integrity is always
+// untrusted, and confidentiality is the intersection of the reader sets of
+// the matched private repositories (public matches contribute the universe
+// set and drop out without shrinking it).
+func attachSearchRepositoriesIFCLabel(ctx context.Context, client *github.Client, repos []*github.Repository, callResult *mcp.CallToolResult) {
+	if callResult == nil || callResult.IsError {
+		return
+	}
+
+	visibilities := make([]bool, 0, len(repos))
+	readerSets := make([][]string, 0, len(repos))
+	for _, repo := range repos {
+		isPrivate := repo.GetPrivate()
+		visibilities = append(visibilities, isPrivate)
+		if !isPrivate {
+			readerSets = append(readerSets, nil)
+			continue
+		}
+		owner := repo.GetOwner().GetLogin()
+		name := repo.GetName()
+		if owner == "" || name == "" {
+			return
+		}
+		collaborators, err := FetchRepoCollaborators(ctx, client, owner, name)
+		if err != nil {
+			return
+		}
+		readerSets = append(readerSets, collaborators)
+	}
+
+	label, ok := ifc.LabelSearchIssues(visibilities, readerSets)
+	if !ok {
+		return
+	}
+	if callResult.Meta == nil {
+		callResult.Meta = mcp.Meta{}
+	}
+	callResult.Meta["ifc"] = label
 }
 
 // SearchCode creates a tool to search for code across GitHub repositories.

--- a/pkg/github/search_test.go
+++ b/pkg/github/search_test.go
@@ -163,9 +163,187 @@ func Test_SearchRepositories(t *testing.T) {
 				assert.Equal(t, *tc.expectedResult.Repositories[i].FullName, repo.FullName)
 				assert.Equal(t, *tc.expectedResult.Repositories[i].HTMLURL, repo.HTMLURL)
 			}
-
 		})
 	}
+}
+
+func Test_SearchRepositories_IFC_InsidersMode(t *testing.T) {
+	t.Parallel()
+
+	serverTool := SearchRepositories(translations.NullTranslationHelper)
+
+	type repoFixture struct {
+		owner               string
+		name                string
+		isPrivate           bool
+		collaborators       []string
+		collaboratorsStatus int
+	}
+
+	makeRepo := func(r repoFixture) *github.Repository {
+		return &github.Repository{
+			ID:       github.Ptr(int64(1)),
+			Name:     github.Ptr(r.name),
+			FullName: github.Ptr(r.owner + "/" + r.name),
+			Private:  github.Ptr(r.isPrivate),
+			Owner:    &github.User{Login: github.Ptr(r.owner)},
+		}
+	}
+
+	makeMockClient := func(repos []repoFixture) *http.Client {
+		searchResult := &github.RepositoriesSearchResult{
+			Total:             github.Ptr(len(repos)),
+			IncompleteResults: github.Ptr(false),
+		}
+		for _, r := range repos {
+			searchResult.Repositories = append(searchResult.Repositories, makeRepo(r))
+		}
+
+		collaboratorsByPath := map[string]repoFixture{}
+		for _, r := range repos {
+			collaboratorsByPath["/repos/"+r.owner+"/"+r.name+"/collaborators"] = r
+		}
+
+		return MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetSearchRepositories: mockResponse(t, http.StatusOK, searchResult),
+			GetReposCollaboratorsByOwnerByRepo: func(w http.ResponseWriter, req *http.Request) {
+				r, ok := collaboratorsByPath[req.URL.Path]
+				if !ok {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+					return
+				}
+				if r.collaboratorsStatus != 0 && r.collaboratorsStatus != http.StatusOK {
+					w.WriteHeader(r.collaboratorsStatus)
+					return
+				}
+				users := make([]*github.User, len(r.collaborators))
+				for i, login := range r.collaborators {
+					users[i] = &github.User{Login: github.Ptr(login)}
+				}
+				body, _ := json.Marshal(users)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+			},
+		})
+	}
+
+	reqParams := map[string]any{"query": "octocat"}
+
+	t.Run("insiders mode disabled omits ifc label", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient([]repoFixture{{owner: "octocat", name: "public-repo"}})),
+			Flags:  FeatureFlags{InsidersMode: false},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		assert.Nil(t, result.Meta)
+	})
+
+	t.Run("insiders mode all public emits public untrusted", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient([]repoFixture{
+				{owner: "octocat", name: "public-a"},
+				{owner: "octocat", name: "public-b"},
+			})),
+			Flags: FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcMap := unmarshalIFC(t, result.Meta["ifc"])
+		assert.Equal(t, "untrusted", ifcMap["integrity"])
+		assert.Equal(t, []any{"public"}, ifcMap["confidentiality"])
+	})
+
+	t.Run("insiders mode mixed public and private keeps the private readers", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient([]repoFixture{
+				{owner: "octocat", name: "private-repo", isPrivate: true, collaborators: []string{"alice"}},
+				{owner: "octocat", name: "public-repo"},
+			})),
+			Flags: FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcMap := unmarshalIFC(t, result.Meta["ifc"])
+		assert.Equal(t, "untrusted", ifcMap["integrity"])
+		assert.Equal(t, []any{"alice"}, ifcMap["confidentiality"])
+	})
+
+	t.Run("insiders mode two private repos intersect collaborators", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient([]repoFixture{
+				{owner: "octocat", name: "repo-a", isPrivate: true, collaborators: []string{"alice", "bob", "carol"}},
+				{owner: "octocat", name: "repo-b", isPrivate: true, collaborators: []string{"bob", "carol", "dan"}},
+			})),
+			Flags: FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcMap := unmarshalIFC(t, result.Meta["ifc"])
+		assert.Equal(t, "untrusted", ifcMap["integrity"])
+		assert.Equal(t, []any{"bob", "carol"}, ifcMap["confidentiality"])
+	})
+
+	t.Run("insiders mode skips ifc label when collaborators lookup fails", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient([]repoFixture{
+				{owner: "octocat", name: "private-repo", isPrivate: true, collaboratorsStatus: http.StatusInternalServerError},
+			})),
+			Flags: FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "tool call should still succeed when collaborators lookup fails")
+
+		if result.Meta != nil {
+			_, hasIFC := result.Meta["ifc"]
+			assert.False(t, hasIFC, "ifc label should be omitted when collaborators lookup fails")
+		}
+	})
+
+	t.Run("insiders mode empty results emits public untrusted", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: github.NewClient(makeMockClient(nil)),
+			Flags:  FeatureFlags{InsidersMode: true},
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcMap := unmarshalIFC(t, result.Meta["ifc"])
+		assert.Equal(t, "untrusted", ifcMap["integrity"])
+		assert.Equal(t, []any{"public"}, ifcMap["confidentiality"])
+	})
 }
 
 func Test_SearchRepositories_FullOutput(t *testing.T) {


### PR DESCRIPTION
Emits an IFC `SecurityLabel` on the `search_repositories` tool result when the `InsidersMode` flag is enabled, mirroring the pattern landed for `get_me` (#2432), `list_issues` (#2453), `get_file_contents` (#2454), `search_issues` (#2456), and `issue_read` (#2457).

Refs github/copilot-mcp-core#1623, github/copilot-mcp-core#1389. The last ingress tool from #1623's table.

> **Chained on #2457** (which is itself chained on #2456). GitHub will auto-retarget the base to `main` as the upstream PRs merge.

## What this PR does

Search results may span multiple repositories, so `_meta.ifc` for `search_repositories` is the IFC meet of the per-repository labels — same semantics as `search_issues` (#2456) after Joanna's review:

- Integrity is always `untrusted` (repository names, descriptions, and topics are user-authored).
- Confidentiality follows the IFC meet (greatest lower bound): **private wins**. A reader of the combined result must be authorised to read every matched private repository.
  - Empty result set → `["public"]` (no data leaked).
  - All matched repos public → `["public"]`.
  - Otherwise → intersection of the collaborator sets across the **private** matches only (public repos contribute the universe set and drop out of the intersection without shrinking it).

If any per-repo collaborators lookup fails, the label is omitted entirely (consistent with `get_file_contents`, `search_issues`, and `issue_read`) to avoid misclassifying the result.

## Helper consolidation

The math is identical to `search_issues`, so the helper has been renamed and is now shared:

- `ifc.LabelSearchIssues` → **`ifc.LabelSearchMultiRepo`** in `pkg/ifc/ifc.go`. Both `search_issues` and `search_repositories` call the same join function.
- Removed the previous constant `LabelSearchRepositories()` (which returned `PublicUntrusted()`).
- New `attachSearchRepositoriesIFCLabel` in `pkg/github/search.go` iterates `result.Repositories`, reads `repo.GetPrivate()` **directly off the search response** (no extra visibility API call), and fetches collaborators only for private hits.

Cost per request: 0 calls for an all-public result; N calls for N private matches (collaborators only). Cheaper than `search_issues` because visibility comes for free on the repository search payload.

## Tests

`Test_SearchRepositories_IFC_InsidersMode` in [pkg/github/search_test.go](pkg/github/search_test.go) with 6 subtests mirroring the `search_issues` coverage:

1. Insiders off → `result.Meta == nil`.
2. Insiders on, all public → `integrity=untrusted`, `confidentiality=["public"]`.
3. Insiders on, mixed public + private → readers = the private repo's collaborator set (private wins).
4. Insiders on, two private repos → intersection of collaborator sets.
5. Insiders on, collaborators lookup fails (500) → no `ifc` meta.
6. Insiders on, empty results → `["public"]`.

## Validation

- `go test -race ./...` — green.
- `gofmt -s` clean; `go vet ./...` clean.
- (`./script/lint` itself fails locally with a pre-existing golangci-lint Go-version mismatch unrelated to this change.)
- No tool schema/annotation changes → no toolsnap or README regeneration needed.
