### PR TITLE
ci(mcp-diff): build UI artifacts available to baseline checkout

### DIFF
--- a/.github/workflows/mcp-diff.yml
+++ b/.github/workflows/mcp-diff.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Build UI
         uses: ./.github/actions/build-ui
 
+      - name: Stash UI artifacts for baseline checkout
+        # mcp-server-diff checks the baseline ref out into a separate working
+        # directory and runs install_command there. Without these prebuilt
+        # artifacts, pkg/github/ui_dist/ would be empty on the baseline side
+        # and UIAssetsAvailable() would return false, producing a false-positive
+        # diff that "adds" _meta.ui to MCP Apps tools on every PR.
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ui_dist"
+          cp pkg/github/ui_dist/*.html "${RUNNER_TEMP}/ui_dist/"
+
       - name: Generate diff configurations
         id: configs
         # The generator imports pkg/github so any new entry in
@@ -43,7 +53,10 @@ jobs:
         uses: SamMorrowDrums/mcp-server-diff@v2.3.5
         with:
           setup_go: "false"
-          install_command: go mod download
+          install_command: |
+            go mod download
+            mkdir -p pkg/github/ui_dist
+            cp "${RUNNER_TEMP}"/ui_dist/*.html pkg/github/ui_dist/
           start_command: go run ./cmd/github-mcp-server stdio
           env_vars: |
             GITHUB_PERSONAL_ACCESS_TOKEN=test-token
@@ -79,6 +92,13 @@ jobs:
       - name: Build UI
         uses: ./.github/actions/build-ui
 
+      - name: Stash UI artifacts for baseline checkout
+        # See the stdio job above for rationale: the action's baseline checkout
+        # has no UI artifacts unless we hand them over via RUNNER_TEMP.
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ui_dist"
+          cp pkg/github/ui_dist/*.html "${RUNNER_TEMP}/ui_dist/"
+
       - name: Generate diff configurations
         id: configs
         # See script/print-mcp-diff-configs/main.go. The http-headers variant
@@ -97,7 +117,10 @@ jobs:
         uses: SamMorrowDrums/mcp-server-diff@v2.3.5
         with:
           setup_go: "false"
-          install_command: go mod download
+          install_command: |
+            go mod download
+            mkdir -p pkg/github/ui_dist
+            cp "${RUNNER_TEMP}"/ui_dist/*.html pkg/github/ui_dist/
           http_start_command: go run ./cmd/github-mcp-server http --port 8082
           http_startup_wait_ms: "5000"
           configurations: ${{ steps.configs.outputs.configurations }}


### PR DESCRIPTION
## Why

The `mcp-diff` workflow has been reporting false-positive diffs that "add" `_meta.ui` metadata to MCP Apps tools (`get_me`, `issue_write`, `create_pull_request`) on PRs that don't touch the UI at all.

## Root cause

`SamMorrowDrums/mcp-server-diff` checks the baseline ref out into a **separate working directory** and runs `install_command` there. The workflow's `./.github/actions/build-ui` step only populates `pkg/github/ui_dist/` in the *PR* checkout, so on the baseline side:

- `pkg/github/ui_dist/` is effectively empty (just `.gitkeep` / `.placeholder.html`)
- `UIAssetsAvailable()` in `pkg/github/ui_embed.go` returns `false`
- `_meta.ui` is never registered on tools
- → diff falsely shows the PR "adding" UI metadata

## Fix

Option D from the investigation: hand the prebuilt artifacts to the baseline checkout via `$RUNNER_TEMP`.

1. After the workflow's `Build UI` step, copy `pkg/github/ui_dist/*.html` to `$RUNNER_TEMP/ui_dist/`.
2. In `install_command`, copy them back into `pkg/github/ui_dist/` so both PR and baseline checkouts end up with identical UI assets.

Applied to both the `mcp-diff` (stdio) and `mcp-diff-http` jobs.

No double UI build, no Node setup needed in the baseline phase, no upstream action change required.