### PR TITLE
Remove trailing periods from tool title annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ The following sets of tools are available:
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
 
-- **get_label** - Get a specific label from a repository.
+- **get_label** - Get a specific label from a repository
   - **Required OAuth Scopes**: `repo`
   - `name`: Label name. (string, required)
   - `owner`: Repository owner (username or organization name) (string, required)
@@ -850,7 +850,7 @@ The following sets of tools are available:
   - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
   - `repo`: The name of the repository (string, required)
 
-- **issue_write** - Create or update issue.
+- **issue_write** - Create or update issue
   - **Required OAuth Scopes**: `repo`
   - `assignees`: Usernames to assign to this issue (string[], optional)
   - `body`: Issue body content (string, optional)
@@ -919,13 +919,13 @@ The following sets of tools are available:
 
 <summary><picture><source media="(prefers-color-scheme: dark)" srcset="pkg/octicons/icons/tag-dark.png"><source media="(prefers-color-scheme: light)" srcset="pkg/octicons/icons/tag-light.png"><img src="pkg/octicons/icons/tag-light.png" width="20" height="20" alt="tag"></picture> Labels</summary>
 
-- **get_label** - Get a specific label from a repository.
+- **get_label** - Get a specific label from a repository
   - **Required OAuth Scopes**: `repo`
   - `name`: Label name. (string, required)
   - `owner`: Repository owner (username or organization name) (string, required)
   - `repo`: Repository name (string, required)
 
-- **label_write** - Write operations on repository labels.
+- **label_write** - Write operations on repository labels
   - **Required OAuth Scopes**: `repo`
   - `color`: Label color as 6-character hex code without '#' prefix (e.g., 'f29513'). Required for 'create', optional for 'update'. (string, optional)
   - `description`: Label description text. Optional for 'create' and 'update'. (string, optional)
@@ -1125,7 +1125,7 @@ The following sets of tools are available:
   - `pullNumber`: Pull request number (number, required)
   - `repo`: Repository name (string, required)
 
-- **pull_request_review_write** - Write operations (create, submit, delete) on pull request reviews.
+- **pull_request_review_write** - Write operations (create, submit, delete) on pull request reviews
   - **Required OAuth Scopes**: `repo`
   - `body`: Review comment text (string, optional)
   - `commitID`: SHA of commit to review (string, optional)

--- a/pkg/github/__toolsnaps__/get_label.snap
+++ b/pkg/github/__toolsnaps__/get_label.snap
@@ -1,7 +1,7 @@
 {
   "annotations": {
     "readOnlyHint": true,
-    "title": "Get a specific label from a repository."
+    "title": "Get a specific label from a repository"
   },
   "description": "Get a specific label from a repository.",
   "inputSchema": {

--- a/pkg/github/__toolsnaps__/issue_write.snap
+++ b/pkg/github/__toolsnaps__/issue_write.snap
@@ -9,7 +9,7 @@
     }
   },
   "annotations": {
-    "title": "Create or update issue."
+    "title": "Create or update issue"
   },
   "description": "Create a new or update an existing issue in a GitHub repository.",
   "inputSchema": {

--- a/pkg/github/__toolsnaps__/label_write.snap
+++ b/pkg/github/__toolsnaps__/label_write.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "title": "Write operations on repository labels."
+    "title": "Write operations on repository labels"
   },
   "description": "Perform write operations on repository labels. To set labels on issues, use the 'update_issue' tool.",
   "inputSchema": {

--- a/pkg/github/__toolsnaps__/list_label.snap
+++ b/pkg/github/__toolsnaps__/list_label.snap
@@ -1,7 +1,7 @@
 {
   "annotations": {
     "readOnlyHint": true,
-    "title": "List labels from a repository."
+    "title": "List labels from a repository"
   },
   "description": "List labels from a repository",
   "inputSchema": {

--- a/pkg/github/__toolsnaps__/pull_request_review_write.snap
+++ b/pkg/github/__toolsnaps__/pull_request_review_write.snap
@@ -1,6 +1,6 @@
 {
   "annotations": {
-    "title": "Write operations (create, submit, delete) on pull request reviews."
+    "title": "Write operations (create, submit, delete) on pull request reviews"
   },
   "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n- resolve_thread: Resolve a review thread. Requires only \"threadId\" parameter with the thread's node ID (e.g., PRRT_kwDOxxx). The owner, repo, and pullNumber parameters are not used for this method. Resolving an already-resolved thread is a no-op.\n- unresolve_thread: Unresolve a previously resolved review thread. Requires only \"threadId\" parameter. The owner, repo, and pullNumber parameters are not used for this method. Unresolving an already-unresolved thread is a no-op.\n",
   "inputSchema": {

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1303,7 +1303,7 @@ func IssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "issue_write",
 			Description: t("TOOL_ISSUE_WRITE_DESCRIPTION", "Create a new or update an existing issue in a GitHub repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_ISSUE_WRITE_USER_TITLE", "Create or update issue."),
+				Title:        t("TOOL_ISSUE_WRITE_USER_TITLE", "Create or update issue"),
 				ReadOnlyHint: false,
 			},
 			Meta: mcp.Meta{

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -24,7 +24,7 @@ func GetLabel(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "get_label",
 			Description: t("TOOL_GET_LABEL_DESCRIPTION", "Get a specific label from a repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_GET_LABEL_TITLE", "Get a specific label from a repository."),
+				Title:        t("TOOL_GET_LABEL_TITLE", "Get a specific label from a repository"),
 				ReadOnlyHint: true,
 			},
 			InputSchema: &jsonschema.Schema{
@@ -126,7 +126,7 @@ func ListLabels(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "list_label",
 			Description: t("TOOL_LIST_LABEL_DESCRIPTION", "List labels from a repository"),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_LIST_LABEL_DESCRIPTION", "List labels from a repository."),
+				Title:        t("TOOL_LIST_LABEL_DESCRIPTION", "List labels from a repository"),
 				ReadOnlyHint: true,
 			},
 			InputSchema: &jsonschema.Schema{
@@ -217,7 +217,7 @@ func LabelWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "label_write",
 			Description: t("TOOL_LABEL_WRITE_DESCRIPTION", "Perform write operations on repository labels. To set labels on issues, use the 'update_issue' tool."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_LABEL_WRITE_TITLE", "Write operations on repository labels."),
+				Title:        t("TOOL_LABEL_WRITE_TITLE", "Write operations on repository labels"),
 				ReadOnlyHint: false,
 			},
 			InputSchema: &jsonschema.Schema{

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1581,7 +1581,7 @@ Available methods:
 - unresolve_thread: Unresolve a previously resolved review thread. Requires only "threadId" parameter. The owner, repo, and pullNumber parameters are not used for this method. Unresolving an already-unresolved thread is a no-op.
 `),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_PULL_REQUEST_REVIEW_WRITE_USER_TITLE", "Write operations (create, submit, delete) on pull request reviews."),
+				Title:        t("TOOL_PULL_REQUEST_REVIEW_WRITE_USER_TITLE", "Write operations (create, submit, delete) on pull request reviews"),
 				ReadOnlyHint: false,
 			},
 			InputSchema: schema,


### PR DESCRIPTION
## Summary
- remove trailing periods from tool title annotations for affected tools
- keep tool descriptions unchanged
- regenerate tool snapshots and README docs to reflect the annotation text changes

## Context
Titles ending with periods were inconsistent with most other tools and looked odd in agent UIs.