### PR TITLE
fix: align Implementation.Name with VS Code config key

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -87,7 +87,7 @@ func NewMCPServer(ctx context.Context, cfg *MCPServerConfig, deps ToolDependenci
 		o(serverOpts)
 	}
 
-	ghServer := NewServer(cfg.Version, cfg.Translator("SERVER_NAME", "github-mcp-server"), cfg.Translator("SERVER_TITLE", "GitHub MCP Server"), serverOpts)
+	ghServer := NewServer(cfg.Version, cfg.Translator("SERVER_NAME", "github"), cfg.Translator("SERVER_TITLE", "GitHub MCP Server"), serverOpts)
 
 	// Add middlewares. Order matters - for example, the error context middleware should be applied last so that it runs FIRST (closest to the handler) to ensure all errors are captured,
 	// and any middleware that needs to read or modify the context should be before it.
@@ -144,14 +144,20 @@ func addGitHubAPIErrorToContext(next mcp.MethodHandler) mcp.MethodHandler {
 
 // NewServer creates a new GitHub MCP server with the given version, server
 // name, display title, and options. If name or title are empty the defaults
-// "github-mcp-server" and "GitHub MCP Server" are used.
+// "github" and "GitHub MCP Server" are used.
+//
+// The "github" name aligns with the configuration key VS Code derives from
+// the human-readable title, so tool prefixes like "github/*" resolve. It
+// intentionally diverges from the MCP registry identifier
+// (io.github.github/github-mcp-server in server.json), which uses the source
+// repo's last segment per the registry naming convention.
 func NewServer(version, name, title string, opts *mcp.ServerOptions) *mcp.Server {
 	if opts == nil {
 		opts = &mcp.ServerOptions{}
 	}
 
 	if name == "" {
-		name = "github-mcp-server"
+		name = "github"
 	}
 	if title == "" {
 		title = "GitHub MCP Server"

--- a/pkg/github/server_test.go
+++ b/pkg/github/server_test.go
@@ -207,7 +207,7 @@ func TestNewServer_NameAndTitleViaTranslation(t *testing.T) {
 		{
 			name:          "defaults when using NullTranslationHelper",
 			translator:    translations.NullTranslationHelper,
-			expectedName:  "github-mcp-server",
+			expectedName:  "github",
 			expectedTitle: "GitHub MCP Server",
 		},
 		{
@@ -242,7 +242,7 @@ func TestNewServer_NameAndTitleViaTranslation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			srv := NewServer("v1.0.0", tt.translator("SERVER_NAME", "github-mcp-server"), tt.translator("SERVER_TITLE", "GitHub MCP Server"), nil)
+			srv := NewServer("v1.0.0", tt.translator("SERVER_NAME", "github"), tt.translator("SERVER_TITLE", "GitHub MCP Server"), nil)
 			require.NotNil(t, srv)
 
 			// Connect a client to retrieve the initialize result and verify ServerInfo.


### PR DESCRIPTION
Sets the protocol-level `Implementation.Name` to `"github"` so the slug matches the configuration key VS Code derives from `server.json`'s title. Without this, references using the recommended `github/*` tool prefix surface as `Unknown tool 'github/github-mcp-server/*'`.

The MCP registry name in `server.json` (`io.github.github/github-mcp-server`) intentionally still uses the source-repo's last segment per the [registry naming convention](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md) — only the client-facing `Implementation.Name` changes here. A comment on `NewServer` documents the divergence so future contributors don't try to "re-sync" them.

Replaces #2043 (force-pushed branch, original commit lost). Co-authored to @yashhzd.

Fixes #1402

### Verification

- `script/lint` — clean
- `go test ./pkg/github -run TestNewServer_NameAndTitleViaTranslation -count=1` — passes (test expectations updated)
- `script/test` — passes