### PR TITLE
fix(ui): advertise get_me as an app via _meta.ui.visibility

### DIFF
--- a/pkg/github/__toolsnaps__/get_me.snap
+++ b/pkg/github/__toolsnaps__/get_me.snap
@@ -1,7 +1,11 @@
 {
   "_meta": {
     "ui": {
-      "resourceUri": "ui://github-mcp-server/get-me"
+      "resourceUri": "ui://github-mcp-server/get-me",
+      "visibility": [
+        "model",
+        "app"
+      ]
     }
   },
   "annotations": {

--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -58,6 +58,7 @@ func GetMe(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Meta: mcp.Meta{
 				"ui": map[string]any{
 					"resourceUri": GetMeUIResourceURI,
+					"visibility":  []string{"model", "app"},
 				},
 			},
 		},


### PR DESCRIPTION
## Bug

The `get_me` tool wires an MCP App UI resource (`ui://github-mcp-server/get-me`) via `_meta.ui.resourceUri`, but the `_meta.ui` map was missing the `visibility` array. MCP clients that key off `visibility` to decide whether to render the resource as an app (e.g. VS Code's MCP Apps renderer) silently skip `get_me` as a result.

## Fix

Add `visibility: ["model", "app"]` to `get_me`'s `_meta.ui`, matching the existing UI-enabled tools (`issue_write`, `create_pull_request`).

## Changes

- `pkg/github/context_tools.go` — one-line addition to the `_meta.ui` map literal in `GetMe`.
- `pkg/github/__toolsnaps__/get_me.snap` — regenerated via `UPDATE_TOOLSNAPS=true go test ./pkg/github -run 'Test_GetMe$'`.

`script/lint` and `script/test` both pass.