### PR TITLE
fix: let get_me handle missing arguments

### DIFF
--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -43,7 +43,7 @@ type UserDetails struct {
 
 // GetMe creates a tool to get details of the authenticated user.
 func GetMe(t translations.TranslationHelperFunc) inventory.ServerTool {
-	return NewTool(
+	return NewToolFromHandler(
 		ToolsetMetadataContext,
 		mcp.Tool{
 			Name:        "get_me",
@@ -63,10 +63,10 @@ func GetMe(t translations.TranslationHelperFunc) inventory.ServerTool {
 			},
 		},
 		nil,
-		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			client, err := deps.GetClient(ctx)
 			if err != nil {
-				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil
 			}
 
 			user, res, err := client.Users.Get(ctx, "")
@@ -75,7 +75,7 @@ func GetMe(t translations.TranslationHelperFunc) inventory.ServerTool {
 					"failed to get user",
 					res,
 					err,
-				), nil, nil
+				), nil
 			}
 
 			// Create minimal user representation instead of returning full user object
@@ -107,7 +107,7 @@ func GetMe(t translations.TranslationHelperFunc) inventory.ServerTool {
 
 			result := MarshalledTextResult(minimalUser)
 			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelGetMe())
-			return result, nil, nil
+			return result, nil
 		},
 	)
 }

--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/github/github-mcp-server/internal/toolsnaps"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v87/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,6 +51,7 @@ func Test_GetMe(t *testing.T) {
 		mockedClient       *http.Client
 		clientErr          string // if set, GetClient returns this error
 		requestArgs        map[string]any
+		missingArguments   bool
 		expectToolError    bool
 		expectedUser       *github.User
 		expectedToolErrMsg string
@@ -62,6 +64,15 @@ func Test_GetMe(t *testing.T) {
 			requestArgs:     map[string]any{},
 			expectToolError: false,
 			expectedUser:    mockUser,
+		},
+		{
+			name: "successful get user with missing arguments",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				GetUser: mockResponse(t, http.StatusOK, mockUser),
+			}),
+			missingArguments: true,
+			expectToolError:  false,
+			expectedUser:     mockUser,
 		},
 		{
 			name: "successful get user with reason",
@@ -103,7 +114,16 @@ func Test_GetMe(t *testing.T) {
 			}
 			handler := serverTool.Handler(deps)
 
-			request := createMCPRequest(tc.requestArgs)
+			var request mcp.CallToolRequest
+			if tc.missingArguments {
+				request = mcp.CallToolRequest{
+					Params: &mcp.CallToolParamsRaw{
+						Name: "get_me",
+					},
+				}
+			} else {
+				request = createMCPRequest(tc.requestArgs)
+			}
 			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Fixes #2587.

## Summary

`get_me` is a zero-argument tool, but it was registered through the generic argument-decoding helper. That still makes the call sensitive to whether a client sends `{}` or omits `arguments` entirely.

This patch registers `get_me` with the no-argument handler path instead. The handler does not need parsed arguments, so it can serve both forms consistently:

- `arguments: {}`
- no `arguments` field

## Validation

- `go test ./pkg/github -run Test_GetMe -count=1`
- `go test ./pkg/github -count=1`
- `go test ./... -count=1`
- `gofmt -w pkg/github/context_tools.go pkg/github/context_tools_test.go`
- `git diff --check origin/main..HEAD`
