### PR TITLE
MCP Apps: align with the 2026-01-26 stable spec

### DIFF
--- a/pkg/github/ui_resources.go
+++ b/pkg/github/ui_resources.go
@@ -10,6 +10,9 @@ import (
 // These are static resources (not templates) that serve HTML content for
 // MCP App-enabled tools. The HTML is built from React/Primer components
 // in the ui/ directory using `script/build-ui`.
+//
+// Resource metadata follows the stable 2026-01-26 MCP Apps spec:
+// https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx
 func RegisterUIResources(s *mcp.Server) {
 	// Register the get_me UI resource
 	s.AddResource(
@@ -27,14 +30,14 @@ func RegisterUIResources(s *mcp.Server) {
 						URI:      GetMeUIResourceURI,
 						MIMEType: MCPAppMIMEType,
 						Text:     html,
-						// MCP Apps UI metadata - CSP configuration to allow loading GitHub avatars
-						// See: https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx
 						Meta: mcp.Meta{
 							"ui": map[string]any{
+								// Allow loading images from GitHub's avatar CDN.
 								"csp": map[string]any{
-									// Allow loading images from GitHub's avatar CDN
 									"resourceDomains": []string{"https://avatars.githubusercontent.com"},
 								},
+								// Profile card renders inline within chat without a host border.
+								"prefersBorder": false,
 							},
 						},
 					},
@@ -59,6 +62,14 @@ func RegisterUIResources(s *mcp.Server) {
 						URI:      IssueWriteUIResourceURI,
 						MIMEType: MCPAppMIMEType,
 						Text:     html,
+						Meta: mcp.Meta{
+							"ui": map[string]any{
+								// No external origins required; documents the secure default.
+								"csp": map[string]any{},
+								// Form surface benefits from a host-provided border.
+								"prefersBorder": true,
+							},
+						},
 					},
 				},
 			}, nil
@@ -81,6 +92,12 @@ func RegisterUIResources(s *mcp.Server) {
 						URI:      PullRequestWriteUIResourceURI,
 						MIMEType: MCPAppMIMEType,
 						Text:     html,
+						Meta: mcp.Meta{
+							"ui": map[string]any{
+								"csp":           map[string]any{},
+								"prefersBorder": true,
+							},
+						},
 					},
 				},
 			}, nil

--- a/pkg/http/handler_test.go
+++ b/pkg/http/handler_test.go
@@ -904,3 +904,44 @@ func TestInsidersRoutePreservesUIMeta(t *testing.T) {
 	require.False(t, plainEnabled, "FF should be off for non-insiders ctx")
 	require.Len(t, plainTools, 1)
 }
+
+// TestUIMetaStrippedWhenClientLacksCapability verifies that even on the
+// /insiders path (where the feature flag is on), UI metadata is stripped from
+// tools/list responses when the client did NOT advertise the
+// io.modelcontextprotocol/ui extension capability. Per the 2026-01-26 MCP
+// Apps spec, servers SHOULD check client capabilities before exposing
+// UI-enabled tools.
+func TestUIMetaStrippedWhenClientLacksCapability(t *testing.T) {
+	const uiURI = "ui://test/widget"
+	uiTool := mockTool("with_ui", "repos", true)
+	uiTool.Tool.Meta = mcp.Meta{"ui": map[string]any{"resourceUri": uiURI}}
+
+	checker := createHTTPFeatureChecker(nil, false)
+	build := func() *inventory.Inventory {
+		inv, err := inventory.NewBuilder().
+			SetTools([]inventory.ServerTool{uiTool}).
+			WithFeatureChecker(checker).
+			WithToolsets([]string{"all"}).
+			Build()
+		require.NoError(t, err)
+		return inv
+	}
+
+	insidersCtx := ghcontext.WithInsidersMode(context.Background(), true)
+	withoutUICap := ghcontext.WithUISupport(insidersCtx, false)
+	withUICap := ghcontext.WithUISupport(insidersCtx, true)
+
+	stripped := build().ToolsForRegistration(withoutUICap)
+	require.Len(t, stripped, 1)
+	require.Nil(t, stripped[0].Tool.Meta["ui"], "_meta.ui should be stripped when client lacks UI capability")
+
+	preserved := build().ToolsForRegistration(withUICap)
+	require.Len(t, preserved, 1)
+	require.NotNil(t, preserved[0].Tool.Meta["ui"], "_meta.ui should be preserved when client advertises UI capability")
+	require.Equal(t, uiURI, preserved[0].Tool.Meta["ui"].(map[string]any)["resourceUri"])
+
+	// Unknown capability falls through to the FF gate (insiders ctx → kept).
+	unknown := build().ToolsForRegistration(insidersCtx)
+	require.Len(t, unknown, 1)
+	require.NotNil(t, unknown[0].Tool.Meta["ui"], "_meta.ui should be preserved when capability is unknown and FF is on")
+}

