### PR TITLE
Annotate add_issue_comment as destructive

### DIFF
--- a/pkg/github/__toolsnaps__/add_issue_comment.snap
+++ b/pkg/github/__toolsnaps__/add_issue_comment.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": true,
     "title": "Add comment to issue"
   },
   "description": "Add a comment to a specific issue in a GitHub repository. Use this tool to add comments to pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add review comments.",

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -640,8 +640,9 @@ func AddIssueComment(t translations.TranslationHelperFunc) inventory.ServerTool 
 			Name:        "add_issue_comment",
 			Description: t("TOOL_ADD_ISSUE_COMMENT_DESCRIPTION", "Add a comment to a specific issue in a GitHub repository. Use this tool to add comments to pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add review comments."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_ADD_ISSUE_COMMENT_USER_TITLE", "Add comment to issue"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_ADD_ISSUE_COMMENT_USER_TITLE", "Add comment to issue"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -405,6 +405,9 @@ func Test_AddIssueComment(t *testing.T) {
 	assert.Equal(t, "add_issue_comment", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	assert.True(t, *tool.Annotations.DestructiveHint)
+
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "owner")
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "repo")
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "issue_number")

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -405,6 +405,7 @@ func Test_AddIssueComment(t *testing.T) {
 	assert.Equal(t, "add_issue_comment", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 
+	require.NotNil(t, tool.Annotations)
 	require.NotNil(t, tool.Annotations.DestructiveHint)
 	assert.True(t, *tool.Annotations.DestructiveHint)
 


### PR DESCRIPTION
Sets `destructiveHint: true` on `add_issue_comment` so the IFC client engine can apply egress policies before invocation. First of four egress annotations from github/copilot-mcp-core#1623.