### PR TITLE
feat: update skill frontmatter to MCP skills-as-groups spec format

### DIFF
--- a/pkg/github/skill_resources.go
+++ b/pkg/github/skill_resources.go
@@ -496,10 +496,8 @@ func buildSkillContent(skill skillDefinition) string {
 	b.WriteString("---\n")
 	fmt.Fprintf(&b, "name: %s\n", skill.name)
 	fmt.Fprintf(&b, "description: %s\n", skill.description)
-	b.WriteString("allowed-tools:\n")
-	for _, tool := range skill.allowedTools {
-		fmt.Fprintf(&b, "  - %s\n", tool)
-	}
+	b.WriteString("metadata:\n")
+	fmt.Fprintf(&b, "  io.modelcontextprotocol/tools: \"%s\"\n", strings.Join(skill.allowedTools, " "))
 	b.WriteString("---\n\n")
 	b.WriteString(skill.body)
 	return b.String()

--- a/pkg/github/skill_resources_test.go
+++ b/pkg/github/skill_resources_test.go
@@ -42,8 +42,8 @@ func TestBuildSkillContent(t *testing.T) {
 	assert.Contains(t, content, "---\n")
 	assert.Contains(t, content, "name: test-skill\n")
 	assert.Contains(t, content, "description: A test skill\n")
-	assert.Contains(t, content, "  - tool_a\n")
-	assert.Contains(t, content, "  - tool_b\n")
+	assert.Contains(t, content, "metadata:\n")
+	assert.Contains(t, content, "  io.modelcontextprotocol/tools: \"tool_a tool_b\"\n")
 	assert.Contains(t, content, "# Test\n")
 }
 


### PR DESCRIPTION
Update skill resource frontmatter to align with the [proposed MCP skills-as-groups spec](https://github.com/modelcontextprotocol/experimental-ext-grouping/pull/13).

### Changes

**Before:**
```yaml
---
name: review-pr
description: ...
allowed-tools:
  - pull_request_read
  - get_file_contents
---
```

**After:**
```yaml
---
name: review-pr
description: ...
metadata:
  io.modelcontextprotocol/tools: "pull_request_read get_file_contents"
---
```

The `skillDefinition` struct keeps `allowedTools []string` internally — only the serialized output format changes.

### Stacked on
PR #2374 (`sammorrowdrums/skills-over-mcp-refactor`)