--- a/pkg/inventory/registry.go
+++ b/pkg/inventory/registry.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"sort"
 
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -169,26 +170,50 @@ func (r *Inventory) ToolsetDescriptions() map[ToolsetID]string {
 
 // ToolsForRegistration returns AvailableTools(ctx) post-processed exactly as
 // RegisterTools would expose them: with MCP Apps UI metadata stripped when
-// the remote_mcp_ui_apps feature flag is not enabled in ctx. Useful for
-// documentation generators and diagnostics that need the same view of the
-// tool surface the server would register.
+// the client cannot consume it. Useful for documentation generators and
+// diagnostics that need the same view of the tool surface the server would
+// register.
+//
+// The strip applies when EITHER of the following is true:
+//
+//   - The remote_mcp_ui_apps feature flag is not enabled in ctx (server-side gate).
+//   - The client explicitly did not advertise the io.modelcontextprotocol/ui
+//     extension capability (per the 2026-01-26 MCP Apps spec, servers SHOULD
+//     check client capabilities before exposing UI-enabled tools). When the
+//     capability is unknown (e.g. stdio paths that do not populate the
+//     context flag) the feature-flag gate is the sole source of truth.
 func (r *Inventory) ToolsForRegistration(ctx context.Context) []ServerTool {
 	tools := r.AvailableTools(ctx)
-	if !r.checkFeatureFlag(ctx, mcpAppsFeatureFlag) {
+	if shouldStripMCPAppsMetadata(ctx, r.checkFeatureFlag(ctx, mcpAppsFeatureFlag)) {
 		tools = stripMCPAppsMetadata(tools)
 	}
 	return tools
 }
 
+// shouldStripMCPAppsMetadata centralises the strip decision so the same logic
+// is exercised by tests and by RegisterTools.
+func shouldStripMCPAppsMetadata(ctx context.Context, featureFlagEnabled bool) bool {
+	if !featureFlagEnabled {
+		return true
+	}
+	// Feature flag is on. Respect the client capability if it is known.
+	if supported, ok := ghcontext.HasUISupport(ctx); ok && !supported {
+		return true
+	}
+	return false
+}
+
 // RegisterTools registers all available tools with the server using the provided dependencies.
-// The context is used for feature flag evaluation.
+// The context is used for feature flag evaluation and client capability checks.
 //
 // MCP Apps UI metadata (`_meta.ui`) is stripped from the registered tools
-// when the MCP Apps feature flag is not enabled for this request. The strip
-// happens here (rather than at Build() time) so the per-request context is
-// in scope — HTTP feature checkers that read insiders mode or user identity
-// from ctx would otherwise see context.Background() and falsely report the
-// flag off, even when the actual request arrived on the /insiders route.
+// when either the MCP Apps feature flag is not enabled for this request, or
+// the client did not advertise the io.modelcontextprotocol/ui extension. The
+// strip happens here (rather than at Build() time) so the per-request
+// context is in scope — HTTP feature checkers that read insiders mode or
+// user identity from ctx would otherwise see context.Background() and
+// falsely report the flag off, even when the actual request arrived on the
+// /insiders route.
 func (r *Inventory) RegisterTools(ctx context.Context, s *mcp.Server, deps any) {
 	for _, tool := range r.ToolsForRegistration(ctx) {
 		tool.RegisterFunc(s, deps)

--- a/pkg/inventory/registry_test.go
+++ b/pkg/inventory/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
@@ -2211,7 +2212,7 @@ func captureRegisteredTools(ctx context.Context, t *testing.T, reg *Inventory) [
 		toolCopy := tools[i].Tool
 		out = append(out, &toolCopy)
 	}
-	if !reg.checkFeatureFlag(ctx, mcpAppsFeatureFlag) {
+	if shouldStripMCPAppsMetadata(ctx, reg.checkFeatureFlag(ctx, mcpAppsFeatureFlag)) {
 		for _, tt := range out {
 			delete(tt.Meta, "ui")
 			if len(tt.Meta) == 0 {
@@ -2220,4 +2221,56 @@ func captureRegisteredTools(ctx context.Context, t *testing.T, reg *Inventory) [
 		}
 	}
 	return out
+}
+
+// TestShouldStripMCPAppsMetadata verifies the spec-conformant strip decision:
+// strip when the feature flag is off, OR when the client explicitly does not
+// advertise the io.modelcontextprotocol/ui extension.
+func TestShouldStripMCPAppsMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setupCtx func() context.Context
+		ffOn     bool
+		want     bool
+	}{
+		{
+			name:     "FF off, capability unknown -> strip",
+			setupCtx: context.Background,
+			ffOn:     false,
+			want:     true,
+		},
+		{
+			name:     "FF off, capability present -> strip (FF wins)",
+			setupCtx: func() context.Context { return ghcontext.WithUISupport(context.Background(), true) },
+			ffOn:     false,
+			want:     true,
+		},
+		{
+			name:     "FF on, capability unknown -> keep",
+			setupCtx: context.Background,
+			ffOn:     true,
+			want:     false,
+		},
+		{
+			name:     "FF on, capability present -> keep",
+			setupCtx: func() context.Context { return ghcontext.WithUISupport(context.Background(), true) },
+			ffOn:     true,
+			want:     false,
+		},
+		{
+			name:     "FF on, capability explicitly absent -> strip",
+			setupCtx: func() context.Context { return ghcontext.WithUISupport(context.Background(), false) },
+			ffOn:     true,
+			want:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldStripMCPAppsMetadata(tc.setupCtx(), tc.ffOn)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/ui/src/apps/get-me/App.tsx
+++ b/ui/src/apps/get-me/App.tsx
@@ -1,4 +1,5 @@
 import { StrictMode, useState } from "react";
+import type React from "react";
 import { createRoot } from "react-dom/client";
 import { Avatar, Box, Text, Link, Heading, Spinner } from "@primer/react";
 import {
@@ -62,8 +63,20 @@ function AvatarWithFallback({ src, login, size }: { src?: string; login: string;
   );
 }
 
-function UserCard({ user }: { user: UserData }) {
+function UserCard({
+  user,
+  onOpenLink,
+}: {
+  user: UserData;
+  onOpenLink?: (url: string) => void;
+}) {
   const d = user.details || {};
+  const handleClick =
+    onOpenLink &&
+    ((url: string) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      onOpenLink(url);
+    });
 
   return (
     <Box
@@ -103,7 +116,13 @@ function UserCard({ user }: { user: UserData }) {
         {d.blog && (
           <>
             <Box sx={{ color: "fg.muted" }}><LinkIcon size={16} /></Box>
-            <Link href={d.blog} target="_blank">{d.blog}</Link>
+            <Link
+              href={d.blog}
+              target="_blank"
+              onClick={handleClick?.(d.blog)}
+            >
+              {d.blog}
+            </Link>
           </>
         )}
         {d.email && (
@@ -140,41 +159,39 @@ function UserCard({ user }: { user: UserData }) {
 }
 
 function GetMeApp() {
-  const { error, toolResult } = useMcpApp({
+  const { error, toolResult, hostContext, openLink } = useMcpApp({
     appName: "github-mcp-server-get-me",
   });
 
-  if (error) {
-    return <Text sx={{ color: "danger.fg" }}>Error: {error.message}</Text>;
-  }
+  const content = (() => {
+    if (error) {
+      return <Text sx={{ color: "danger.fg" }}>Error: {error.message}</Text>;
+    }
+    if (!toolResult) {
+      return (
+        <Box display="flex" alignItems="center" gap={2}>
+          <Spinner size="small" />
+          <Text sx={{ color: "fg.muted" }}>Loading user data...</Text>
+        </Box>
+      );
+    }
+    const textContent = toolResult.content?.find((c: { type: string }) => c.type === "text");
+    if (!textContent || !("text" in textContent)) {
+      return <Text sx={{ color: "danger.fg" }}>No user data in response</Text>;
+    }
+    try {
+      const userData = JSON.parse(textContent.text as string) as UserData;
+      return <UserCard user={userData} onOpenLink={(url) => void openLink(url)} />;
+    } catch {
+      return <Text sx={{ color: "danger.fg" }}>Failed to parse user data</Text>;
+    }
+  })();
 
-  if (!toolResult) {
-    return (
-      <Box display="flex" alignItems="center" gap={2}>
-        <Spinner size="small" />
-        <Text sx={{ color: "fg.muted" }}>Loading user data...</Text>
-      </Box>
-    );
-  }
-
-  // Parse user data from tool result
-  const textContent = toolResult.content?.find((c: { type: string }) => c.type === "text");
-  if (!textContent || !("text" in textContent)) {
-    return <Text sx={{ color: "danger.fg" }}>No user data in response</Text>;
-  }
-
-  try {
-    const userData = JSON.parse(textContent.text as string) as UserData;
-    return <UserCard user={userData} />;
-  } catch {
-    return <Text sx={{ color: "danger.fg" }}>Failed to parse user data</Text>;
-  }
+  return <AppProvider hostContext={hostContext}>{content}</AppProvider>;
 }
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <AppProvider>
-      <GetMeApp />
-    </AppProvider>
+    <GetMeApp />
   </StrictMode>
 );

--- a/ui/src/apps/issue-write/App.tsx
+++ b/ui/src/apps/issue-write/App.tsx
@@ -121,7 +121,7 @@ function CreateIssueApp() {
   const [error, setError] = useState<string | null>(null);
   const [successIssue, setSuccessIssue] = useState<IssueResult | null>(null);
 
-  const { app, error: appError, toolInput, callTool } = useMcpApp({
+  const { app, error: appError, toolInput, callTool, hostContext, setModelContext } = useMcpApp({
     appName: "github-mcp-server-issue-write",
   });
 
@@ -181,6 +181,19 @@ function CreateIssueApp() {
           try {
             const issueData = JSON.parse(textContent.text as string);
             setSuccessIssue(issueData);
+            // Per the MCP Apps 2026-01-26 spec, push the created/updated issue
+            // into the model's context so subsequent agent turns have it.
+            void setModelContext({
+              structuredContent: issueData,
+              content: [
+                {
+                  type: "text",
+                  text: isUpdateMode
+                    ? `Issue #${issueNumber} in ${owner}/${repo} was updated by the user via the issue-write view.`
+                    : `A new issue was created in ${owner}/${repo} by the user via the issue-write view.`,
+                },
+              ],
+            });
           } catch {
             setSuccessIssue({ title, body });
           }
@@ -191,8 +204,9 @@ function CreateIssueApp() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [title, body, owner, repo, isUpdateMode, issueNumber, callTool]);
+  }, [title, body, owner, repo, isUpdateMode, issueNumber, callTool, setModelContext]);
 
+  const body_node = (() => {
   if (appError) {
     return (
       <Flash variant="danger" sx={{ m: 2 }}>
@@ -307,12 +321,13 @@ function CreateIssueApp() {
       </Box>
     </Box>
   );
+  })();
+
+  return <AppProvider hostContext={hostContext}>{body_node}</AppProvider>;
 }
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <AppProvider>
-      <CreateIssueApp />
-    </AppProvider>
+    <CreateIssueApp />
   </StrictMode>
 );

--- a/ui/src/apps/pr-write/App.tsx
+++ b/ui/src/apps/pr-write/App.tsx
@@ -126,7 +126,7 @@ function CreatePRApp() {
   const [isDraft, setIsDraft] = useState(false);
   const [maintainerCanModify, setMaintainerCanModify] = useState(true);
 
-  const { app, error: appError, toolInput, callTool } = useMcpApp({
+  const { app, error: appError, toolInput, callTool, hostContext, setModelContext } = useMcpApp({
     appName: "github-mcp-server-create-pull-request",
   });
 
@@ -175,6 +175,17 @@ function CreatePRApp() {
         if (textContent && textContent.type === "text" && textContent.text) {
           const prData = JSON.parse(textContent.text);
           setSuccessPR(prData);
+          // Push the new PR into the model context so subsequent agent
+          // turns can reference it (MCP Apps 2026-01-26 ui/update-model-context).
+          void setModelContext({
+            structuredContent: prData,
+            content: [
+              {
+                type: "text",
+                text: `A new pull request was created in ${owner}/${repo} by the user via the create-pull-request view.`,
+              },
+            ],
+          });
         }
       }
     } catch (e) {
@@ -182,11 +193,11 @@ function CreatePRApp() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [title, body, owner, repo, head, base, isDraft, maintainerCanModify, callTool]);
+  }, [title, body, owner, repo, head, base, isDraft, maintainerCanModify, callTool, setModelContext]);
 
   if (successPR) {
     return (
-      <AppProvider>
+      <AppProvider hostContext={hostContext}>
         <SuccessView pr={successPR} owner={owner} repo={repo} submittedTitle={submittedTitle} />
       </AppProvider>
     );
@@ -194,7 +205,7 @@ function CreatePRApp() {
 
   if (!app && !appError) {
     return (
-      <AppProvider>
+      <AppProvider hostContext={hostContext}>
         <Box display="flex" alignItems="center" justifyContent="center" p={4}>
           <Spinner size="medium" />
         </Box>
@@ -204,14 +215,14 @@ function CreatePRApp() {
 
   if (appError) {
     return (
-      <AppProvider>
+      <AppProvider hostContext={hostContext}>
         <Flash variant="danger">{appError.message}</Flash>
       </AppProvider>
     );
   }
 
   return (
-    <AppProvider>
+    <AppProvider hostContext={hostContext}>
       <Box
         borderWidth={1}
         borderStyle="solid"

--- a/ui/src/components/AppProvider.tsx
+++ b/ui/src/components/AppProvider.tsx
@@ -1,26 +1,50 @@
 import { ThemeProvider, BaseStyles, Box } from "@primer/react";
-import type { ReactNode } from "react";
-import { useEffect } from "react";
+import type { ReactNode, CSSProperties } from "react";
+import { useEffect, useMemo } from "react";
+import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import { FeedbackFooter } from "./FeedbackFooter";
 
 interface AppProviderProps {
   children: ReactNode;
+  hostContext?: McpUiHostContext;
 }
 
-export function AppProvider({ children }: AppProviderProps) {
+export function AppProvider({ children, hostContext }: AppProviderProps) {
+  const hostTheme = hostContext?.theme;
+  const hostVariables = hostContext?.styles?.variables;
+
   useEffect(() => {
-    // Set up theme data attributes for proper Primer theming
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const colorMode = prefersDark ? "dark" : "light";
+    // Prefer the host-supplied theme; fall back to the OS preference.
+    const colorMode =
+      hostTheme === "light" || hostTheme === "dark"
+        ? hostTheme
+        : window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
     document.body.setAttribute("data-color-mode", colorMode);
     document.body.setAttribute("data-light-theme", "light");
     document.body.setAttribute("data-dark-theme", "dark");
-  }, []);
+  }, [hostTheme]);
+
+  // Project the host's standardized CSS variables onto the root so child
+  // components can consume them via `var(--color-...)`. We rely on Primer's
+  // own defaults when the host does not supply variables.
+  const styleVars = useMemo<CSSProperties | undefined>(() => {
+    if (!hostVariables) return undefined;
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(hostVariables)) {
+      if (typeof value === "string") out[key] = value;
+    }
+    return out as CSSProperties;
+  }, [hostVariables]);
+
+  const colorMode =
+    hostTheme === "light" || hostTheme === "dark" ? hostTheme : "auto";
 
   return (
-    <ThemeProvider colorMode="auto">
+    <ThemeProvider colorMode={colorMode}>
       <BaseStyles>
-        <Box p={3}>
+        <Box p={3} style={styleVars}>
           {children}
           <FeedbackFooter />
         </Box>

--- a/ui/src/hooks/useMcpApp.ts
+++ b/ui/src/hooks/useMcpApp.ts
@@ -1,11 +1,23 @@
 import { useApp as useExtApp } from "@modelcontextprotocol/ext-apps/react";
-import type { App } from "@modelcontextprotocol/ext-apps";
+import type {
+  App,
+  McpUiDisplayMode,
+  McpUiHostContext,
+  McpUiUpdateModelContextRequest,
+} from "@modelcontextprotocol/ext-apps";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 interface UseMcpAppOptions {
   appName: string;
   appVersion?: string;
+  /**
+   * Display modes this view supports. Per the MCP Apps 2026-01-26 spec, a
+   * view MUST declare every display mode it supports during initialization.
+   * Defaults to ["inline"] which is the only mode the bundled github-mcp-server
+   * views currently render.
+   */
+  availableDisplayModes?: McpUiDisplayMode[];
   onToolResult?: (result: CallToolResult) => void;
   onToolInput?: (input: Record<string, unknown>) => void;
 }
@@ -15,21 +27,38 @@ interface UseMcpAppReturn {
   error: Error | null;
   toolResult: CallToolResult | null;
   toolInput: Record<string, unknown> | null;
+  hostContext: McpUiHostContext | undefined;
   callTool: (name: string, args: Record<string, unknown>) => Promise<CallToolResult>;
+  /**
+   * Sends `ui/update-model-context` so the agent's next turn sees the
+   * supplied structured content / blocks. No-op when the app isn't connected.
+   */
+  setModelContext: (
+    params: McpUiUpdateModelContextRequest["params"]
+  ) => Promise<void>;
+  /**
+   * Sends `ui/open-link` so the host opens an external URL in the user's
+   * browser. Falls back to `window.open` when the app isn't connected.
+   */
+  openLink: (url: string) => Promise<void>;
 }
 
 export function useMcpApp({
   appName,
   appVersion = "1.0.0",
+  availableDisplayModes = ["inline"],
   onToolResult,
   onToolInput,
 }: UseMcpAppOptions): UseMcpAppReturn {
   const [toolResult, setToolResult] = useState<CallToolResult | null>(null);
   const [toolInput, setToolInput] = useState<Record<string, unknown> | null>(null);
+  const [hostContext, setHostContext] = useState<McpUiHostContext | undefined>(undefined);
 
+  // The SDK's autoResize=true installs a ResizeObserver that emits
+  // `ui/notifications/size-changed` automatically; no manual wiring needed.
   const { app, error } = useExtApp({
     appInfo: { name: appName, version: appVersion },
-    capabilities: {},
+    capabilities: { availableDisplayModes },
     autoResize: true,
     strict: import.meta.env.DEV,
     onAppCreated: (app) => {
@@ -42,9 +71,18 @@ export function useMcpApp({
         setToolInput(args);
         onToolInput?.(args);
       };
+      app.onhostcontextchanged = (params) => {
+        setHostContext((prev) => ({ ...(prev ?? {}), ...params }));
+      };
       app.onerror = console.error;
     },
   });
+
+  useEffect(() => {
+    if (!app) return;
+    const initial = app.getHostContext();
+    if (initial) setHostContext(initial);
+  }, [app]);
 
   const callTool = useCallback(
     async (name: string, args: Record<string, unknown>) => {
@@ -54,5 +92,33 @@ export function useMcpApp({
     [app]
   );
 
-  return { app, error, toolResult, toolInput, callTool };
+  const setModelContext = useCallback<UseMcpAppReturn["setModelContext"]>(
+    async (params) => {
+      if (!app) return;
+      await app.updateModelContext(params);
+    },
+    [app]
+  );
+
+  const openLink = useCallback<UseMcpAppReturn["openLink"]>(
+    async (url) => {
+      if (!app) {
+        window.open(url, "_blank", "noopener,noreferrer");
+        return;
+      }
+      await app.openLink({ url });
+    },
+    [app]
+  );
+
+  return {
+    app,
+    error,
+    toolResult,
+    toolInput,
+    hostContext,
+    callTool,
+    setModelContext,
+    openLink,
+  };
 }


### PR DESCRIPTION
Aligns this repository's MCP Apps implementation with the stable 2026-01-26 spec (<https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx>).

### Server (Go)
- **Strip `_meta.ui` when the client lacks the UI capability.** Per the spec, servers SHOULD check client capabilities before advertising UI-enabled tools. The per-request inventory strip now also applies when the request context reports the client has no UI support; unknown capability (e.g. stdio paths) falls through to the existing feature-flag gate. New unit test in `pkg/inventory/registry_test.go` and integration test in `pkg/http/handler_test.go`.
- **`prefersBorder` on every UI resource** (false for the get-me profile card, true for the issue/PR write forms) — the spec recommends an explicit value because host defaults vary.
- **Empty `csp: {}`** on `issue_write_ui` and `pr_write_ui` to document they need no external origins.
- Spec-link comment now points at the stable `/specification/2026-01-26/` path.

### Views (React, `ui/`)
- Declare **`appCapabilities.availableDisplayModes`** during initialization (defaults to `["inline"]`); required by the new spec.
- Consume **`McpUiHostContext`**: track host `theme` and `styles.variables`, project the standardized CSS custom properties onto the root element, and pass the theme to Primer's `ThemeProvider`.
- New `useMcpApp` helpers:
  - `setModelContext(...)` — used by issue-write and pr-write after a successful submission to update the agent's model context with the created/updated entity (`ui/update-model-context`).
  - `openLink(url)` — used by the get-me view's external blog link (`ui/open-link`).
- Bundles rebuilt against the resolved `@modelcontextprotocol/ext-apps` 1.7.2 (matches the `^1.7.2` already pinned in `package.json`).

### Testing
- `script/lint` — clean.
- `script/test` — all passing, including new `TestShouldStripMCPAppsMetadata` and `TestUIMetaStrippedWhenClientLacksCapability`.
- `npm run typecheck && npm run build` — clean.

Companion PR on `github-mcp-server-remote`: https://github.com/github/github-mcp-server-remote/pull/849