### PR TITLE
docs: auto-generate per-flag tool lists for insiders and feature flags

### DIFF
--- a/cmd/github-mcp-server/feature_flag_docs.go
+++ b/cmd/github-mcp-server/feature_flag_docs.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/github/github-mcp-server/pkg/github"
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/translations"
+)
+
+// generateInsidersFeaturesDocs refreshes the auto-generated section of
+// docs/insiders-features.md with the tools and schemas affected by each
+// Insiders feature flag.
+func generateInsidersFeaturesDocs(docsPath string) error {
+	body := generateFlaggedToolsDoc(github.InsidersFeatureFlags, "_No Insiders-only tool changes._")
+	return rewriteAutomatedSection(docsPath, "START AUTOMATED INSIDERS TOOLS", "END AUTOMATED INSIDERS TOOLS", body)
+}
+
+// generateFeatureFlagsDocs refreshes the auto-generated section of
+// docs/feature-flags.md with the tools and schemas affected by each
+// user-controllable feature flag.
+func generateFeatureFlagsDocs(docsPath string) error {
+	body := generateFlaggedToolsDoc(github.AllowedFeatureFlags, "_No user-controllable feature flags affect tool registration._")
+	return rewriteAutomatedSection(docsPath, "START AUTOMATED FEATURE FLAG TOOLS", "END AUTOMATED FEATURE FLAG TOOLS", body)
+}
+
+// generateFlaggedToolsDoc renders, for each flag in the input set, the tools
+// whose registration or definition differs from the default user experience.
+// Each affected tool is printed with its full schema using the same writer
+// used by the README so the output style stays consistent.
+func generateFlaggedToolsDoc(flags []string, emptyMessage string) string {
+	t, _ := translations.TranslationHelper()
+	defaultTools := indexToolsByName(buildInventoryWithFlags(t, nil).ToolsForRegistration(context.Background()))
+
+	var buf strings.Builder
+	hasAny := false
+
+	for _, flag := range flags {
+		affected := flaggedToolDiff(t, flag, defaultTools)
+		if len(affected) == 0 {
+			continue
+		}
+
+		if hasAny {
+			buf.WriteString("\n\n")
+		}
+		hasAny = true
+
+		fmt.Fprintf(&buf, "### `%s`\n\n", flag)
+		for i, tool := range affected {
+			writeToolDoc(&buf, tool)
+			if i < len(affected)-1 {
+				buf.WriteString("\n\n")
+			}
+		}
+	}
+
+	if !hasAny {
+		return emptyMessage
+	}
+	// Leading/trailing newlines around the body produce blank lines between
+	// our content and the surrounding marker comments, so the trailing comment
+	// doesn't get absorbed into the final list item by markdown renderers.
+	return "\n" + strings.TrimSuffix(buf.String(), "\n") + "\n"
+}
+
+// flaggedToolDiff returns the tools whose definition (input schema or meta)
+// differs from the default-flagged inventory when only the given flag is on,
+// plus tools that exist only in the flag-on inventory. Results are sorted by
+// tool name.
+func flaggedToolDiff(t translations.TranslationHelperFunc, flag string, defaultTools map[string]inventory.ServerTool) []inventory.ServerTool {
+	flagTools := buildInventoryWithFlags(t, map[string]bool{flag: true}).ToolsForRegistration(context.Background())
+
+	out := make([]inventory.ServerTool, 0)
+	seen := make(map[string]struct{}, len(flagTools))
+
+	for _, tool := range flagTools {
+		if _, ok := seen[tool.Tool.Name]; ok {
+			continue
+		}
+		seen[tool.Tool.Name] = struct{}{}
+
+		baseline, hadBaseline := defaultTools[tool.Tool.Name]
+		if hadBaseline && reflect.DeepEqual(tool.Tool.InputSchema, baseline.Tool.InputSchema) && reflect.DeepEqual(tool.Tool.Meta, baseline.Tool.Meta) {
+			continue
+		}
+		out = append(out, tool)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Tool.Name < out[j].Tool.Name })
+	return out
+}
+
+// buildInventoryWithFlags constructs an inventory whose feature checker treats
+// the given flags as enabled and every other flag as disabled. Passing nil
+// produces the default-flagged inventory.
+func buildInventoryWithFlags(t translations.TranslationHelperFunc, enabled map[string]bool) *inventory.Inventory {
+	checker := func(_ context.Context, flag string) (bool, error) {
+		return enabled[flag], nil
+	}
+	inv, _ := github.NewInventory(t).
+		WithToolsets([]string{"all"}).
+		WithFeatureChecker(checker).
+		Build()
+	return inv
+}
+
+// indexToolsByName returns a map keyed by tool name. When duplicates exist
+// (e.g. flag-gated dual registrations), the first occurrence wins, mirroring
+// AvailableTools' deterministic sort order.
+func indexToolsByName(tools []inventory.ServerTool) map[string]inventory.ServerTool {
+	out := make(map[string]inventory.ServerTool, len(tools))
+	for _, tool := range tools {
+		if _, ok := out[tool.Tool.Name]; ok {
+			continue
+		}
+		out[tool.Tool.Name] = tool
+	}
+	return out
+}
+
+// rewriteAutomatedSection reads a markdown file, replaces the content between
+// the named markers with body, and writes it back.
+func rewriteAutomatedSection(path, startMarker, endMarker, body string) error {
+	content, err := os.ReadFile(path) //#nosec G304
+	if err != nil {
+		return fmt.Errorf("failed to read docs file: %w", err)
+	}
+	updated, err := replaceSection(string(content), startMarker, endMarker, body)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(updated), 0600) //#nosec G306
+}

