### PR TITLE
Annotate create_issue and issue_write as destructive

### DIFF
--- a/pkg/github/__toolsnaps__/create_issue.snap
+++ b/pkg/github/__toolsnaps__/create_issue.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Create Issue"
   },

--- a/pkg/github/__toolsnaps__/issue_write.snap
+++ b/pkg/github/__toolsnaps__/issue_write.snap
@@ -9,6 +9,7 @@
     }
   },
   "annotations": {
+    "destructiveHint": true,
     "title": "Create or update issue."
   },
   "description": "Create a new or update an existing issue in a GitHub repository.",

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1127,8 +1127,9 @@ func IssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "issue_write",
 			Description: t("TOOL_ISSUE_WRITE_DESCRIPTION", "Create a new or update an existing issue in a GitHub repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_ISSUE_WRITE_USER_TITLE", "Create or update issue."),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_ISSUE_WRITE_USER_TITLE", "Create or update issue."),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			Meta: mcp.Meta{
 				"ui": map[string]any{

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -117,7 +117,7 @@ func GranularCreateIssue(t translations.TranslationHelperFunc) inventory.ServerT
 			Annotations: &mcp.ToolAnnotations{
 				Title:           t("TOOL_CREATE_ISSUE_USER_TITLE", "Create Issue"),
 				ReadOnlyHint:    false,
-				DestructiveHint: jsonschema.Ptr(false),
+				DestructiveHint: jsonschema.Ptr(true),
 				OpenWorldHint:   jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -1058,6 +1058,8 @@ func Test_CreateIssue(t *testing.T) {
 
 	assert.Equal(t, "issue_write", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	assert.True(t, *tool.Annotations.DestructiveHint)
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "method")
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "owner")
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "repo")

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -1050,7 +1050,7 @@ func unmarshalIFC(t *testing.T, ifcLabel any) map[string]any {
 	return ifcMap
 }
 
-func Test_CreateIssue(t *testing.T) {
+func Test_IssueWrite_Create(t *testing.T) {
 	// Verify tool definition once
 	serverTool := IssueWrite(translations.NullTranslationHelper)
 	tool := serverTool.Tool
@@ -1058,6 +1058,7 @@ func Test_CreateIssue(t *testing.T) {
 
 	assert.Equal(t, "issue_write", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations)
 	require.NotNil(t, tool.Annotations.DestructiveHint)
 	assert.True(t, *tool.Annotations.DestructiveHint)
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "method")


### PR DESCRIPTION
Sets `destructiveHint: true` on the granular `create_issue` tool and the unified `issue_write` tool so the IFC client engine can apply egress policies regardless of which surface the client uses. Second of four egress annotations from github/copilot-mcp-core#1623.