### PR TITLE
fix: guard CompletionsHandler against nil params/ref

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -204,6 +204,9 @@ func NewServer(version, name, title string, opts *mcp.ServerOptions) *mcp.Server
 
 func CompletionsHandler(getClient GetClientFn) func(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
 	return func(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+		if req == nil || req.Params == nil || req.Params.Ref == nil {
+			return nil, fmt.Errorf("invalid request: missing ref parameter")
+		}
 		switch req.Params.Ref.Type {
 		case "ref/resource":
 			if strings.HasPrefix(req.Params.Ref.URI, "repo://") {

--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -205,7 +205,7 @@ func NewServer(version, name, title string, opts *mcp.ServerOptions) *mcp.Server
 func CompletionsHandler(getClient GetClientFn) func(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
 	return func(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
 		if req == nil || req.Params == nil || req.Params.Ref == nil {
-			return nil, fmt.Errorf("invalid request: missing ref parameter")
+			return nil, fmt.Errorf("missing required parameter: ref")
 		}
 		switch req.Params.Ref.Type {
 		case "ref/resource":

--- a/pkg/github/server_test.go
+++ b/pkg/github/server_test.go
@@ -369,7 +369,7 @@ func TestCompletionsHandler_RejectsMissingRef(t *testing.T) {
 			result, err := handler(context.Background(), tc.req)
 			require.Error(t, err)
 			assert.Nil(t, result)
-			assert.Contains(t, err.Error(), "missing ref parameter")
+			assert.Contains(t, err.Error(), "missing required parameter: ref")
 		})
 	}
 }

--- a/pkg/github/server_test.go
+++ b/pkg/github/server_test.go
@@ -349,3 +349,27 @@ func TestResolveEnabledToolsets(t *testing.T) {
 		})
 	}
 }
+
+func TestCompletionsHandler_RejectsMissingRef(t *testing.T) {
+	getClient := func(_ context.Context) (*gogithub.Client, error) {
+		return &gogithub.Client{}, nil
+	}
+	handler := CompletionsHandler(getClient)
+
+	tests := []struct {
+		name string
+		req  *mcp.CompleteRequest
+	}{
+		{name: "nil request", req: nil},
+		{name: "nil params", req: &mcp.CompleteRequest{}},
+		{name: "nil ref", req: &mcp.CompleteRequest{Params: &mcp.CompleteParams{}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := handler(context.Background(), tc.req)
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "missing ref parameter")
+		})
+	}
+}


### PR DESCRIPTION
A malformed `completion/complete` request with missing or empty parameters caused a nil pointer dereference in `CompletionsHandler`, panicking the process. This adds a nil-guard that rejects such requests with a clear error before dispatching on `Ref.Type`.

Reported by @manthanghasadiya in [GHSA-w4q6-qw23-4rg7](https://github.com/github/github-mcp-server/security/advisories/GHSA-w4q6-qw23-4rg7).

### Impact
- Local stdio server: a malformed request would crash the process. Trust boundary is the spawning client, so impact is self-DoS.
- Remote server: not reachable unauthenticated (PAT/token required), so at worst an authenticated caller self-crashes their own session.

Still worth fixing as routine hardening.

### Changes
- `pkg/github/server.go`: nil-guard on `req`, `req.Params`, and `req.Params.Ref`.
- `pkg/github/server_test.go`: `TestCompletionsHandler_RejectsMissingRef` covering all three nil cases.

### Validation
- `script/lint` → 0 issues
- `script/test` → all packages pass