--- a/cmd/github-mcp-server/generate_docs.go
+++ b/cmd/github-mcp-server/generate_docs.go
@@ -43,6 +43,8 @@ func generateAllDocs() error {
 		// File to edit, function to generate its docs
 		{"README.md", generateReadmeDocs},
 		{"docs/remote-server.md", generateRemoteServerDocs},
+		{"docs/insiders-features.md", generateInsidersFeaturesDocs},
+		{"docs/feature-flags.md", generateFeatureFlagsDocs},
 		{"docs/tool-renaming.md", generateDeprecatedAliasesDocs},
 	} {
 		if err := doc.fn(doc.path); err != nil {
@@ -168,7 +170,7 @@ func generateToolsetsDoc(i *inventory.Inventory) string {
 }
 
 func generateToolsDoc(r *inventory.Inventory) string {
-	tools := r.AvailableTools(context.Background())
+	tools := r.ToolsForRegistration(context.Background())
 	if len(tools) == 0 {
 		return ""
 	}
@@ -224,6 +226,15 @@ func writeToolDoc(buf *strings.Builder, tool inventory.ServerTool) {
 		// Only show accepted scopes if they differ from required scopes
 		if len(tool.AcceptedScopes) > 0 && !scopesEqual(tool.RequiredScopes, tool.AcceptedScopes) {
 			fmt.Fprintf(buf, "  - **Accepted OAuth Scopes**: `%s`\n", strings.Join(tool.AcceptedScopes, "`, `"))
+		}
+	}
+
+	// MCP App UI metadata (only rendered when the remote_mcp_ui_apps flag
+	// applied to the inventory; for the no-flags README this section is
+	// stripped by inventory.ToolsForRegistration before rendering).
+	if ui, ok := tool.Tool.Meta["ui"].(map[string]any); ok {
+		if uri, ok := ui["resourceUri"].(string); ok && uri != "" {
+			fmt.Fprintf(buf, "  - **MCP App UI**: `%s`\n", uri)
 		}
 	}
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,267 @@
+# Feature Flags
+
+Feature flags let you opt into experimental tool behavior on top of the default
+GitHub MCP Server surface. Insiders Mode turns on a curated subset of these
+flags automatically — see [Insiders Features](./insiders-features.md) for that
+specific set.
+
+For background on how flags resolve at request time, see the [resolution
+section in the Insiders docs](./insiders-features.md#how-feature-flags-are-resolved).
+
+## Enabling a flag
+
+| Method | Remote Server | Local Server |
+|--------|---------------|--------------|
+| Header | `X-MCP-Features: <flag>,<flag>` | N/A |
+| CLI flag | N/A | `--features=<flag>,<flag>` |
+| Environment variable | N/A | `GITHUB_FEATURES=<flag>,<flag>` |
+
+Only flags listed in
+[`AllowedFeatureFlags`](../pkg/github/feature_flags.go) can be enabled by
+end users. Insiders-only flags are not user-toggleable.
+
+---
+
+## Tools affected by each flag
+
+The list below is regenerated from the Go source. For each user-controllable
+feature flag, it lists every tool whose **inventory or input schema** differs
+from the default — either because the flag introduces a new tool, or because
+it selects a flag-aware variant of an existing tool. Flags that only affect
+runtime behavior (such as output formatting) won't appear here.
+
+<!-- START AUTOMATED FEATURE FLAG TOOLS -->
+
+### `remote_mcp_ui_apps`
+
+- **create_pull_request** - Open new pull request
+  - **Required OAuth Scopes**: `repo`
+  - **MCP App UI**: `ui://github-mcp-server/pr-write`
+  - `base`: Branch to merge into (string, required)
+  - `body`: PR description (string, optional)
+  - `draft`: Create as draft PR (boolean, optional)
+  - `head`: Branch containing changes (string, required)
+  - `maintainer_can_modify`: Allow maintainer edits (boolean, optional)
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `title`: PR title (string, required)
+
+- **get_me** - Get my user profile
+  - **MCP App UI**: `ui://github-mcp-server/get-me`
+  - No parameters required
+
+- **issue_write** - Create or update issue
+  - **Required OAuth Scopes**: `repo`
+  - **MCP App UI**: `ui://github-mcp-server/issue-write`
+  - `assignees`: Usernames to assign to this issue (string[], optional)
+  - `body`: Issue body content (string, optional)
+  - `duplicate_of`: Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'. (number, optional)
+  - `issue_number`: Issue number to update (number, optional)
+  - `labels`: Labels to apply to this issue (string[], optional)
+  - `method`: Write operation to perform on a single issue.
+    Options are:
+    - 'create' - creates a new issue.
+    - 'update' - updates an existing issue.
+     (string, required)
+  - `milestone`: Milestone number (number, optional)
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `state`: New state (string, optional)
+  - `state_reason`: Reason for the state change. Ignored unless state is changed. (string, optional)
+  - `title`: Issue title (string, optional)
+  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string, optional)
+
+### `remote_mcp_issue_fields`
+
+- **list_issue_fields** - List issue fields
+  - **Required OAuth Scopes**: `repo`, `read:org`
+  - **Accepted OAuth Scopes**: `admin:org`, `read:org`, `repo`, `write:org`
+  - `owner`: The account owner of the repository or organization. The name is not case sensitive. (string, required)
+  - `repo`: The name of the repository. When provided, returns fields for this specific repository (inherited from its organization). When omitted, returns org-level fields directly. (string, optional)
+
+- **list_issues** - List issues
+  - **Required OAuth Scopes**: `repo`
+  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `direction`: Order direction. If provided, the 'orderBy' also needs to be provided. (string, optional)
+  - `field_filters`: Filter by custom issue field values. Each entry takes a field_name and a value; the server looks up the field and coerces the value to its type (single-select option name, text, number, or YYYY-MM-DD date). (object[], optional)
+  - `labels`: Filter by labels (string[], optional)
+  - `orderBy`: Order issues by field. If provided, the 'direction' also needs to be provided. (string, optional)
+  - `owner`: Repository owner (string, required)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `repo`: Repository name (string, required)
+  - `since`: Filter by date (ISO 8601 timestamp) (string, optional)
+  - `state`: Filter by state, by default both open and closed issues are returned when not provided (string, optional)
+
+### `issues_granular`
+
+- **add_sub_issue** - Add Sub-Issue
+  - **Required OAuth Scopes**: `repo`
+  - `issue_number`: The parent issue number (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `replace_parent`: If true, reparent the sub-issue if it already has a parent (boolean, optional)
+  - `repo`: Repository name (string, required)
+  - `sub_issue_id`: The ID of the sub-issue to add. ID is not the same as issue number (number, required)
+
+- **create_issue** - Create Issue
+  - **Required OAuth Scopes**: `repo`
+  - `body`: Issue body content (optional) (string, optional)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+  - `title`: Issue title (string, required)
+
+- **remove_sub_issue** - Remove Sub-Issue
+  - **Required OAuth Scopes**: `repo`
+  - `issue_number`: The parent issue number (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+  - `sub_issue_id`: The ID of the sub-issue to remove. ID is not the same as issue number (number, required)
+
+- **reprioritize_sub_issue** - Reprioritize Sub-Issue
+  - **Required OAuth Scopes**: `repo`
+  - `after_id`: The ID of the sub-issue to place this after (either after_id OR before_id should be specified) (number, optional)
+  - `before_id`: The ID of the sub-issue to place this before (either after_id OR before_id should be specified) (number, optional)
+  - `issue_number`: The parent issue number (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+  - `sub_issue_id`: The ID of the sub-issue to reorder. ID is not the same as issue number (number, required)
+
+- **set_issue_fields** - Set Issue Fields
+  - **Required OAuth Scopes**: `repo`
+  - `fields`: Array of issue field values to set. Each element must have a 'field_id' (string, the GraphQL node ID of the field) and exactly one value field: 'text_value' for text fields, 'number_value' for number fields, 'date_value' (ISO 8601 date string) for date fields, or 'single_select_option_id' (the GraphQL node ID of the option) for single select fields. Set 'delete' to true to remove a field value. (object[], required)
+  - `issue_number`: The issue number to update (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+
+- **update_issue_assignees** - Update Issue Assignees
+  - **Required OAuth Scopes**: `repo`
+  - `assignees`: GitHub usernames to assign to this issue (string[], required)
+  - `issue_number`: The issue number to update (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+
+- **update_issue_body** - Update Issue Body
+  - **Required OAuth Scopes**: `repo`
+  - `body`: The new body content for the issue (string, required)
+  - `issue_number`: The issue number to update (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+
+- **update_issue_labels** - Update Issue Labels
+  - **Required OAuth Scopes**: `repo`
+  - `issue_number`: The issue number to update (number, required)
+  - `labels`: Labels to apply to this issue. ([], required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+
+- **update_issue_milestone** - Update Issue Milestone
+  - **Required OAuth Scopes**: `repo`
+  - `issue_number`: The issue number to update (number, required)
+  - `milestone`: The milestone number to set on the issue (integer, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+
+- **update_issue_state** - Update Issue State
+  - **Required OAuth Scopes**: `repo`
+  - `issue_number`: The issue number to update (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+  - `state`: The new state for the issue (string, required)
+  - `state_reason`: The reason for the state change (only for closed state) (string, optional)
+
+- **update_issue_title** - Update Issue Title
+  - **Required OAuth Scopes**: `repo`
+  - `issue_number`: The issue number to update (number, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `repo`: Repository name (string, required)
+  - `title`: The new title for the issue (string, required)
+
+- **update_issue_type** - Update Issue Type
+  - **Required OAuth Scopes**: `repo`
+  - `issue_number`: The issue number to update (number, required)
+  - `issue_type`: The issue type to set (string, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `rationale`: One concise sentence explaining what specifically about the issue led you to choose this type. State the concrete signal (e.g. 'Reports a crash when saving' → bug, 'Asks for dark mode support' → feature). (string, optional)
+  - `repo`: Repository name (string, required)
+
+### `pull_requests_granular`
+
+- **add_pull_request_review_comment** - Add Pull Request Review Comment
+  - **Required OAuth Scopes**: `repo`
+  - `body`: The comment body (string, required)
+  - `line`: The line number in the diff to comment on (optional) (number, optional)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `path`: The relative path of the file to comment on (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+  - `side`: The side of the diff to comment on (optional) (string, optional)
+  - `startLine`: The start line of a multi-line comment (optional) (number, optional)
+  - `startSide`: The start side of a multi-line comment (optional) (string, optional)
+  - `subjectType`: The subject type of the comment (string, required)
+
+- **create_pull_request_review** - Create Pull Request Review
+  - **Required OAuth Scopes**: `repo`
+  - `body`: The review body text (optional) (string, optional)
+  - `commitID`: The SHA of the commit to review (optional, defaults to latest) (string, optional)
+  - `event`: The review action to perform. If omitted, creates a pending review. (string, optional)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+
+- **delete_pending_pull_request_review** - Delete Pending Pull Request Review
+  - **Required OAuth Scopes**: `repo`
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+
+- **request_pull_request_reviewers** - Request Pull Request Reviewers
+  - **Required OAuth Scopes**: `repo`
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+  - `reviewers`: GitHub usernames to request reviews from (string[], required)
+
+- **resolve_review_thread** - Resolve Review Thread
+  - **Required OAuth Scopes**: `repo`
+  - `threadID`: The node ID of the review thread to resolve (e.g., PRRT_kwDOxxx) (string, required)
+
+- **submit_pending_pull_request_review** - Submit Pending Pull Request Review
+  - **Required OAuth Scopes**: `repo`
+  - `body`: The review body text (optional) (string, optional)
+  - `event`: The review action to perform (string, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+
+- **unresolve_review_thread** - Unresolve Review Thread
+  - **Required OAuth Scopes**: `repo`
+  - `threadID`: The node ID of the review thread to unresolve (e.g., PRRT_kwDOxxx) (string, required)
+
+- **update_pull_request_body** - Update Pull Request Body
+  - **Required OAuth Scopes**: `repo`
+  - `body`: The new body content for the pull request (string, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+
+- **update_pull_request_draft_state** - Update Pull Request Draft State
+  - **Required OAuth Scopes**: `repo`
+  - `draft`: Set to true to convert to draft, false to mark as ready for review (boolean, required)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+
+- **update_pull_request_state** - Update Pull Request State
+  - **Required OAuth Scopes**: `repo`
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+  - `state`: The new state for the pull request (string, required)
+
+- **update_pull_request_title** - Update Pull Request Title
+  - **Required OAuth Scopes**: `repo`
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `pullNumber`: The pull request number (number, required)
+  - `repo`: Repository name (string, required)
+  - `title`: The new title for the pull request (string, required)
+
+<!-- END AUTOMATED FEATURE FLAG TOOLS -->

--- a/docs/insiders-features.md
+++ b/docs/insiders-features.md
@@ -20,6 +20,76 @@ For configuration examples, see the [Server Configuration Guide](./server-config
 
 ---
 
+## Tools added or changed by Insiders Mode
+
+The list below is generated from the Go source. It covers tool **inventory and schema deltas** introduced by each Insiders feature flag — newly registered tools, or existing tools whose input schema or MCP metadata changes when the flag is on. Flags that only affect runtime behavior (e.g. output formatting or extra field lookups behind an existing schema) won't appear here; those are documented in the prose sections of this file.
+
+<!-- START AUTOMATED INSIDERS TOOLS -->
+
+### `remote_mcp_ui_apps`
+
+- **create_pull_request** - Open new pull request
+  - **Required OAuth Scopes**: `repo`
+  - **MCP App UI**: `ui://github-mcp-server/pr-write`
+  - `base`: Branch to merge into (string, required)
+  - `body`: PR description (string, optional)
+  - `draft`: Create as draft PR (boolean, optional)
+  - `head`: Branch containing changes (string, required)
+  - `maintainer_can_modify`: Allow maintainer edits (boolean, optional)
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `title`: PR title (string, required)
+
+- **get_me** - Get my user profile
+  - **MCP App UI**: `ui://github-mcp-server/get-me`
+  - No parameters required
+
+- **issue_write** - Create or update issue
+  - **Required OAuth Scopes**: `repo`
+  - **MCP App UI**: `ui://github-mcp-server/issue-write`
+  - `assignees`: Usernames to assign to this issue (string[], optional)
+  - `body`: Issue body content (string, optional)
+  - `duplicate_of`: Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'. (number, optional)
+  - `issue_number`: Issue number to update (number, optional)
+  - `labels`: Labels to apply to this issue (string[], optional)
+  - `method`: Write operation to perform on a single issue.
+    Options are:
+    - 'create' - creates a new issue.
+    - 'update' - updates an existing issue.
+     (string, required)
+  - `milestone`: Milestone number (number, optional)
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+  - `state`: New state (string, optional)
+  - `state_reason`: Reason for the state change. Ignored unless state is changed. (string, optional)
+  - `title`: Issue title (string, optional)
+  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string, optional)
+
+### `remote_mcp_issue_fields`
+
+- **list_issue_fields** - List issue fields
+  - **Required OAuth Scopes**: `repo`, `read:org`
+  - **Accepted OAuth Scopes**: `admin:org`, `read:org`, `repo`, `write:org`
+  - `owner`: The account owner of the repository or organization. The name is not case sensitive. (string, required)
+  - `repo`: The name of the repository. When provided, returns fields for this specific repository (inherited from its organization). When omitted, returns org-level fields directly. (string, optional)
+
+- **list_issues** - List issues
+  - **Required OAuth Scopes**: `repo`
+  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `direction`: Order direction. If provided, the 'orderBy' also needs to be provided. (string, optional)
+  - `field_filters`: Filter by custom issue field values. Each entry takes a field_name and a value; the server looks up the field and coerces the value to its type (single-select option name, text, number, or YYYY-MM-DD date). (object[], optional)
+  - `labels`: Filter by labels (string[], optional)
+  - `orderBy`: Order issues by field. If provided, the 'direction' also needs to be provided. (string, optional)
+  - `owner`: Repository owner (string, required)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `repo`: Repository name (string, required)
+  - `since`: Filter by date (ISO 8601 timestamp) (string, optional)
+  - `state`: Filter by state, by default both open and closed issues are returned when not provided (string, optional)
+
+<!-- END AUTOMATED INSIDERS TOOLS -->
+
+---
+
 ## MCP Apps
 
 [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) is an extension to the Model Context Protocol that enables servers to deliver interactive user interfaces to end users. Instead of returning plain text that the LLM must interpret and relay, tools can render forms, profiles, and dashboards right in the chat using MCP Apps.

--- a/pkg/inventory/registry.go
+++ b/pkg/inventory/registry.go
@@ -167,6 +167,19 @@ func (r *Inventory) ToolsetDescriptions() map[ToolsetID]string {
 	return r.toolsetDescriptions
 }
 
+// ToolsForRegistration returns AvailableTools(ctx) post-processed exactly as
+// RegisterTools would expose them: with MCP Apps UI metadata stripped when
+// the remote_mcp_ui_apps feature flag is not enabled in ctx. Useful for
+// documentation generators and diagnostics that need the same view of the
+// tool surface the server would register.
+func (r *Inventory) ToolsForRegistration(ctx context.Context) []ServerTool {
+	tools := r.AvailableTools(ctx)
+	if !r.checkFeatureFlag(ctx, mcpAppsFeatureFlag) {
+		tools = stripMCPAppsMetadata(tools)
+	}
+	return tools
+}
+
 // RegisterTools registers all available tools with the server using the provided dependencies.
 // The context is used for feature flag evaluation.
 //
@@ -177,11 +190,7 @@ func (r *Inventory) ToolsetDescriptions() map[ToolsetID]string {
 // from ctx would otherwise see context.Background() and falsely report the
 // flag off, even when the actual request arrived on the /insiders route.
 func (r *Inventory) RegisterTools(ctx context.Context, s *mcp.Server, deps any) {
-	tools := r.AvailableTools(ctx)
-	if !r.checkFeatureFlag(ctx, mcpAppsFeatureFlag) {
-		tools = stripMCPAppsMetadata(tools)
-	}
-	for _, tool := range tools {
+	for _, tool := range r.ToolsForRegistration(ctx) {
 		tool.RegisterFunc(s, deps)
 	}
 }


### PR DESCRIPTION
## What

Two auto-generated documentation sections that describe how feature flags shape the tool surface — kept intentionally minimal, just tool names and their schemas.

### `docs/insiders-features.md`
Per-flag block added under the existing hand-written prose. For each Insiders flag whose tools differ from the default surface, the full tool schema is rendered using the same writer as README.

### `docs/feature-flags.md` (new)
Same treatment for every flag in `AllowedFeatureFlags` (user-controllable flags). Links back to the Insiders doc for the auto-enabled subset.

## How

A single generator (`cmd/github-mcp-server/feature_flag_docs.go`) diffs each flag's inventory against the default-flagged inventory and reports any tool that is **new** or has a different `InputSchema` / `Meta`. No reason classification — contributors don't need to update the generator when adding a new flag.

- Wired into `generateAllDocs` alongside the other doc files.
- Reuses `writeToolDoc` and `replaceSection` from `generate_docs.go`.
- Marker pairs: `<- Updated .gitignore to exclude START AUTOMATED INSIDERS TOOLS -->` / `<- Updated .gitignore to exclude START AUTOMATED FEATURE FLAG TOOLS -->`.

## Checks

`script/generate-docs`, `script/lint`, and `script/test` all pass.