### PR TITLE
Annotate create_pull_request as destructive

### DIFF
--- a/pkg/github/__toolsnaps__/create_pull_request.snap
+++ b/pkg/github/__toolsnaps__/create_pull_request.snap
@@ -9,6 +9,7 @@
     }
   },
   "annotations": {
+    "destructiveHint": true,
     "title": "Open new pull request"
   },
   "description": "Create a new pull request in a GitHub repository.",

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -545,8 +545,9 @@ func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 			Name:        "create_pull_request",
 			Description: t("TOOL_CREATE_PULL_REQUEST_DESCRIPTION", "Create a new pull request in a GitHub repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_CREATE_PULL_REQUEST_USER_TITLE", "Open new pull request"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_CREATE_PULL_REQUEST_USER_TITLE", "Open new pull request"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			Meta: mcp.Meta{
 				"ui": map[string]any{

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -2198,6 +2198,7 @@ func Test_CreatePullRequest(t *testing.T) {
 
 	assert.Equal(t, "create_pull_request", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations)
 	require.NotNil(t, tool.Annotations.DestructiveHint)
 	assert.True(t, *tool.Annotations.DestructiveHint)
 	schema := tool.InputSchema.(*jsonschema.Schema)

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -2198,6 +2198,8 @@ func Test_CreatePullRequest(t *testing.T) {
 
 	assert.Equal(t, "create_pull_request", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	assert.True(t, *tool.Annotations.DestructiveHint)
 	schema := tool.InputSchema.(*jsonschema.Schema)
 	assert.Contains(t, schema.Properties, "owner")
 	assert.Contains(t, schema.Properties, "repo")

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -1082,7 +1082,6 @@ func Test_SearchPullRequests(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_GetPullRequestFiles(t *testing.T) {


### PR DESCRIPTION
Sets `destructiveHint: true` on `create_pull_request` so the IFC client engine can apply egress policies. Final of four egress annotations from github/copilot-mcp-core#1623.