### PR TITLE
feat(issue-fields): expose fullDatabaseId (BigInt) in list_issue_fields

### DIFF
--- a/pkg/github/issue_fields.go
+++ b/pkg/github/issue_fields.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
@@ -19,6 +20,7 @@ import (
 // IssueField represents a repository issue field definition.
 type IssueField struct {
 	ID          string                         `json:"id"`
+	DatabaseID  int64                          `json:"database_id,omitempty"`
 	Name        string                         `json:"name"`
 	Description string                         `json:"description,omitempty"`
 	DataType    string                         `json:"data_type"`
@@ -37,36 +39,42 @@ type IssueSingleSelectFieldOption struct {
 
 // issueFieldNode is the GraphQL fragment for a single issue field in the IssueFields union.
 // Only the fragment matching __typename is populated; read from the matching fragment.
+// fullDatabaseId (BigInt scalar, returned as string) is fetched on each concrete type because
+// shurcooL/githubv4 does not support interface fragments at the top level of a union.
 type issueFieldNode struct {
 	TypeName       githubv4.String `graphql:"__typename"`
 	IssueFieldText struct {
-		ID          githubv4.ID
-		Name        githubv4.String
-		Description githubv4.String
-		DataType    githubv4.String
-		Visibility  githubv4.String
+		ID             githubv4.ID
+		FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
+		Name           githubv4.String
+		Description    githubv4.String
+		DataType       githubv4.String
+		Visibility     githubv4.String
 	} `graphql:"... on IssueFieldText"`
 	IssueFieldNumber struct {
-		ID          githubv4.ID
-		Name        githubv4.String
-		Description githubv4.String
-		DataType    githubv4.String
-		Visibility  githubv4.String
+		ID             githubv4.ID
+		FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
+		Name           githubv4.String
+		Description    githubv4.String
+		DataType       githubv4.String
+		Visibility     githubv4.String
 	} `graphql:"... on IssueFieldNumber"`
 	IssueFieldDate struct {
-		ID          githubv4.ID
-		Name        githubv4.String
-		Description githubv4.String
-		DataType    githubv4.String
-		Visibility  githubv4.String
+		ID             githubv4.ID
+		FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
+		Name           githubv4.String
+		Description    githubv4.String
+		DataType       githubv4.String
+		Visibility     githubv4.String
 	} `graphql:"... on IssueFieldDate"`
 	IssueFieldSingleSelect struct {
-		ID          githubv4.ID
-		Name        githubv4.String
-		Description githubv4.String
-		DataType    githubv4.String
-		Visibility  githubv4.String
-		Options     []struct {
+		ID             githubv4.ID
+		FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
+		Name           githubv4.String
+		Description    githubv4.String
+		DataType       githubv4.String
+		Visibility     githubv4.String
+		Options        []struct {
 			ID          githubv4.ID
 			Name        githubv4.String
 			Description githubv4.String
@@ -200,6 +208,7 @@ func issueFieldsFromNodes(nodes []issueFieldNode) []IssueField {
 			}
 			f = IssueField{
 				ID:          fmt.Sprintf("%v", node.IssueFieldSingleSelect.ID),
+				DatabaseID:  parseFullDatabaseID(string(node.IssueFieldSingleSelect.FullDatabaseID)),
 				Name:        string(node.IssueFieldSingleSelect.Name),
 				Description: string(node.IssueFieldSingleSelect.Description),
 				DataType:    string(node.IssueFieldSingleSelect.DataType),
@@ -209,6 +218,7 @@ func issueFieldsFromNodes(nodes []issueFieldNode) []IssueField {
 		case "IssueFieldText":
 			f = IssueField{
 				ID:          fmt.Sprintf("%v", node.IssueFieldText.ID),
+				DatabaseID:  parseFullDatabaseID(string(node.IssueFieldText.FullDatabaseID)),
 				Name:        string(node.IssueFieldText.Name),
 				Description: string(node.IssueFieldText.Description),
 				DataType:    string(node.IssueFieldText.DataType),
@@ -217,6 +227,7 @@ func issueFieldsFromNodes(nodes []issueFieldNode) []IssueField {
 		case "IssueFieldNumber":
 			f = IssueField{
 				ID:          fmt.Sprintf("%v", node.IssueFieldNumber.ID),
+				DatabaseID:  parseFullDatabaseID(string(node.IssueFieldNumber.FullDatabaseID)),
 				Name:        string(node.IssueFieldNumber.Name),
 				Description: string(node.IssueFieldNumber.Description),
 				DataType:    string(node.IssueFieldNumber.DataType),
@@ -225,6 +236,7 @@ func issueFieldsFromNodes(nodes []issueFieldNode) []IssueField {
 		case "IssueFieldDate":
 			f = IssueField{
 				ID:          fmt.Sprintf("%v", node.IssueFieldDate.ID),
+				DatabaseID:  parseFullDatabaseID(string(node.IssueFieldDate.FullDatabaseID)),
 				Name:        string(node.IssueFieldDate.Name),
 				Description: string(node.IssueFieldDate.Description),
 				DataType:    string(node.IssueFieldDate.DataType),
@@ -236,4 +248,17 @@ func issueFieldsFromNodes(nodes []issueFieldNode) []IssueField {
 		fields = append(fields, f)
 	}
 	return fields
+}
+
+// parseFullDatabaseID converts a BigInt scalar string (e.g. "12345") to int64.
+// Returns 0 if the string is empty or cannot be parsed.
+func parseFullDatabaseID(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
 }

--- a/pkg/github/issue_fields_test.go
+++ b/pkg/github/issue_fields_test.go
@@ -75,12 +75,13 @@ func Test_ListIssueFields(t *testing.T) {
 					"issueFields": map[string]any{
 						"nodes": []any{
 							map[string]any{
-								"__typename":  "IssueFieldText",
-								"id":          "IFT_1",
-								"name":        "DRI",
-								"description": "Directly responsible individual",
-								"dataType":    "TEXT",
-								"visibility":  "ORG_ONLY",
+								"__typename":     "IssueFieldText",
+								"id":             "IFT_1",
+								"fullDatabaseId": "42",
+								"name":           "DRI",
+								"description":    "Directly responsible individual",
+								"dataType":       "TEXT",
+								"visibility":     "ORG_ONLY",
 							},
 						},
 					},
@@ -89,6 +90,7 @@ func Test_ListIssueFields(t *testing.T) {
 			expectedFields: []IssueField{
 				{
 					ID:          "IFT_1",
+					DatabaseID:  42,
 					Name:        "DRI",
 					Description: "Directly responsible individual",
 					DataType:    "TEXT",
@@ -107,12 +109,13 @@ func Test_ListIssueFields(t *testing.T) {
 					"issueFields": map[string]any{
 						"nodes": []any{
 							map[string]any{
-								"__typename":  "IssueFieldSingleSelect",
-								"id":          "IFSS_1",
-								"name":        "Priority",
-								"description": "Level of importance",
-								"dataType":    "SINGLE_SELECT",
-								"visibility":  "ALL",
+								"__typename":     "IssueFieldSingleSelect",
+								"id":             "IFSS_1",
+								"fullDatabaseId": "99",
+								"name":           "Priority",
+								"description":    "Level of importance",
+								"dataType":       "SINGLE_SELECT",
+								"visibility":     "ALL",
 								"options": []any{
 									map[string]any{
 										"id":    "OPT_1",
@@ -133,6 +136,7 @@ func Test_ListIssueFields(t *testing.T) {
 			expectedFields: []IssueField{
 				{
 					ID:          "IFSS_1",
+					DatabaseID:  99,
 					Name:        "Priority",
 					Description: "Level of importance",
 					DataType:    "SINGLE_SELECT",
@@ -165,18 +169,19 @@ func Test_ListIssueFields(t *testing.T) {
 					"issueFields": map[string]any{
 						"nodes": []any{
 							map[string]any{
-								"__typename": "IssueFieldText",
-								"id":         "IFT_1",
-								"name":       "DRI",
-								"dataType":   "TEXT",
-								"visibility": "ORG_ONLY",
+								"__typename":     "IssueFieldText",
+								"id":             "IFT_1",
+								"fullDatabaseId": "77",
+								"name":           "DRI",
+								"dataType":       "TEXT",
+								"visibility":     "ORG_ONLY",
 							},
 						},
 					},
 				},
 			}),
 			expectedFields: []IssueField{
-				{ID: "IFT_1", Name: "DRI", DataType: "TEXT", Visibility: "ORG_ONLY"},
+				{ID: "IFT_1", DatabaseID: 77, Name: "DRI", DataType: "TEXT", Visibility: "ORG_ONLY"},
 			},
 		},
 		{
@@ -190,18 +195,19 @@ func Test_ListIssueFields(t *testing.T) {
 					"issueFields": map[string]any{
 						"nodes": []any{
 							map[string]any{
-								"__typename": "IssueFieldNumber",
-								"id":         "IFN_1",
-								"name":       "Engineering Staffing",
-								"dataType":   "NUMBER",
-								"visibility": "ORG_ONLY",
+								"__typename":     "IssueFieldNumber",
+								"id":             "IFN_1",
+								"fullDatabaseId": "101",
+								"name":           "Engineering Staffing",
+								"dataType":       "NUMBER",
+								"visibility":     "ORG_ONLY",
 							},
 						},
 					},
 				},
 			}),
 			expectedFields: []IssueField{
-				{ID: "IFN_1", Name: "Engineering Staffing", DataType: "NUMBER", Visibility: "ORG_ONLY"},
+				{ID: "IFN_1", DatabaseID: 101, Name: "Engineering Staffing", DataType: "NUMBER", Visibility: "ORG_ONLY"},
 			},
 		},
 		{
@@ -215,18 +221,19 @@ func Test_ListIssueFields(t *testing.T) {
 					"issueFields": map[string]any{
 						"nodes": []any{
 							map[string]any{
-								"__typename": "IssueFieldDate",
-								"id":         "IFD_1",
-								"name":       "Target Date",
-								"dataType":   "DATE",
-								"visibility": "ORG_ONLY",
+								"__typename":     "IssueFieldDate",
+								"id":             "IFD_1",
+								"fullDatabaseId": "202",
+								"name":           "Target Date",
+								"dataType":       "DATE",
+								"visibility":     "ORG_ONLY",
 							},
 						},
 					},
 				},
 			}),
 			expectedFields: []IssueField{
-				{ID: "IFD_1", Name: "Target Date", DataType: "DATE", Visibility: "ORG_ONLY"},
+				{ID: "IFD_1", DatabaseID: 202, Name: "Target Date", DataType: "DATE", Visibility: "ORG_ONLY"},
 			},
 		},
 		{
@@ -284,6 +291,7 @@ func Test_ListIssueFields(t *testing.T) {
 			require.Equal(t, len(tc.expectedFields), len(returnedFields))
 			for i, expected := range tc.expectedFields {
 				assert.Equal(t, expected.ID, returnedFields[i].ID)
+				assert.Equal(t, expected.DatabaseID, returnedFields[i].DatabaseID)
 				assert.Equal(t, expected.Name, returnedFields[i].Name)
 				assert.Equal(t, expected.DataType, returnedFields[i].DataType)
 				assert.Equal(t, expected.Visibility, returnedFields[i].Visibility)


### PR DESCRIPTION
- https://github.com/github/github-mcp-server/pull/2492 depends on this
- depends on https://github.com/github/github/pull/433228

<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

- Add DatabaseID (int64) to IssueField struct, populated from fullDatabaseId BigInt scalar on all 4 concrete GQL union types
- Repeat fullDatabaseId per union fragment (shurcooL/githubv4 cannot use interface-level fragments at union top-level)
- Add parseFullDatabaseID helper to parse BigInt string to int64
- Update tests to assert DatabaseID is populated from fullDatabaseId

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes #

We are using this tool in two places:
1. Set issue fields granular tool, which is using the GraphQL endpoint to update issue fields
2. Issues write, which is using the REST endpoint to update issue fields on an issue
Because of this, we need to have both node ID and database ID exposed in this tool so both other tools can use it.

## What changed


## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [ ] Updated (README / docs / examples)
