### PR TITLE
Adding suggest bool flag to suggest type changes to an issue

### DIFF
--- a/pkg/github/__toolsnaps__/update_issue_type.snap
+++ b/pkg/github/__toolsnaps__/update_issue_type.snap
@@ -7,6 +7,10 @@
   "description": "Update the type of an existing issue (e.g. 'bug', 'feature').",
   "inputSchema": {
     "properties": {
+      "is_suggestion": {
+        "description": "If true, propose the issue type change instead of applying it. Defaults to false, which applies the change to the issue.",
+        "type": "boolean"
+      },
       "issue_number": {
         "description": "The issue number to update",
         "minimum": 1,
@@ -28,10 +32,6 @@
       "repo": {
         "description": "Repository name",
         "type": "string"
-      },
-      "suggest": {
-        "description": "If true, propose the issue type change instead of applying it. Defaults to false, which applies the change to the issue.",
-        "type": "boolean"
       }
     },
     "required": [

--- a/pkg/github/__toolsnaps__/update_issue_type.snap
+++ b/pkg/github/__toolsnaps__/update_issue_type.snap
@@ -28,6 +28,10 @@
       "repo": {
         "description": "Repository name",
         "type": "string"
+      },
+      "suggest": {
+        "description": "If true, propose the issue type change instead of applying it. Defaults to false, which applies the change to the issue.",
+        "type": "boolean"
       }
     },
     "required": [

--- a/pkg/github/granular_tools_test.go
+++ b/pkg/github/granular_tools_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -454,6 +455,70 @@ func TestGranularUpdateIssueType(t *testing.T) {
 			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 			assert.False(t, result.IsError)
+		})
+	}
+}
+
+func TestGranularUpdateIssueTypeSuggest(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestArgs map[string]any
+		expected    map[string]any
+	}{
+		{
+			name: "suggest without rationale",
+			requestArgs: map[string]any{
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+				"issue_type":   "bug",
+				"suggest":      true,
+			},
+			expected: map[string]any{
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+				"issue_type":   "bug",
+				"suggested":    true,
+			},
+		},
+		{
+			name: "suggest with rationale",
+			requestArgs: map[string]any{
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+				"issue_type":   "feature",
+				"rationale":    "  Asks for dark mode support  ",
+				"suggest":      true,
+			},
+			expected: map[string]any{
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+				"issue_type":   "feature",
+				"rationale":    "Asks for dark mode support",
+				"suggested":    true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// No HTTP handler registered: any API call would fail the test.
+			deps := BaseDeps{Client: mustNewGHClient(t, MockHTTPClientWithHandlers(nil))}
+			serverTool := GranularUpdateIssueType(translations.NullTranslationHelper)
+			handler := serverTool.Handler(deps)
+
+			request := createMCPRequest(tc.requestArgs)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			require.NoError(t, err)
+			require.False(t, result.IsError)
+
+			textContent := getTextResult(t, result)
+			var got map[string]any
+			require.NoError(t, json.Unmarshal([]byte(textContent.Text), &got))
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -512,6 +512,11 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 							"State the concrete signal (e.g. 'Reports a crash when saving' → bug, 'Asks for dark mode support' → feature).",
 						MaxLength: jsonschema.Ptr(280),
 					},
+					"suggest": {
+						Type: "boolean",
+						Description: "If true, propose the issue type change instead of applying it. " +
+							"Defaults to false, which applies the change to the issue.",
+					},
 				},
 				Required: []string{"owner", "repo", "issue_number", "issue_type"},
 			},
@@ -541,6 +546,28 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 			rationale = strings.TrimSpace(rationale)
 			if len([]rune(rationale)) > 280 {
 				return utils.NewToolResultError("parameter rationale must be 280 characters or less"), nil, nil
+			}
+			suggest, err := OptionalParam[bool](args, "suggest")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			if suggest {
+				suggestion := map[string]any{
+					"owner":        owner,
+					"repo":         repo,
+					"issue_number": issueNumber,
+					"issue_type":   issueType,
+					"suggested":    true,
+				}
+				if rationale != "" {
+					suggestion["rationale"] = rationale
+				}
+				r, err := json.Marshal(suggestion)
+				if err != nil {
+					return utils.NewToolResultErrorFromErr("failed to marshal suggestion", err), nil, nil
+				}
+				return utils.NewToolResultText(string(r)), nil, nil
 			}
 
 			client, err := deps.GetClient(ctx)

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -512,7 +512,7 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 							"State the concrete signal (e.g. 'Reports a crash when saving' → bug, 'Asks for dark mode support' → feature).",
 						MaxLength: jsonschema.Ptr(280),
 					},
-					"suggest": {
+					"is_suggestion": {
 						Type: "boolean",
 						Description: "If true, propose the issue type change instead of applying it. " +
 							"Defaults to false, which applies the change to the issue.",


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
Modifies the issues_granular tool to support a boolean `suggest` flag to the update issue type granular tool.

## Context

Allows agents to only suggest a change to an issue's type, and a user can then choose whether to reject or apply it.

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Closes https://github.com/github/plan-track-agentic-toolkit/issues/128
