### PR TITLE
Fix return Thread node ID in get_review_comments response

### DIFF
--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+    "fmt"
 	"strconv"
 	"time"
 
@@ -858,6 +859,7 @@ type MinimalReviewComment struct {
 
 // MinimalReviewThread is the trimmed output type for PR review thread objects.
 type MinimalReviewThread struct {
+    ID          string
 	IsResolved  bool                   `json:"is_resolved"`
 	IsOutdated  bool                   `json:"is_outdated"`
 	IsCollapsed bool                   `json:"is_collapsed"`
@@ -994,6 +996,7 @@ func convertToMinimalReviewThread(thread reviewThreadNode) MinimalReviewThread {
 	}
 
 	return MinimalReviewThread{
+	    ID:          fmt.Sprintf("%v", thread.ID)
 		IsResolved:  bool(thread.IsResolved),
 		IsOutdated:  bool(thread.IsOutdated),
 		IsCollapsed: bool(thread.IsCollapsed),

--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -1,7 +1,7 @@
 package github
 
 import (
-    "fmt"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -859,7 +859,7 @@ type MinimalReviewComment struct {
 
 // MinimalReviewThread is the trimmed output type for PR review thread objects.
 type MinimalReviewThread struct {
-    ID          string
+	ID          string
 	IsResolved  bool                   `json:"is_resolved"`
 	IsOutdated  bool                   `json:"is_outdated"`
 	IsCollapsed bool                   `json:"is_collapsed"`
@@ -996,7 +996,7 @@ func convertToMinimalReviewThread(thread reviewThreadNode) MinimalReviewThread {
 	}
 
 	return MinimalReviewThread{
-	    ID:          fmt.Sprintf("%v", thread.ID)
+		ID:          fmt.Sprintf("%v", thread.ID),
 		IsResolved:  bool(thread.IsResolved),
 		IsOutdated:  bool(thread.IsOutdated),
 		IsCollapsed: bool(thread.IsCollapsed),


### PR DESCRIPTION
## Problem                                                                                                                                                                                                         
  `pull_request_read` with `method: get_review_comments` never returns the thread                                                                                                                                    
  node ID (e.g. `PRRT_kwDO...`). The README documents using this ID with                                                                                                                                             
  `resolve_thread`, making that workflow completely broken.

## Root Cause                               
  `convertToMinimalReviewThread()` in `pkg/github/minimal_types.go` maps                                                                                                                                             
  `reviewThreadNode` → `MinimalReviewThread`, but `MinimalReviewThread` had no                                                                                                                                       
  `ID` field, so `thread.ID` was silently dropped.     

 ## Fix                                                                                                                                                                                                             
  Added `ID string` to `MinimalReviewThread` and populate it via                                                                                                                                                     
  `fmt.Sprintf("%v", thread.ID)` in `convertToMinimalReviewThread`.  

## Result                                                                                                                                                                                                          
  `get_review_comments` now includes `"id"` on each thread object, enabling the                                                                                                                                      
  documented `resolve_thread` workflow end-to-end. 