### PR TITLE
docs: update CLI command for adding GitHub PAT in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ To keep your GitHub PAT secure and reusable across different MCP hosts:
 
    ```bash
    # CLI usage
-   claude mcp update github -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PAT
+   claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PAT -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
 
    # In config files (where supported)
    "env": {


### PR DESCRIPTION
## Summary
 Updates the README Claude CLI example for configuring the GitHub MCP Server with a PAT to use the current `claude mcp add` command.
 
 ## Why
The README referenced `claude mcp update github`, but `update` is not a valid Claude MCP command. This aligns the README with the existing Claude installation guide.
 
 Fixes #2053
 
 ## What changed
 - Replaced the outdated `claude mcp update github` example in `README.md`
 - Updated the example to use `claude mcp add github ... -- docker run ...`
 
 ## MCP impact
 - [x] No tool or API changes
 - [ ] Tool schema or behavior changed
 - [ ] New tool added
 
 ## Prompts tested (tool changes only)
 - N/A (documentation-only change)
 
 ## Security / limits
 - [x] No security or limits impact
 - [ ] Auth / permissions considered
 - [ ] Data exposure, filtering, or token/size limits considered
 
 ## Tool renaming
 - [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
    - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
 - [x] I am not renaming tools as part of this PR
 
 ## Lint & tests
 - [ ] Linted locally with `./script/lint` — not run; documentation-only change
 - [ ] Tested locally with `./script/test` — not run; documentation-only change
 
 ## Docs
 - [ ] Not needed
 - [x] Updated (README / docs / examples)