### PR TITLE
chore(gitignore): anchor binary names to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@ bin/
 .DS_Store
 
 # binary
-github-mcp-server
-mcpcurl
-e2e.test
+/github-mcp-server
+/mcpcurl
+/e2e.test
 
 .history
 conformance-report/


### PR DESCRIPTION
The bare `github-mcp-server`, `mcpcurl`, and `e2e.test` entries in `.gitignore` matched those names anywhere in the tree, which silently ignored any new file added under `cmd/github-mcp-server/` (the rule matched the directory component). I hit this while adding a new `.go` file to that directory in #2521 — it was invisible to `git status` until `git add -f`.

The intent of those rules was to ignore the binaries produced by `go build` at repo root, so this anchors each one with a leading slash. The existing `cmd/github-mcp-server/github-mcp-server` rule on line 2 still covers the binary when built inside the cmd directory.

### Verification

```
$ git check-ignore -v cmd/github-mcp-server/insiders_docs.go
(not ignored)

$ git check-ignore -v github-mcp-server
.gitignore:20:/github-mcp-server  github-mcp-server

$ git check-ignore -v cmd/github-mcp-server/github-mcp-server
.gitignore:2:cmd/github-mcp-server/github-mcp-server  cmd/github-mcp-server/github-mcp-server
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>