### PR TITLE
docs: add installation guides for Zed and OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Alternatively, to manually configure VS Code, choose the appropriate JSON block 
 - **[Claude Applications](/docs/installation-guides/install-claude.md)** - Installation guide for Claude Desktop and Claude Code CLI
 - **[Codex](/docs/installation-guides/install-codex.md)** - Installation guide for OpenAI Codex
 - **[Cursor](/docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE
+- **[OpenCode](/docs/installation-guides/install-opencode.md)** - Installation guide for the OpenCode terminal agent
 - **[Windsurf](/docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
+- **[Zed](/docs/installation-guides/install-zed.md)** - Installation guide for Zed editor
 - **[Rovo Dev CLI](/docs/installation-guides/install-rovo-dev-cli.md)** - Installation guide for Rovo Dev CLI
 
 > **Note:** Each MCP host application needs to configure a GitHub App or OAuth App to support remote access via OAuth. Any host application that supports remote MCP servers should support the remote GitHub server with PAT authentication. Configuration details and support levels vary by host. Make sure to refer to the host application's documentation for more info.
@@ -356,7 +358,9 @@ For other MCP host applications, please refer to our installation guides:
 - **[Claude Code & Claude Desktop](docs/installation-guides/install-claude.md)** - Installation guide for Claude Code and Claude Desktop
 - **[Cursor](docs/installation-guides/install-cursor.md)** - Installation guide for Cursor IDE
 - **[Google Gemini CLI](docs/installation-guides/install-gemini-cli.md)** - Installation guide for Google Gemini CLI
+- **[OpenCode](docs/installation-guides/install-opencode.md)** - Installation guide for the OpenCode terminal agent
 - **[Windsurf](docs/installation-guides/install-windsurf.md)** - Installation guide for Windsurf IDE
+- **[Zed](docs/installation-guides/install-zed.md)** - Installation guide for Zed editor
 
 For a complete overview of all installation options, see our **[Installation Guides Index](docs/installation-guides)**.
 

--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -11,9 +11,11 @@ This directory contains detailed installation instructions for the GitHub MCP Se
 - **[Cursor](install-cursor.md)** - Installation guide for Cursor IDE
 - **[Google Gemini CLI](install-gemini-cli.md)** - Installation guide for Google Gemini CLI
 - **[OpenAI Codex](install-codex.md)** - Installation guide for OpenAI Codex
+- **[OpenCode](install-opencode.md)** - Installation guide for the OpenCode terminal agent
 - **[Roo Code](install-roo-code.md)** - Installation guide for Roo Code
 - **[Windsurf](install-windsurf.md)** - Installation guide for Windsurf IDE
 - **[Xcode (Codex & Claude Agent)](install-xcode.md)** - Installation guide for Codex and Claude Agent within Xcode
+- **[Zed](install-zed.md)** - Installation guide for Zed editor
 
 ## Support by Host Application
 
@@ -29,8 +31,10 @@ This directory contains detailed installation instructions for the GitHub MCP Se
 | Cline | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Cursor | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Google Gemini CLI | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
+| OpenCode | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Roo Code | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Windsurf | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
+| Zed | ✅ | ✅ PAT + ❌ No OAuth | Docker or Go build, GitHub PAT | Easy |
 | Copilot in Xcode | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: Copilot for Xcode 0.41.0+ | Easy |
 | Copilot in Eclipse | ✅ | ✅ Full (OAuth + PAT) | Local: Docker or Go build, GitHub PAT<br>Remote: Eclipse Plug-in for Copilot 0.10.0+ | Easy |
 | Xcode (Codex) | ✅ | ✅ PAT + ❌ No OAuth | Local: Docker (full path required), GitHub PAT<br>Remote: GitHub PAT via `GITHUB_PAT_TOKEN` env var (`bearer_token_env_var`) | Easy |

--- a/docs/installation-guides/install-opencode.md
+++ b/docs/installation-guides/install-opencode.md
@@ -1,0 +1,154 @@
+# Install GitHub MCP Server in OpenCode
+
+[OpenCode](https://opencode.ai) is a terminal-based AI coding agent that exposes MCP servers under the `mcp` key in `opencode.json` (or `opencode.jsonc`). For general setup information (prerequisites, Docker installation, security best practices), see the [Installation Guides README](./README.md).
+
+## Prerequisites
+
+1. OpenCode installed (`brew install sst/tap/opencode` or see [OpenCode install docs](https://opencode.ai/docs/))
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new) with appropriate scopes
+3. For local installation: [Docker](https://www.docker.com/) installed and running
+
+> [!IMPORTANT]
+> The OpenCode docs note that the GitHub MCP server can add a lot of tokens to your context. Consider limiting toolsets — for example, by setting `X-MCP-Toolsets` on the remote server or `--toolsets` on the local server — to keep prompts within your model's context window. See the [Server Configuration Guide](../server-configuration.md) and the [main README's toolsets section](../../README.md#available-toolsets).
+
+## Remote Server (Recommended)
+
+Uses GitHub's hosted server at `https://api.githubcopilot.com/mcp/`. Edit your [OpenCode config](https://opencode.ai/docs/config/) (typically `~/.config/opencode/opencode.json`, or `opencode.json` in your project root) and add the following under `mcp`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "github": {
+      "type": "remote",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "enabled": true,
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_GITHUB_PAT` with your [GitHub Personal Access Token](https://github.com/settings/tokens). The `oauth: false` setting disables OpenCode's automatic OAuth discovery and tells it to use the PAT in `Authorization` instead — without this, OpenCode may try the OAuth flow first.
+
+### Using an environment variable for the PAT
+
+OpenCode supports environment-variable interpolation in config values via `{env:VAR_NAME}`. To avoid putting your PAT directly in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "github": {
+      "type": "remote",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "enabled": true,
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {env:GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Set `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment before starting OpenCode.
+
+## Local Server (Docker)
+
+The local GitHub MCP server runs via Docker and requires Docker Desktop (or another Docker runtime) to be installed and running.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "github": {
+      "type": "local",
+      "command": [
+        "docker", "run", "-i", "--rm",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "enabled": true,
+      "environment": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+> [!IMPORTANT]
+> OpenCode expects `command` as a **single array** combining the executable and its arguments (e.g. `["docker", "run", "-i", ...]`), and the env-var key is `environment` (not `env`). This differs from hosts like Zed and Cursor.
+
+## Verify Installation
+
+1. Restart OpenCode (or start a new session).
+2. Check that the server is discovered:
+   ```sh
+   opencode mcp list
+   ```
+3. Try a prompt that references the server by name to bias the model toward its tools:
+   ```
+   Use the github tool to list my recently merged pull requests.
+   ```
+
+## Managing the Server
+
+OpenCode exposes a few useful subcommands for MCP servers:
+
+| Command | Purpose |
+| --- | --- |
+| `opencode mcp list` | List configured MCP servers and their auth/connection status. |
+| `opencode mcp debug github` | Show auth status, test HTTP connectivity, and walk through OAuth discovery for the `github` server. |
+| `opencode mcp auth github` | Trigger an OAuth flow manually (only relevant if `oauth` is not set to `false`). |
+| `opencode mcp logout github` | Clear stored OAuth tokens for the server. |
+
+## Disabling Tools Per-Agent
+
+Because the GitHub MCP server can register a large number of tools, you may want to **disable them globally** and **re-enable them only for specific agents**. OpenCode uses the `<server-name>_*` glob pattern to match all tools from a server:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "github": {
+      "type": "remote",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "enabled": true,
+      "oauth": false,
+      "headers": { "Authorization": "Bearer {env:GITHUB_PERSONAL_ACCESS_TOKEN}" }
+    }
+  },
+  "tools": {
+    "github_*": false
+  },
+  "agent": {
+    "github-helper": {
+      "tools": { "github_*": true }
+    }
+  }
+}
+```
+
+This pattern is recommended by the [OpenCode MCP docs](https://opencode.ai/docs/mcp-servers/) for servers with many tools.
+
+## Troubleshooting
+
+- **`401 Unauthorized` from the remote server**: confirm your PAT is valid and not expired. If you set `oauth: false`, OpenCode will not attempt an OAuth fallback — the `Authorization` header must be correct.
+- **Server marked failed in `opencode mcp list`**: run `opencode mcp debug github` to see the exact connectivity and auth diagnostics.
+- **Tools missing from prompts**: check that `enabled: true` is set on the server and that you have not disabled `github_*` in your `tools` block without re-enabling it for the current agent.
+- **Context window exceeded**: the GitHub MCP server can register many tools. Use server-side toolset filtering (`X-MCP-Toolsets` header) to register only the toolsets you need.
+- **Docker errors on the local server**: ensure Docker Desktop is running and the `ghcr.io/github/github-mcp-server` image has been pulled (`docker pull ghcr.io/github/github-mcp-server`).
+
+## Important Notes
+
+- **Configuration key**: OpenCode uses `mcp` (not `mcpServers` or `context_servers`).
+- **Type discriminator**: every entry must include `"type": "local"` or `"type": "remote"`.
+- **Command shape**: `command` is a single array combining the executable and its arguments.
+- **Environment variable key**: `environment` (not `env`).
+- **OAuth**: enabled by default for remote servers. Set `"oauth": false` when using PAT-in-`Authorization`, otherwise OpenCode may try OAuth first.
+- **Env interpolation**: use `{env:VAR_NAME}` in string values to read from the shell environment instead of hard-coding secrets.

--- a/docs/installation-guides/install-zed.md
+++ b/docs/installation-guides/install-zed.md
@@ -1,0 +1,103 @@
+# Install GitHub MCP Server in Zed
+
+[Zed](https://zed.dev) is a high-performance multiplayer code editor with native MCP support. Zed exposes MCP servers under the `context_servers` settings key. For general setup information (prerequisites, Docker installation, security best practices), see the [Installation Guides README](./README.md).
+
+## Prerequisites
+
+1. Zed installed (latest version — Zed v0.224.0+ recommended for the modern `agent.tool_permissions` settings shape)
+2. [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new) with appropriate scopes
+3. For local installation: [Docker](https://www.docker.com/) installed and running
+
+## Installation Methods
+
+There are two ways to install the GitHub MCP server in Zed:
+
+- **Option A — Zed Extension (easiest):** a community-maintained [GitHub MCP extension](https://zed.dev/extensions/mcp-server-github) is available in the Zed extension gallery. Install it from the Agent Panel's top-right menu → "View Server Extensions", or from the command palette via the `zed: extensions` action. After installation, Zed pops up a modal asking for your GitHub Personal Access Token.
+- **Option B — Custom Server (recommended for the official remote endpoint):** add the configuration manually to `settings.json` to use either GitHub's hosted remote server or the official Docker image directly. The rest of this guide covers Option B.
+
+## Remote Server (Recommended)
+
+Uses GitHub's hosted server at `https://api.githubcopilot.com/mcp/`. Open your Zed [settings file](https://zed.dev/docs/configuring-zed.html#settings-files) (Command Palette → `zed: open settings`) and add the configuration below under `context_servers`.
+
+```json
+{
+  "context_servers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_GITHUB_PAT` with your [GitHub Personal Access Token](https://github.com/settings/tokens). To customize toolsets, add server-side headers like `X-MCP-Toolsets` or `X-MCP-Readonly` to the `headers` object — see the [Server Configuration Guide](../server-configuration.md).
+
+> [!NOTE]
+> If you omit the `Authorization` header, Zed will attempt the standard MCP OAuth flow on first use. The GitHub MCP server does not currently advertise OAuth for non-Copilot hosts, so a Personal Access Token in the `Authorization` header is the supported path.
+
+## Local Server (Docker)
+
+The local GitHub MCP server runs via Docker and requires Docker Desktop (or another Docker runtime) to be installed and running.
+
+```json
+{
+  "context_servers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "YOUR_GITHUB_PAT"
+      }
+    }
+  }
+}
+```
+
+> [!IMPORTANT]
+> Zed expects `command` as a **string** plus a separate `args` array, not a single array combining both. This differs from hosts like OpenCode and Claude Desktop.
+
+## Verify Installation
+
+1. Open the Agent Panel and click into its Settings view (or run `agent: open settings`).
+2. Find `github` in the context servers list. A green indicator dot with the tooltip "Server is active" confirms a working configuration. Other colors and tooltip messages indicate startup or auth errors.
+3. Try a prompt that should invoke a tool — for example, `List my recent GitHub pull requests`. Zed will prompt for tool approval before the first call unless your `agent.tool_permissions.default` is set to `"allow"`.
+
+## Tool Permissions (Optional)
+
+Zed v0.224.0+ controls tool approval via `agent.tool_permissions`. Approve a specific GitHub MCP tool without per-call prompts by using the `mcp:<server>:<tool_name>` key format:
+
+```json
+{
+  "agent": {
+    "tool_permissions": {
+      "default": "confirm",
+      "rules": [
+        { "tool": "mcp:github:list_pull_requests", "permission": "allow" },
+        { "tool": "mcp:github:list_issues", "permission": "allow" }
+      ]
+    }
+  }
+}
+```
+
+See the [Zed tool permissions docs](https://zed.dev/docs/ai/tool-permissions.html) for the full schema.
+
+## Troubleshooting
+
+- **Server indicator stays red / "Server is not running"**: check the Agent Panel's settings view for the per-server error string. Most common cause is invalid JSON in `settings.json` — Zed surfaces JSON parse errors in the editor itself.
+- **`401 Unauthorized`**: verify your PAT has not expired and includes the scopes for the tools you intend to call. The remote endpoint will reject requests with no `Authorization` header (no anonymous access).
+- **Tools missing from prompts**: confirm the Agent profile in use has not disabled the server. If you're using a [custom profile](https://zed.dev/docs/ai/agent-panel.html#custom-profiles), make sure `enable_all_context_servers` is `true` or that `github` is explicitly listed.
+- **Docker errors on the local server**: ensure Docker Desktop is running and the `ghcr.io/github/github-mcp-server` image has been pulled at least once. Try `docker pull ghcr.io/github/github-mcp-server` from a terminal.
+
+## Important Notes
+
+- **Configuration key**: Zed uses `context_servers` (not `mcpServers`).
+- **Command shape**: `command` is a string + separate `args` array.
+- **OAuth**: omitting `Authorization` triggers Zed's MCP OAuth flow, but the GitHub MCP server's PAT-based auth is the supported path today.
+- **External agents**: MCP servers configured in `context_servers` are forwarded to [external agents](https://zed.dev/docs/ai/external-agents.html) via the Agent Client Protocol.


### PR DESCRIPTION
## Summary

Adds two new installation guides under `docs/installation-guides/` for MCP host applications that were missing documentation:

- **`install-zed.md`** -- the [Zed](https://zed.dev) editor.
- **`install-opencode.md`** -- the [OpenCode](https://opencode.ai) terminal agent.

Both guides follow the established pattern of the existing installation guides (Cursor, Cline, Windsurf, Antigravity, etc.): prerequisites, remote-server-recommended path, local Docker path, verify steps, host-specific quirks, and troubleshooting.

Closes #2531.

## Why these two

The two hosts have notably different MCP config shapes from the IDEs already covered, and both have shipped users hitting setup issues:

- **Zed** uses a `context_servers` settings key (not `mcpServers`), and expects `command` as a string plus a separate `args` array. It also introduced an `mcp:<server>:<tool>` permission key format in v0.224.0 that users need to know about to grant approval per-tool.
- **OpenCode** uses an `mcp` key with a required `type` discriminator (`"local"` / `"remote"`), `command` as a single array (executable + args), `environment` instead of `env`, automatic OAuth that needs `"oauth": false` to opt out, and a `{env:VAR}` string-interpolation pattern. The OpenCode docs specifically call out that the GitHub MCP server can blow the context window, so the OpenCode guide includes the per-agent tool-gating pattern recommended by their docs.

## What's in the guides

Each guide covers:

- **Remote server (recommended)** using `https://api.githubcopilot.com/mcp/` with a PAT in the `Authorization` header.
- **Local server (Docker)** using `ghcr.io/github/github-mcp-server`.
- **Host-specific gotchas** that I confirmed against the host's official docs (Zed's [MCP docs](https://zed.dev/docs/ai/mcp) and OpenCode's [MCP servers docs](https://opencode.ai/docs/mcp-servers/)).
- **Verify** steps using each host's actual UI / CLI commands (`opencode mcp list`, `opencode mcp debug`, Zed Agent Panel indicator dot).
- **Troubleshooting** for the most common configuration mistakes specific to each host.

## Index/table updates

I also updated:

- `docs/installation-guides/README.md` -- added both hosts to the installation-guides index list and to the "Support by Host Application" table.
- `README.md` -- added both hosts to the "Install in other MCP hosts" (VS Code section) and "Install in Other MCP Hosts" (Claude section) lists.

## Out of scope

- No code changes; docs-only.
- No tool-schema changes -- `script/generate-docs` does not need to run.
- Did not add UI deeplink-install buttons. Zed and OpenCode do not currently expose `mcp-install` deeplink schemes the way Cursor/VS Code do; the guides instead point at the Zed extension gallery (where a community-maintained GitHub MCP extension already exists) and OpenCode's standard config-file flow.
