### PR TITLE
Annotate granular update_issue tools as destructive

### DIFF
--- a/pkg/github/__toolsnaps__/update_issue_assignees.snap
+++ b/pkg/github/__toolsnaps__/update_issue_assignees.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Update Issue Assignees"
   },

--- a/pkg/github/__toolsnaps__/update_issue_body.snap
+++ b/pkg/github/__toolsnaps__/update_issue_body.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Update Issue Body"
   },

--- a/pkg/github/__toolsnaps__/update_issue_labels.snap
+++ b/pkg/github/__toolsnaps__/update_issue_labels.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Update Issue Labels"
   },

--- a/pkg/github/__toolsnaps__/update_issue_milestone.snap
+++ b/pkg/github/__toolsnaps__/update_issue_milestone.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Update Issue Milestone"
   },

--- a/pkg/github/__toolsnaps__/update_issue_state.snap
+++ b/pkg/github/__toolsnaps__/update_issue_state.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Update Issue State"
   },

--- a/pkg/github/__toolsnaps__/update_issue_title.snap
+++ b/pkg/github/__toolsnaps__/update_issue_title.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Update Issue Title"
   },

--- a/pkg/github/__toolsnaps__/update_issue_type.snap
+++ b/pkg/github/__toolsnaps__/update_issue_type.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "destructiveHint": false,
+    "destructiveHint": true,
     "openWorldHint": true,
     "title": "Update Issue Type"
   },

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -53,7 +53,7 @@ func issueUpdateTool(
 			Annotations: &mcp.ToolAnnotations{
 				Title:           t("TOOL_"+strings.ToUpper(name)+"_USER_TITLE", title),
 				ReadOnlyHint:    false,
-				DestructiveHint: jsonschema.Ptr(false),
+				DestructiveHint: jsonschema.Ptr(true),
 				OpenWorldHint:   jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{
@@ -332,7 +332,7 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 			Annotations: &mcp.ToolAnnotations{
 				Title:           t("TOOL_UPDATE_ISSUE_TYPE_USER_TITLE", "Update Issue Type"),
 				ReadOnlyHint:    false,
-				DestructiveHint: jsonschema.Ptr(false),
+				DestructiveHint: jsonschema.Ptr(true),
 				OpenWorldHint:   jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{


### PR DESCRIPTION
Sets `destructiveHint: true` on the seven granular `update_issue_*` tools (title, body, assignees, labels, milestone, state, type) so the IFC client engine can apply egress policies. The unified `issue_write` tool is covered by #2470. Third of four egress annotations from github/copilot-mcp-core#1623.