### PR TITLE
fix: hide write UI resources in read-only mode

### DIFF
--- a/pkg/github/server.go
+++ b/pkg/github/server.go
@@ -111,7 +111,7 @@ func NewMCPServer(ctx context.Context, cfg *MCPServerConfig, deps ToolDependenci
 	// remote/HTTP server also serves them, fixing the "-32002 Resource not
 	// found" error clients hit after the tool returns a ui:// URI.
 	if UIAssetsAvailable() {
-		RegisterUIResources(ghServer)
+		RegisterUIResources(ghServer, cfg.ReadOnly)
 	}
 
 	return ghServer, nil

--- a/pkg/github/ui_resources.go
+++ b/pkg/github/ui_resources.go
@@ -13,7 +13,7 @@ import (
 //
 // Resource metadata follows the stable 2026-01-26 MCP Apps spec:
 // https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx
-func RegisterUIResources(s *mcp.Server) {
+func RegisterUIResources(s *mcp.Server, readOnly bool) {
 	// Register the get_me UI resource
 	s.AddResource(
 		&mcp.Resource{
@@ -45,6 +45,10 @@ func RegisterUIResources(s *mcp.Server) {
 			}, nil
 		},
 	)
+
+	if readOnly {
+		return
+	}
 
 	// Register the issue_write UI resource
 	s.AddResource(

--- a/pkg/github/ui_resources_test.go
+++ b/pkg/github/ui_resources_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/github/github-mcp-server/pkg/inventory"
@@ -26,7 +27,7 @@ func TestRegisterUIResources_ReadableViaClient(t *testing.T) {
 	}
 
 	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
-	RegisterUIResources(srv)
+	RegisterUIResources(srv, false)
 
 	// Connect an in-memory client/server pair and read each advertised URI.
 	st, ct := mcp.NewInMemoryTransports()
@@ -111,6 +112,49 @@ func TestNewMCPServer_RegistersUIResources(t *testing.T) {
 	require.NotNil(t, res)
 	require.NotEmpty(t, res.Contents)
 	assert.Equal(t, MCPAppMIMEType, res.Contents[0].MIMEType)
+}
+
+func TestRegisterUIResources_ReadOnlySkipsWriteResources(t *testing.T) {
+	t.Parallel()
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	RegisterUIResources(srv, true)
+
+	st, ct := mcp.NewInMemoryTransports()
+
+	type clientResult struct {
+		res *mcp.ListResourcesResult
+		err error
+	}
+	clientCh := make(chan clientResult, 1)
+	go func() {
+		client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+		cs, err := client.Connect(context.Background(), ct, nil)
+		if err != nil {
+			clientCh <- clientResult{err: err}
+			return
+		}
+		defer func() { _ = cs.Close() }()
+
+		res, err := cs.ListResources(context.Background(), nil)
+		clientCh <- clientResult{res: res, err: err}
+	}()
+
+	ss, err := srv.Connect(context.Background(), st, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ss.Close() })
+
+	got := <-clientCh
+	require.NoError(t, got.err)
+	require.NotNil(t, got.res)
+
+	names := make([]string, 0, len(got.res.Resources))
+	for _, res := range got.res.Resources {
+		names = append(names, res.Name)
+	}
+	slices.Sort(names)
+
+	assert.Equal(t, []string{"get_me_ui"}, names)
 }
 
 // mustEmptyInventory builds an empty inventory for tests that only care about


### PR DESCRIPTION
﻿## Summary
- pass the server read-only setting into MCP App UI resource registration
- keep the read-only `get_me_ui` resource available
- skip `issue_write_ui` and `pr_write_ui` when write tools are filtered by `--read-only`

Fixes #2519.

## To verify
- `go test ./pkg/github -run "TestRegisterUIResources_ReadOnlySkipsWriteResources|TestRegisterUIResources_ReadableViaClient|TestNewMCPServer_RegistersUIResources" -count=1`
- `go test ./pkg/github -count=1`
- `git diff --check`
