### PR TITLE
Document Copilot Spaces PAT requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,6 +1413,11 @@ The following sets of tools are available:
 
 <summary>Copilot Spaces</summary>
 
+- **Authentication note**
+  - Fine-grained PATs are not hidden by classic PAT scope filtering, so these tools may still appear even when the token cannot use them.
+  - For org-owned spaces, fine-grained PATs must be installed on the owning organization and include `organization_copilot_spaces: read`.
+  - If an org-owned space contains repository-backed resources, the token must also have access to every referenced repository or the space may be treated as not found.
+
 - **get_copilot_space** - Get Copilot Space
   - `owner`: The owner of the space. (string, required)
   - `name`: The name of the space. (string, required)


### PR DESCRIPTION
## Summary
Document the authentication constraints for the remote-only Copilot Spaces tools in the README. The new note explains why fine-grained PAT users can still see the tools, but still need the right org installation, `organization_copilot_spaces: read`, and repo access for repo-backed resources.

## Why

The README currently lists `get_copilot_space` and `list_copilot_spaces` without explaining why a fine-grained PAT might still see those tools but fail when it tries to use them. This is a small docs followup so the org-installed token requirement and the repo-backed-resource visibility behavior are easier to discover.

## What changed
- Added an authentication note to the remote-only Copilot Spaces section in `README.md`.
- Called out that fine-grained PATs are not hidden by classic PAT scope filtering.
- Documented the org installation + `organization_copilot_spaces: read` requirement and the repo-backed-resource access requirement.

## MCP impact
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
- Not applicable; docs-only change.

## Security / limits
- [ ] No security or limits impact
- [x] Auth / permissions considered
  - This PR only documents the existing Copilot Spaces auth requirements for fine-grained PATs.
- [x] Data exposure, filtering, or token/size limits considered
  - The README now calls out that org-owned spaces with repo-backed resources may be hidden if the token lacks repo access.

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs
- [ ] Not needed
- [x] Updated (README / docs / examples)
