### PR TITLE
fix: hide write UI resources in read-only mode

### DIFF
--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -179,7 +179,7 @@ func NewStdioMCPServer(ctx context.Context, cfg github.MCPServerConfig) (*mcp.Se
 	// requiring a UI build (graceful degradation).
 	mcpAppsEnabled, _ := featureChecker(context.Background(), github.MCPAppsFeatureFlag)
 	if mcpAppsEnabled && github.UIAssetsAvailable() {
-		github.RegisterUIResources(ghServer)
+		github.RegisterUIResources(ghServer, cfg.ReadOnly)
 	}
 
 	ghServer.AddReceivingMiddleware(addUserAgentsMiddleware(cfg, clients.restUATransp, clients.gqlHTTP))

--- a/pkg/github/ui_resources.go
+++ b/pkg/github/ui_resources.go
@@ -10,7 +10,7 @@ import (
 // These are static resources (not templates) that serve HTML content for
 // MCP App-enabled tools. The HTML is built from React/Primer components
 // in the ui/ directory using `script/build-ui`.
-func RegisterUIResources(s *mcp.Server) {
+func RegisterUIResources(s *mcp.Server, readOnly bool) {
 	// Register the get_me UI resource
 	s.AddResource(
 		&mcp.Resource{
@@ -42,6 +42,10 @@ func RegisterUIResources(s *mcp.Server) {
 			}, nil
 		},
 	)
+
+	if readOnly {
+		return
+	}
 
 	// Register the issue_write UI resource
 	s.AddResource(

--- a/pkg/github/ui_resources_test.go
+++ b/pkg/github/ui_resources_test.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func listUIResourceNames(t *testing.T, readOnly bool) []string {
+	t.Helper()
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	RegisterUIResources(srv, readOnly)
+
+	st, ct := mcp.NewInMemoryTransports()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+
+	type clientResult struct {
+		res *mcp.ListResourcesResult
+		err error
+	}
+	clientResultCh := make(chan clientResult, 1)
+	go func() {
+		cs, err := client.Connect(context.Background(), ct, nil)
+		if err != nil {
+			clientResultCh <- clientResult{err: err}
+			return
+		}
+		defer func() { _ = cs.Close() }()
+
+		res, err := cs.ListResources(context.Background(), nil)
+		clientResultCh <- clientResult{res: res, err: err}
+	}()
+
+	ss, err := srv.Connect(context.Background(), st, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ss.Close() })
+
+	got := <-clientResultCh
+	require.NoError(t, got.err)
+	require.NotNil(t, got.res)
+
+	names := make([]string, 0, len(got.res.Resources))
+	for _, res := range got.res.Resources {
+		names = append(names, res.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func TestRegisterUIResources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registers all UI resources by default", func(t *testing.T) {
+		t.Parallel()
+
+		names := listUIResourceNames(t, false)
+		require.Equal(t, []string{"get_me_ui", "issue_write_ui", "pr_write_ui"}, names)
+	})
+
+	t.Run("skips write UI resources in read-only mode", func(t *testing.T) {
+		t.Parallel()
+
+		names := listUIResourceNames(t, true)
+		require.Equal(t, []string{"get_me_ui"}, names)
+	})
+}


### PR DESCRIPTION
Fixes #2519

## Summary
- pass read-only mode into MCP App UI resource registration
- keep get_me_ui available in read-only mode
- skip issue_write_ui and pr_write_ui when write tools are filtered out

## To verify
- go test ./pkg/github -run TestRegisterUIResources -count=1
- go test ./cmd/github-mcp-server ./pkg/github
- go test ./internal/ghmcp ./pkg/github
- git diff --check