### PR TITLE
fix: make job logs failed_only a modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,12 +628,12 @@ The following sets of tools are available:
 
 - **get_job_logs** - Get GitHub Actions workflow job logs
   - **Required OAuth Scopes**: `repo`
-  - `failed_only`: When true, gets logs for all failed jobs in the workflow run specified by run_id. Requires run_id to be provided. (boolean, optional)
-  - `job_id`: The unique identifier of the workflow job. Required when getting logs for a single job. (number, optional)
+  - `failed_only`: When true, only returns logs for failed jobs. With job_id, the job must have failed. With run_id, only failed jobs in the run are included. (boolean, optional)
+  - `job_id`: The unique identifier of the workflow job. Provide either job_id or run_id, not both. (number, optional)
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
   - `return_content`: Returns actual log content instead of URLs (boolean, optional)
-  - `run_id`: The unique identifier of the workflow run. Required when failed_only is true to get logs for all failed jobs in the run. (number, optional)
+  - `run_id`: The unique identifier of the workflow run. Provide either run_id or job_id, not both. (number, optional)
   - `tail_lines`: Number of lines to return from the end of the log (number, optional)
 
 </details>

--- a/pkg/github/__toolsnaps__/get_job_logs.snap
+++ b/pkg/github/__toolsnaps__/get_job_logs.snap
@@ -1,17 +1,17 @@
 {
   "annotations": {
     "readOnlyHint": true,
-    "title": "Get job logs"
+    "title": "Get GitHub Actions workflow job logs"
   },
-  "description": "Download logs for a specific workflow job or efficiently get all failed job logs for a workflow run",
+  "description": "Get logs for GitHub Actions workflow jobs.\nUse this tool to retrieve logs for a specific job or all jobs in a workflow run.\nProvide job_id for one job, or run_id for all jobs in a run. Set failed_only=true to restrict either mode to failed jobs only.\n",
   "inputSchema": {
     "properties": {
       "failed_only": {
-        "description": "When true, gets logs for all failed jobs in run_id",
+        "description": "When true, only returns logs for failed jobs. With job_id, the job must have failed. With run_id, only failed jobs in the run are included.",
         "type": "boolean"
       },
       "job_id": {
-        "description": "The unique identifier of the workflow job (required for single job logs)",
+        "description": "The unique identifier of the workflow job. Provide either job_id or run_id, not both.",
         "type": "number"
       },
       "owner": {
@@ -27,7 +27,7 @@
         "type": "boolean"
       },
       "run_id": {
-        "description": "Workflow run ID (required when using failed_only)",
+        "description": "The unique identifier of the workflow run. Provide either run_id or job_id, not both.",
         "type": "number"
       },
       "tail_lines": {

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -46,8 +46,7 @@ const (
 	actionsMethodDeleteWorkflowRunLogs    = "delete_workflow_run_logs"
 )
 
-// handleFailedJobLogs gets logs for all failed jobs in a workflow run
-func handleFailedJobLogs(ctx context.Context, client *github.Client, owner, repo string, runID int64, returnContent bool, tailLines int, contentWindowSize int) (*mcp.CallToolResult, any, error) {
+func handleRunJobLogs(ctx context.Context, client *github.Client, owner, repo string, runID int64, failedOnly bool, returnContent bool, tailLines int, contentWindowSize int) (*mcp.CallToolResult, any, error) {
 	// First, get all jobs for the workflow run
 	jobs, resp, err := client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, &github.ListWorkflowJobsOptions{
 		Filter: "latest",
@@ -57,28 +56,34 @@ func handleFailedJobLogs(ctx context.Context, client *github.Client, owner, repo
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Filter for failed jobs
-	var failedJobs []*github.WorkflowJob
+	// Filter jobs when requested. Otherwise return logs for every job in the run.
+	var selectedJobs []*github.WorkflowJob
 	for _, job := range jobs.Jobs {
-		if job.GetConclusion() == "failure" {
-			failedJobs = append(failedJobs, job)
+		if !failedOnly || job.GetConclusion() == "failure" {
+			selectedJobs = append(selectedJobs, job)
 		}
 	}
 
-	if len(failedJobs) == 0 {
+	if len(selectedJobs) == 0 {
+		message := "No jobs found in this workflow run"
+		if failedOnly {
+			message = "No failed jobs found in this workflow run"
+		}
 		result := map[string]any{
-			"message":     "No failed jobs found in this workflow run",
-			"run_id":      runID,
-			"total_jobs":  len(jobs.Jobs),
-			"failed_jobs": 0,
+			"message":    message,
+			"run_id":     runID,
+			"total_jobs": len(jobs.Jobs),
+		}
+		if failedOnly {
+			result["failed_jobs"] = 0
 		}
 		r, _ := json.Marshal(result)
 		return utils.NewToolResultText(string(r)), nil, nil
 	}
 
-	// Collect logs for all failed jobs
+	// Collect logs for all selected jobs
 	var logResults []map[string]any
-	for _, job := range failedJobs {
+	for _, job := range selectedJobs {
 		jobResult, resp, err := getJobLogData(ctx, client, owner, repo, job.GetID(), job.GetName(), returnContent, tailLines, contentWindowSize)
 		if err != nil {
 			// Continue with other jobs even if one fails
@@ -94,13 +99,19 @@ func handleFailedJobLogs(ctx context.Context, client *github.Client, owner, repo
 		logResults = append(logResults, jobResult)
 	}
 
+	message := fmt.Sprintf("Retrieved logs for %d jobs", len(selectedJobs))
+	if failedOnly {
+		message = fmt.Sprintf("Retrieved logs for %d failed jobs", len(selectedJobs))
+	}
 	result := map[string]any{
-		"message":       fmt.Sprintf("Retrieved logs for %d failed jobs", len(failedJobs)),
+		"message":       message,
 		"run_id":        runID,
 		"total_jobs":    len(jobs.Jobs),
-		"failed_jobs":   len(failedJobs),
 		"logs":          logResults,
 		"return_format": map[string]bool{"content": returnContent, "urls": !returnContent},
+	}
+	if failedOnly {
+		result["failed_jobs"] = len(selectedJobs)
 	}
 
 	r, err := json.Marshal(result)
@@ -112,7 +123,19 @@ func handleFailedJobLogs(ctx context.Context, client *github.Client, owner, repo
 }
 
 // handleSingleJobLogs gets logs for a single job
-func handleSingleJobLogs(ctx context.Context, client *github.Client, owner, repo string, jobID int64, returnContent bool, tailLines int, contentWindowSize int) (*mcp.CallToolResult, any, error) {
+func handleSingleJobLogs(ctx context.Context, client *github.Client, owner, repo string, jobID int64, failedOnly bool, returnContent bool, tailLines int, contentWindowSize int) (*mcp.CallToolResult, any, error) {
+	if failedOnly {
+		workflowJob, resp, err := client.Actions.GetWorkflowJobByID(ctx, owner, repo, jobID)
+		if err != nil {
+			return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to get workflow job", resp, err), nil, nil
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if workflowJob.GetConclusion() != "failure" {
+			return utils.NewToolResultError(fmt.Sprintf("job_id %d has conclusion %q, not failure", jobID, workflowJob.GetConclusion())), nil, nil
+		}
+	}
+
 	jobResult, resp, err := getJobLogData(ctx, client, owner, repo, jobID, "", returnContent, tailLines, contentWindowSize)
 	if err != nil {
 		return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to get job logs", resp, err), nil, nil
@@ -650,8 +673,8 @@ func ActionsGetJobLogs(t translations.TranslationHelperFunc) inventory.ServerToo
 		mcp.Tool{
 			Name: "get_job_logs",
 			Description: t("TOOL_GET_JOB_LOGS_CONSOLIDATED_DESCRIPTION", `Get logs for GitHub Actions workflow jobs.
-Use this tool to retrieve logs for a specific job or all failed jobs in a workflow run.
-For single job logs, provide job_id. For all failed jobs in a run, provide run_id with failed_only=true.
+Use this tool to retrieve logs for a specific job or all jobs in a workflow run.
+Provide job_id for one job, or run_id for all jobs in a run. Set failed_only=true to restrict either mode to failed jobs only.
 `),
 			Annotations: &mcp.ToolAnnotations{
 				Title:        t("TOOL_GET_JOB_LOGS_CONSOLIDATED_USER_TITLE", "Get GitHub Actions workflow job logs"),
@@ -670,15 +693,15 @@ For single job logs, provide job_id. For all failed jobs in a run, provide run_i
 					},
 					"job_id": {
 						Type:        "number",
-						Description: "The unique identifier of the workflow job. Required when getting logs for a single job.",
+						Description: "The unique identifier of the workflow job. Provide either job_id or run_id, not both.",
 					},
 					"run_id": {
 						Type:        "number",
-						Description: "The unique identifier of the workflow run. Required when failed_only is true to get logs for all failed jobs in the run.",
+						Description: "The unique identifier of the workflow run. Provide either run_id or job_id, not both.",
 					},
 					"failed_only": {
 						Type:        "boolean",
-						Description: "When true, gets logs for all failed jobs in the workflow run specified by run_id. Requires run_id to be provided.",
+						Description: "When true, only returns logs for failed jobs. With job_id, the job must have failed. With run_id, only failed jobs in the run are included.",
 					},
 					"return_content": {
 						Type:        "boolean",
@@ -738,12 +761,11 @@ For single job logs, provide job_id. For all failed jobs in a run, provide run_i
 				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
 
-			// Validate parameters
-			if failedOnly && runID == 0 {
-				return utils.NewToolResultError("run_id is required when failed_only is true"), nil, nil
+			if jobID > 0 && runID > 0 {
+				return utils.NewToolResultError("provide either job_id or run_id, not both"), nil, nil
 			}
-			if !failedOnly && jobID == 0 {
-				return utils.NewToolResultError("job_id is required when failed_only is false"), nil, nil
+			if jobID == 0 && runID == 0 {
+				return utils.NewToolResultError("one of job_id or run_id must be provided"), nil, nil
 			}
 
 			// attachIFC adds the IFC label to a successful result when IFC
@@ -754,17 +776,13 @@ For single job logs, provide job_id. For all failed jobs in a run, provide run_i
 				return attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, r, ifc.LabelActionsResult)
 			}
 
-			if failedOnly && runID > 0 {
-				// Handle failed-only mode: get logs for all failed jobs in the workflow run
-				result, payload, err := handleFailedJobLogs(ctx, client, owner, repo, int64(runID), returnContent, tailLines, deps.GetContentWindowSize())
-				return attachIFC(result), payload, err
-			} else if jobID > 0 {
-				// Handle single job mode
-				result, payload, err := handleSingleJobLogs(ctx, client, owner, repo, int64(jobID), returnContent, tailLines, deps.GetContentWindowSize())
+			if runID > 0 {
+				result, payload, err := handleRunJobLogs(ctx, client, owner, repo, int64(runID), failedOnly, returnContent, tailLines, deps.GetContentWindowSize())
 				return attachIFC(result), payload, err
 			}
 
-			return utils.NewToolResultError("Either job_id must be provided for single job logs, or run_id with failed_only=true for failed job logs"), nil, nil
+			result, payload, err := handleSingleJobLogs(ctx, client, owner, repo, int64(jobID), failedOnly, returnContent, tailLines, deps.GetContentWindowSize())
+			return attachIFC(result), payload, err
 		},
 	)
 	return tool

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -58,8 +58,13 @@ func handleRunJobLogs(ctx context.Context, client *github.Client, owner, repo st
 
 	// Filter jobs when requested. Otherwise return logs for every job in the run.
 	var selectedJobs []*github.WorkflowJob
+	failedJobsCount := 0
 	for _, job := range jobs.Jobs {
-		if !failedOnly || job.GetConclusion() == "failure" {
+		failed := job.GetConclusion() == "failure"
+		if failed {
+			failedJobsCount++
+		}
+		if !failedOnly || failed {
 			selectedJobs = append(selectedJobs, job)
 		}
 	}
@@ -70,12 +75,10 @@ func handleRunJobLogs(ctx context.Context, client *github.Client, owner, repo st
 			message = "No failed jobs found in this workflow run"
 		}
 		result := map[string]any{
-			"message":    message,
-			"run_id":     runID,
-			"total_jobs": len(jobs.Jobs),
-		}
-		if failedOnly {
-			result["failed_jobs"] = 0
+			"message":     message,
+			"run_id":      runID,
+			"total_jobs":  len(jobs.Jobs),
+			"failed_jobs": failedJobsCount,
 		}
 		r, _ := json.Marshal(result)
 		return utils.NewToolResultText(string(r)), nil, nil
@@ -107,11 +110,9 @@ func handleRunJobLogs(ctx context.Context, client *github.Client, owner, repo st
 		"message":       message,
 		"run_id":        runID,
 		"total_jobs":    len(jobs.Jobs),
+		"failed_jobs":   failedJobsCount,
 		"logs":          logResults,
 		"return_format": map[string]bool{"content": returnContent, "urls": !returnContent},
-	}
-	if failedOnly {
-		result["failed_jobs"] = len(selectedJobs)
 	}
 
 	r, err := json.Marshal(result)

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -581,10 +581,140 @@ func Test_ActionsGetJobLogs_SingleJob(t *testing.T) {
 		assert.Contains(t, response, "logs_url")
 		assert.Equal(t, "Job logs are available for download", response["message"])
 	})
+
+	t.Run("successful failed-only single job logs", func(t *testing.T) {
+		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposActionsJobsByOwnerByRepoByJobID: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				job := &github.WorkflowJob{
+					ID:         github.Ptr(int64(123)),
+					Name:       github.Ptr("test-job"),
+					Conclusion: github.Ptr("failure"),
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(job)
+			}),
+			GetReposActionsJobsLogsByOwnerByRepoByJobID: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Location", "https://github.com/logs/job/123")
+				w.WriteHeader(http.StatusFound)
+			}),
+		})
+
+		client := github.NewClient(mockedClient)
+		deps := BaseDeps{
+			Client:            client,
+			ContentWindowSize: 5000,
+		}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":       "owner",
+			"repo":        "repo",
+			"job_id":      float64(123),
+			"failed_only": true,
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		var response map[string]any
+		err = json.Unmarshal([]byte(textContent.Text), &response)
+		require.NoError(t, err)
+		assert.Equal(t, float64(123), response["job_id"])
+		assert.Contains(t, response, "logs_url")
+	})
+
+	t.Run("failed-only single job returns error for successful job", func(t *testing.T) {
+		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposActionsJobsByOwnerByRepoByJobID: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				job := &github.WorkflowJob{
+					ID:         github.Ptr(int64(123)),
+					Name:       github.Ptr("test-job"),
+					Conclusion: github.Ptr("success"),
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(job)
+			}),
+		})
+
+		client := github.NewClient(mockedClient)
+		deps := BaseDeps{
+			Client:            client,
+			ContentWindowSize: 5000,
+		}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":       "owner",
+			"repo":        "repo",
+			"job_id":      float64(123),
+			"failed_only": true,
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		assert.Contains(t, getTextResult(t, result).Text, "success")
+	})
 }
 
 func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 	toolDef := ActionsGetJobLogs(translations.NullTranslationHelper)
+
+	t.Run("successful all jobs logs", func(t *testing.T) {
+		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposActionsRunsJobsByOwnerByRepoByRunID: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				jobs := &github.Jobs{
+					TotalCount: github.Ptr(2),
+					Jobs: []*github.WorkflowJob{
+						{
+							ID:         github.Ptr(int64(1)),
+							Name:       github.Ptr("test-job-1"),
+							Conclusion: github.Ptr("success"),
+						},
+						{
+							ID:         github.Ptr(int64(2)),
+							Name:       github.Ptr("test-job-2"),
+							Conclusion: github.Ptr("failure"),
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(jobs)
+			}),
+			GetReposActionsJobsLogsByOwnerByRepoByJobID: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", "https://github.com/logs/job/"+r.URL.Path[len(r.URL.Path)-1:])
+				w.WriteHeader(http.StatusFound)
+			}),
+		})
+
+		client := github.NewClient(mockedClient)
+		deps := BaseDeps{
+			Client:            client,
+			ContentWindowSize: 5000,
+		}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":  "owner",
+			"repo":   "repo",
+			"run_id": float64(456),
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		var response map[string]any
+		err = json.Unmarshal([]byte(textContent.Text), &response)
+		require.NoError(t, err)
+		assert.Equal(t, float64(456), response["run_id"])
+		assert.Equal(t, float64(2), response["total_jobs"])
+		assert.Len(t, response["logs"], 2)
+		assert.Contains(t, response["message"], "Retrieved logs for 2 jobs")
+	})
 
 	t.Run("successful failed jobs logs", func(t *testing.T) {
 		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
@@ -691,5 +821,41 @@ func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 		err = json.Unmarshal([]byte(textContent.Text), &response)
 		require.NoError(t, err)
 		assert.Equal(t, "No failed jobs found in this workflow run", response["message"])
+	})
+}
+
+func Test_ActionsGetJobLogs_Validation(t *testing.T) {
+	toolDef := ActionsGetJobLogs(translations.NullTranslationHelper)
+	client := github.NewClient(MockHTTPClientWithHandlers(map[string]http.HandlerFunc{}))
+	deps := BaseDeps{
+		Client:            client,
+		ContentWindowSize: 5000,
+	}
+	handler := toolDef.Handler(deps)
+
+	t.Run("requires one id", func(t *testing.T) {
+		request := createMCPRequest(map[string]any{
+			"owner": "owner",
+			"repo":  "repo",
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		assert.Contains(t, getTextResult(t, result).Text, "one of job_id or run_id")
+	})
+
+	t.Run("rejects both ids", func(t *testing.T) {
+		request := createMCPRequest(map[string]any{
+			"owner":  "owner",
+			"repo":   "repo",
+			"job_id": float64(123),
+			"run_id": float64(456),
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		assert.Contains(t, getTextResult(t, result).Text, "not both")
 	})
 }

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -529,10 +529,7 @@ func Test_ActionsGetJobLogs(t *testing.T) {
 	// Verify tool definition once
 	toolDef := ActionsGetJobLogs(translations.NullTranslationHelper)
 
-	// Note: consolidated ActionsGetJobLogs has same tool name "get_job_logs" as the individual tool
-	// but with different descriptions. We skip toolsnap validation here since the individual
-	// tool's toolsnap already exists and is tested in Test_GetJobLogs.
-	// The consolidated tool has FeatureFlagEnable set, so only one will be active at a time.
+	require.NoError(t, toolsnaps.Test(toolDef.Tool.Name, toolDef.Tool))
 	assert.Equal(t, "get_job_logs", toolDef.Tool.Name)
 	assert.NotEmpty(t, toolDef.Tool.Description)
 	inputSchema := toolDef.Tool.InputSchema.(*jsonschema.Schema)
@@ -599,7 +596,7 @@ func Test_ActionsGetJobLogs_SingleJob(t *testing.T) {
 			}),
 		})
 
-		client := github.NewClient(mockedClient)
+		client := mustNewGHClient(t, mockedClient)
 		deps := BaseDeps{
 			Client:            client,
 			ContentWindowSize: 5000,
@@ -638,7 +635,7 @@ func Test_ActionsGetJobLogs_SingleJob(t *testing.T) {
 			}),
 		})
 
-		client := github.NewClient(mockedClient)
+		client := mustNewGHClient(t, mockedClient)
 		deps := BaseDeps{
 			Client:            client,
 			ContentWindowSize: 5000,
@@ -689,7 +686,7 @@ func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 			}),
 		})
 
-		client := github.NewClient(mockedClient)
+		client := mustNewGHClient(t, mockedClient)
 		deps := BaseDeps{
 			Client:            client,
 			ContentWindowSize: 5000,
@@ -712,6 +709,7 @@ func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, float64(456), response["run_id"])
 		assert.Equal(t, float64(2), response["total_jobs"])
+		assert.Equal(t, float64(1), response["failed_jobs"])
 		assert.Len(t, response["logs"], 2)
 		assert.Contains(t, response["message"], "Retrieved logs for 2 jobs")
 	})
@@ -771,8 +769,62 @@ func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 		err = json.Unmarshal([]byte(textContent.Text), &response)
 		require.NoError(t, err)
 		assert.Equal(t, float64(456), response["run_id"])
+		assert.Equal(t, float64(2), response["failed_jobs"])
 		assert.Contains(t, response, "logs")
 		assert.Contains(t, response["message"], "Retrieved logs for")
+	})
+
+	t.Run("successful failed-only logs when all jobs failed", func(t *testing.T) {
+		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposActionsRunsJobsByOwnerByRepoByRunID: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				jobs := &github.Jobs{
+					TotalCount: github.Ptr(2),
+					Jobs: []*github.WorkflowJob{
+						{
+							ID:         github.Ptr(int64(1)),
+							Name:       github.Ptr("test-job-1"),
+							Conclusion: github.Ptr("failure"),
+						},
+						{
+							ID:         github.Ptr(int64(2)),
+							Name:       github.Ptr("test-job-2"),
+							Conclusion: github.Ptr("failure"),
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(jobs)
+			}),
+			GetReposActionsJobsLogsByOwnerByRepoByJobID: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", "https://github.com/logs/job/"+r.URL.Path[len(r.URL.Path)-1:])
+				w.WriteHeader(http.StatusFound)
+			}),
+		})
+
+		client := mustNewGHClient(t, mockedClient)
+		deps := BaseDeps{
+			Client:            client,
+			ContentWindowSize: 5000,
+		}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":       "owner",
+			"repo":        "repo",
+			"run_id":      float64(456),
+			"failed_only": true,
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		textContent := getTextResult(t, result)
+		var response map[string]any
+		err = json.Unmarshal([]byte(textContent.Text), &response)
+		require.NoError(t, err)
+		assert.Equal(t, float64(2), response["failed_jobs"])
+		assert.Len(t, response["logs"], 2)
 	})
 
 	t.Run("no failed jobs found", func(t *testing.T) {
@@ -826,7 +878,7 @@ func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {
 
 func Test_ActionsGetJobLogs_Validation(t *testing.T) {
 	toolDef := ActionsGetJobLogs(translations.NullTranslationHelper)
-	client := github.NewClient(MockHTTPClientWithHandlers(map[string]http.HandlerFunc{}))
+	client := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{}))
 	deps := BaseDeps{
 		Client:            client,
 		ContentWindowSize: 5000,

--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -133,6 +133,7 @@ const (
 	PostReposActionsRunsRerunByOwnerByRepoByRunID                = "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"
 	PostReposActionsRunsRerunFailedJobsByOwnerByRepoByRunID      = "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs"
 	PostReposActionsRunsCancelByOwnerByRepoByRunID               = "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel"
+	GetReposActionsJobsByOwnerByRepoByJobID                      = "GET /repos/{owner}/{repo}/actions/jobs/{job_id}"
 	GetReposActionsJobsLogsByOwnerByRepoByJobID                  = "GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs"
 	DeleteReposActionsRunsLogsByOwnerByRepoByRunID               = "DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs"
 


### PR DESCRIPTION
## Summary
- allow `get_job_logs` to fetch all jobs in a run when `run_id` is provided without `failed_only`
- make `failed_only` a modifier for both `run_id` and `job_id`
- reject ambiguous calls that provide both `job_id` and `run_id`
- keep `failed_jobs` in run-level responses for compatibility; it now reports the number of failed jobs even when returning all jobs
- update the `get_job_logs` tool snapshot so the public schema change is explicit

Fixes #2389.

## Notes
- Passing both `job_id` and `run_id` now returns a validation error instead of relying on the old precedence rule.

## To verify
- `go test ./pkg/github -run 'Test_ActionsGetJobLogs' -count=1`
- `go test ./pkg/github -count=1`
- `go test ./... -count=1`
- `git diff --check`