### PR TITLE
docs: clarify auth in Codex CLI instructions

### DIFF
--- a/docs/installation-guides/install-codex.md
+++ b/docs/installation-guides/install-codex.md
@@ -20,7 +20,7 @@ bearer_token_env_var = "GITHUB_PAT_TOKEN"
 
 You can also add it via the Codex CLI:
 
-```cli
+```bash
 codex mcp add github --url https://api.githubcopilot.com/mcp/ --bearer-token-env-var GITHUB_PAT_TOKEN
 ```
 

--- a/docs/installation-guides/install-codex.md
+++ b/docs/installation-guides/install-codex.md
@@ -21,8 +21,10 @@ bearer_token_env_var = "GITHUB_PAT_TOKEN"
 You can also add it via the Codex CLI:
 
 ```cli
-codex mcp add github --url https://api.githubcopilot.com/mcp/  
+codex mcp add github --url https://api.githubcopilot.com/mcp/ --bearer-token-env-var GITHUB_PAT_TOKEN
 ```
+
+The `--bearer-token-env-var` option is required for PAT-authenticated access to the hosted GitHub MCP server.
 
 <details>
 <summary><b>Storing Your PAT Securely</b></summary>


### PR DESCRIPTION
## Summary
Updates the Codex installation guide so the CLI setup command configures the required bearer token environment variable for the hosted GitHub MCP server.
 
## Why
Fixes #2421

The existing Codex CLI example only stored the remote MCP server URL, which produced an unauthenticated config and could leave users in a confusing 401 state.
 
## What changed
- Updated `docs/installation-guides/install-codex.md` to add `--bearer-token-env-var GITHUB_PAT_TOKEN` to the `codex mcp add` example.
- Added a short note explaining that the bearer token environment variable is required for PAT-authenticated access to the hosted GitHub MCP server.
 
## MCP impact
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added
 
## Prompts tested (tool changes only)
- N/A
 
## Security / limits
- [ ] No security or limits impact
- [x] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered
 
The docs now direct users to configure Codex to read the PAT from `GITHUB_PAT_TOKEN` instead of creating an unauthenticated remote server entry.
 
 ## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
- [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR
 
 ## Lint & tests
 - [ ] Linted locally with `./script/lint`
 - [ ] Tested locally with `./script/test`ipt/test`
 
 Docs-only change. Validated the documented `codex mcp add github --url https://api.githubcopilot.com/mcp/ --bearer-token-env-var GITHUB_PAT_TOKEN` command writes `bearer_token_env_var = "GITHUB_PAT_TOKEN"` to `~/.codex/config.toml`.
 
 ## Docs
 - [ ] Not needed
 - [x] Updated (README / docs / examples)