### PR TITLE
use the REST PATCH endpoint if updating rationale or suggestion

### DIFF
--- a/pkg/github/granular_tools_test.go
+++ b/pkg/github/granular_tools_test.go
@@ -1313,7 +1313,11 @@ func TestGranularSetIssueFields(t *testing.T) {
 						"rationale": "Reflects the reported severity",
 					},
 				},
-			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{Number: gogithub.Ptr(5)})),
+			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{
+				ID:      gogithub.Ptr(int64(123)),
+				Number:  gogithub.Ptr(5),
+				HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/5"),
+			})),
 		}))
 
 		deps := BaseDeps{Client: restClient, GQLClient: gqlClient}
@@ -1335,6 +1339,9 @@ func TestGranularSetIssueFields(t *testing.T) {
 		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
+		textContent := getTextResult(t, result)
+		assert.Contains(t, textContent.Text, `"id":"123"`)
+		assert.Contains(t, textContent.Text, "https://github.com/owner/repo/issues/5")
 	})
 
 	t.Run("rationale too long returns error", func(t *testing.T) {
@@ -1396,7 +1403,11 @@ func TestGranularSetIssueFields(t *testing.T) {
 						"suggest":   true,
 					},
 				},
-			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{Number: gogithub.Ptr(5)})),
+			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{
+				ID:      gogithub.Ptr(int64(123)),
+				Number:  gogithub.Ptr(5),
+				HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/5"),
+			})),
 		}))
 
 		deps := BaseDeps{Client: restClient, GQLClient: gqlClient}
@@ -1413,6 +1424,138 @@ func TestGranularSetIssueFields(t *testing.T) {
 					"text_value":    "hello",
 					"rationale":     "Reflects the reported severity",
 					"is_suggestion": true,
+				},
+			},
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		textContent := getTextResult(t, result)
+		assert.Contains(t, textContent.Text, `"id":"123"`)
+		assert.Contains(t, textContent.Text, "https://github.com/owner/repo/issues/5")
+	})
+
+	t.Run("successful set with single_select_option_id and rationale", func(t *testing.T) {
+		fieldsQuery := githubv4mock.NewQueryMatcher(
+			issueFieldsRepoQuery{},
+			map[string]any{
+				"owner": githubv4.String("owner"),
+				"name":  githubv4.String("repo"),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issueFields": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"__typename":     "IssueFieldSingleSelect",
+								"id":             "FIELD_1",
+								"fullDatabaseId": "42",
+								"name":           "Priority",
+								"dataType":       "SINGLE_SELECT",
+								"visibility":     "ALL",
+								"options": []any{
+									map[string]any{"id": "OPT_HIGH", "name": "High", "description": ""},
+								},
+							},
+						},
+					},
+				},
+			}),
+		)
+		gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(fieldsQuery))
+
+		restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			PatchReposIssuesByOwnerByRepoByIssueNumber: expectRequestBody(t, map[string]any{
+				"issue_field_values": []any{
+					map[string]any{
+						"field_id":  float64(42),
+						"value":     "High",
+						"rationale": "Severe customer impact",
+					},
+				},
+			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{
+				ID:      gogithub.Ptr(int64(123)),
+				Number:  gogithub.Ptr(5),
+				HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/5"),
+			})),
+		}))
+
+		deps := BaseDeps{Client: restClient, GQLClient: gqlClient}
+		serverTool := GranularSetIssueFields(translations.NullTranslationHelper)
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":        "owner",
+			"repo":         "repo",
+			"issue_number": float64(5),
+			"fields": []any{
+				map[string]any{
+					"field_id":                "FIELD_1",
+					"single_select_option_id": "OPT_HIGH",
+					"rationale":               "Severe customer impact",
+				},
+			},
+		})
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+
+	t.Run("successful set with number value and rationale", func(t *testing.T) {
+		fieldsQuery := githubv4mock.NewQueryMatcher(
+			issueFieldsRepoQuery{},
+			map[string]any{
+				"owner": githubv4.String("owner"),
+				"name":  githubv4.String("repo"),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issueFields": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"__typename":     "IssueFieldNumber",
+								"id":             "FIELD_1",
+								"fullDatabaseId": "42",
+								"name":           "Score",
+								"dataType":       "NUMBER",
+								"visibility":     "ALL",
+							},
+						},
+					},
+				},
+			}),
+		)
+		gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(fieldsQuery))
+
+		restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			PatchReposIssuesByOwnerByRepoByIssueNumber: expectRequestBody(t, map[string]any{
+				"issue_field_values": []any{
+					map[string]any{
+						"field_id":  float64(42),
+						"value":     float64(7),
+						"rationale": "Initial estimate",
+					},
+				},
+			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{
+				ID:      gogithub.Ptr(int64(123)),
+				Number:  gogithub.Ptr(5),
+				HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/5"),
+			})),
+		}))
+
+		deps := BaseDeps{Client: restClient, GQLClient: gqlClient}
+		serverTool := GranularSetIssueFields(translations.NullTranslationHelper)
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":        "owner",
+			"repo":         "repo",
+			"issue_number": float64(5),
+			"fields": []any{
+				map[string]any{
+					"field_id":     "FIELD_1",
+					"number_value": float64(7),
+					"rationale":    "Initial estimate",
 				},
 			},
 		})

--- a/pkg/github/granular_tools_test.go
+++ b/pkg/github/granular_tools_test.go
@@ -1277,75 +1277,46 @@ func TestGranularSetIssueFields(t *testing.T) {
 	})
 
 	t.Run("successful set with text value and rationale", func(t *testing.T) {
-		matchers := []githubv4mock.Matcher{
-			githubv4mock.NewQueryMatcher(
-				struct {
-					Repository struct {
-						Issue struct {
-							ID githubv4.ID
-						} `graphql:"issue(number: $issueNumber)"`
-					} `graphql:"repository(owner: $owner, name: $repo)"`
-				}{},
-				map[string]any{
-					"owner":       githubv4.String("owner"),
-					"repo":        githubv4.String("repo"),
-					"issueNumber": githubv4.Int(5),
-				},
-				githubv4mock.DataResponse(map[string]any{
-					"repository": map[string]any{
-						"issue": map[string]any{"id": "ISSUE_123"},
-					},
-				}),
-			),
-			githubv4mock.NewMutationMatcher(
-				struct {
-					SetIssueFieldValue struct {
-						Issue struct {
-							ID     githubv4.ID
-							Number githubv4.Int
-							URL    githubv4.String
-						}
-						IssueFieldValues []struct {
-							TextValue struct {
-								Value string
-							} `graphql:"... on IssueFieldTextValue"`
-							SingleSelectValue struct {
-								Name string
-							} `graphql:"... on IssueFieldSingleSelectValue"`
-							DateValue struct {
-								Value string
-							} `graphql:"... on IssueFieldDateValue"`
-							NumberValue struct {
-								Value float64
-							} `graphql:"... on IssueFieldNumberValue"`
-						}
-					} `graphql:"setIssueFieldValue(input: $input)"`
-				}{},
-				SetIssueFieldValueInput{
-					IssueID: githubv4.ID("ISSUE_123"),
-					IssueFields: []IssueFieldCreateOrUpdateInput{
-						{
-							FieldID:   githubv4.ID("FIELD_1"),
-							TextValue: githubv4.NewString(githubv4.String("hello")),
-							Rationale: githubv4.NewString(githubv4.String("Reflects the reported severity")),
+		// fetchIssueFields query mock for resolving the field's database ID.
+		fieldsQuery := githubv4mock.NewQueryMatcher(
+			issueFieldsRepoQuery{},
+			map[string]any{
+				"owner": githubv4.String("owner"),
+				"name":  githubv4.String("repo"),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issueFields": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"__typename":     "IssueFieldText",
+								"id":             "FIELD_1",
+								"fullDatabaseId": "42",
+								"name":           "DRI",
+								"dataType":       "TEXT",
+								"visibility":     "ALL",
+							},
 						},
 					},
 				},
-				nil,
-				githubv4mock.DataResponse(map[string]any{
-					"setIssueFieldValue": map[string]any{
-						"issue": map[string]any{
-							"id":     "ISSUE_123",
-							"number": 5,
-							"url":    "https://github.com/owner/repo/issues/5",
-						},
-					},
-				}),
-			),
-		}
+			}),
+		)
+		gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(fieldsQuery))
 
-		gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(matchers...))
-		deps := BaseDeps{GQLClient: gqlClient}
+		// REST PATCH mock asserting the issue_field_values wire format.
+		restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			PatchReposIssuesByOwnerByRepoByIssueNumber: expectRequestBody(t, map[string]any{
+				"issue_field_values": []any{
+					map[string]any{
+						"field_id":  float64(42),
+						"value":     "hello",
+						"rationale": "Reflects the reported severity",
+					},
+				},
+			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{Number: gogithub.Ptr(5)})),
+		}))
+
+		deps := BaseDeps{Client: restClient, GQLClient: gqlClient}
 		serverTool := GranularSetIssueFields(translations.NullTranslationHelper)
 		handler := serverTool.Handler(deps)
 
@@ -1390,77 +1361,45 @@ func TestGranularSetIssueFields(t *testing.T) {
 	})
 
 	t.Run("successful set with suggest flag", func(t *testing.T) {
-		suggestTrue := githubv4.Boolean(true)
-		matchers := []githubv4mock.Matcher{
-			githubv4mock.NewQueryMatcher(
-				struct {
-					Repository struct {
-						Issue struct {
-							ID githubv4.ID
-						} `graphql:"issue(number: $issueNumber)"`
-					} `graphql:"repository(owner: $owner, name: $repo)"`
-				}{},
-				map[string]any{
-					"owner":       githubv4.String("owner"),
-					"repo":        githubv4.String("repo"),
-					"issueNumber": githubv4.Int(5),
-				},
-				githubv4mock.DataResponse(map[string]any{
-					"repository": map[string]any{
-						"issue": map[string]any{"id": "ISSUE_123"},
-					},
-				}),
-			),
-			githubv4mock.NewMutationMatcher(
-				struct {
-					SetIssueFieldValue struct {
-						Issue struct {
-							ID     githubv4.ID
-							Number githubv4.Int
-							URL    githubv4.String
-						}
-						IssueFieldValues []struct {
-							TextValue struct {
-								Value string
-							} `graphql:"... on IssueFieldTextValue"`
-							SingleSelectValue struct {
-								Name string
-							} `graphql:"... on IssueFieldSingleSelectValue"`
-							DateValue struct {
-								Value string
-							} `graphql:"... on IssueFieldDateValue"`
-							NumberValue struct {
-								Value float64
-							} `graphql:"... on IssueFieldNumberValue"`
-						}
-					} `graphql:"setIssueFieldValue(input: $input)"`
-				}{},
-				SetIssueFieldValueInput{
-					IssueID: githubv4.ID("ISSUE_123"),
-					IssueFields: []IssueFieldCreateOrUpdateInput{
-						{
-							FieldID:   githubv4.ID("FIELD_1"),
-							TextValue: githubv4.NewString(githubv4.String("hello")),
-							Rationale: githubv4.NewString(githubv4.String("Reflects the reported severity")),
-							Suggest:   &suggestTrue,
+		fieldsQuery := githubv4mock.NewQueryMatcher(
+			issueFieldsRepoQuery{},
+			map[string]any{
+				"owner": githubv4.String("owner"),
+				"name":  githubv4.String("repo"),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issueFields": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"__typename":     "IssueFieldText",
+								"id":             "FIELD_1",
+								"fullDatabaseId": "42",
+								"name":           "DRI",
+								"dataType":       "TEXT",
+								"visibility":     "ALL",
+							},
 						},
 					},
 				},
-				nil,
-				githubv4mock.DataResponse(map[string]any{
-					"setIssueFieldValue": map[string]any{
-						"issue": map[string]any{
-							"id":     "ISSUE_123",
-							"number": 5,
-							"url":    "https://github.com/owner/repo/issues/5",
-						},
-					},
-				}),
-			),
-		}
+			}),
+		)
+		gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(fieldsQuery))
 
-		gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(matchers...))
-		deps := BaseDeps{GQLClient: gqlClient}
+		restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			PatchReposIssuesByOwnerByRepoByIssueNumber: expectRequestBody(t, map[string]any{
+				"issue_field_values": []any{
+					map[string]any{
+						"field_id":  float64(42),
+						"value":     "hello",
+						"rationale": "Reflects the reported severity",
+						"suggest":   true,
+					},
+				},
+			}).andThen(mockResponse(t, http.StatusOK, &gogithub.Issue{Number: gogithub.Ptr(5)})),
+		}))
+
+		deps := BaseDeps{Client: restClient, GQLClient: gqlClient}
 		serverTool := GranularSetIssueFields(translations.NullTranslationHelper)
 		handler := serverTool.Handler(deps)
 

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"strconv"
 	"strings"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
@@ -1157,8 +1156,9 @@ func GranularSetIssueFields(t translations.TranslationHelperFunc) inventory.Serv
 
 // issueFieldValueRESTRequest is the JSON body shape accepted by the REST
 // update-issue endpoint when setting issue field values with rationale or
-// suggestion. The endpoint expects integer database IDs and a single string
-// value per field. Used as a fallback to the GraphQL setIssueFieldValue
+// suggestion. The endpoint expects integer database IDs and a value whose
+// JSON type matches the field's data type (string for text/date/single_select,
+// number for number). Used as a fallback to the GraphQL setIssueFieldValue
 // mutation, which does not (yet) support rationale or suggest.
 type issueFieldValueRESTRequest struct {
 	IssueFieldValues []issueFieldValueRESTEntry `json:"issue_field_values"`
@@ -1166,7 +1166,7 @@ type issueFieldValueRESTRequest struct {
 
 type issueFieldValueRESTEntry struct {
 	FieldID   int64  `json:"field_id"`
-	Value     string `json:"value"`
+	Value     any    `json:"value"`
 	Rationale string `json:"rationale,omitempty"`
 	Suggest   bool   `json:"suggest,omitempty"`
 }
@@ -1215,12 +1215,12 @@ func setIssueFieldsViaREST(
 			return utils.NewToolResultError(fmt.Sprintf("could not resolve database ID for field %q", def.Name)), nil, nil
 		}
 
-		var value string
+		var value any
 		switch {
 		case f.TextValue != nil:
 			value = string(*f.TextValue)
 		case f.NumberValue != nil:
-			value = strconv.FormatFloat(float64(*f.NumberValue), 'f', -1, 64)
+			value = float64(*f.NumberValue)
 		case f.DateValue != nil:
 			value = string(*f.DateValue)
 		case f.SingleSelectOptionID != nil:

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
@@ -1009,6 +1010,10 @@ func GranularSetIssueFields(t translations.TranslationHelperFunc) inventory.Serv
 				return utils.NewToolResultError("fields array must not be empty"), nil, nil
 			}
 
+			// needsREST is set when any field has rationale or suggest, since
+			// those are not yet supported on the GraphQL setIssueFieldValue
+			// mutation. The whole request is then dispatched via REST.
+			needsREST := false
 			issueFields := make([]IssueFieldCreateOrUpdateInput, 0, len(fieldMaps))
 			for _, fieldMap := range fieldMaps {
 				fieldID, err := RequiredParam[string](fieldMap, "field_id")
@@ -1070,6 +1075,7 @@ func GranularSetIssueFields(t translations.TranslationHelperFunc) inventory.Serv
 					}
 					if rationale != "" {
 						input.Rationale = githubv4.NewString(githubv4.String(rationale))
+						needsREST = true
 					}
 				}
 
@@ -1080,9 +1086,14 @@ func GranularSetIssueFields(t translations.TranslationHelperFunc) inventory.Serv
 				if isSuggestion {
 					suggestVal := githubv4.Boolean(true)
 					input.Suggest = &suggestVal
+					needsREST = true
 				}
 
 				issueFields = append(issueFields, input)
+			}
+
+			if needsREST {
+				return setIssueFieldsViaREST(ctx, deps, owner, repo, issueNumber, issueFields)
 			}
 
 			gqlClient, err := deps.GetGQLClient(ctx)
@@ -1142,4 +1153,129 @@ func GranularSetIssueFields(t translations.TranslationHelperFunc) inventory.Serv
 	)
 	st.FeatureFlagEnable = FeatureFlagIssuesGranular
 	return st
+}
+
+// issueFieldValueRESTRequest is the JSON body shape accepted by the REST
+// update-issue endpoint when setting issue field values with rationale or
+// suggestion. The endpoint expects integer database IDs and a single string
+// value per field. Used as a fallback to the GraphQL setIssueFieldValue
+// mutation, which does not (yet) support rationale or suggest.
+type issueFieldValueRESTRequest struct {
+	IssueFieldValues []issueFieldValueRESTEntry `json:"issue_field_values"`
+}
+
+type issueFieldValueRESTEntry struct {
+	FieldID   int64  `json:"field_id"`
+	Value     string `json:"value"`
+	Rationale string `json:"rationale,omitempty"`
+	Suggest   bool   `json:"suggest,omitempty"`
+}
+
+// setIssueFieldsViaREST dispatches a set_issue_fields request through the
+// REST update-issue endpoint. It resolves each field's integer database ID
+// (and, for single_select fields, each option's name) using the GraphQL
+// issue field definitions, then PATCHes the issue.
+func setIssueFieldsViaREST(
+	ctx context.Context,
+	deps ToolDependencies,
+	owner, repo string,
+	issueNumber int,
+	issueFields []IssueFieldCreateOrUpdateInput,
+) (*mcp.CallToolResult, any, error) {
+	// Delete is not supported on the REST shape we use here.
+	for _, f := range issueFields {
+		if f.Delete != nil && bool(*f.Delete) {
+			return utils.NewToolResultError("delete is not supported when rationale or is_suggestion is set"), nil, nil
+		}
+	}
+
+	gqlClient, err := deps.GetGQLClient(ctx)
+	if err != nil {
+		return utils.NewToolResultErrorFromErr("failed to get GitHub GraphQL client", err), nil, nil
+	}
+
+	defs, err := fetchIssueFields(ctx, gqlClient, owner, repo)
+	if err != nil {
+		return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "failed to look up issue field definitions", err), nil, nil
+	}
+
+	fieldByNodeID := make(map[string]IssueField, len(defs))
+	for _, f := range defs {
+		fieldByNodeID[f.ID] = f
+	}
+
+	entries := make([]issueFieldValueRESTEntry, 0, len(issueFields))
+	for _, f := range issueFields {
+		nodeID := fmt.Sprintf("%v", f.FieldID)
+		def, ok := fieldByNodeID[nodeID]
+		if !ok {
+			return utils.NewToolResultError(fmt.Sprintf("unknown field_id %q for %s/%s", nodeID, owner, repo)), nil, nil
+		}
+		if def.DatabaseID == 0 {
+			return utils.NewToolResultError(fmt.Sprintf("could not resolve database ID for field %q", def.Name)), nil, nil
+		}
+
+		var value string
+		switch {
+		case f.TextValue != nil:
+			value = string(*f.TextValue)
+		case f.NumberValue != nil:
+			value = strconv.FormatFloat(float64(*f.NumberValue), 'f', -1, 64)
+		case f.DateValue != nil:
+			value = string(*f.DateValue)
+		case f.SingleSelectOptionID != nil:
+			optID := fmt.Sprintf("%v", *f.SingleSelectOptionID)
+			optName := ""
+			for _, opt := range def.Options {
+				if opt.ID == optID {
+					optName = opt.Name
+					break
+				}
+			}
+			if optName == "" {
+				return utils.NewToolResultError(fmt.Sprintf("unknown single_select_option_id %q for field %q", optID, def.Name)), nil, nil
+			}
+			value = optName
+		}
+
+		entry := issueFieldValueRESTEntry{
+			FieldID: def.DatabaseID,
+			Value:   value,
+		}
+		if f.Rationale != nil {
+			entry.Rationale = string(*f.Rationale)
+		}
+		if f.Suggest != nil {
+			entry.Suggest = bool(*f.Suggest)
+		}
+		entries = append(entries, entry)
+	}
+
+	client, err := deps.GetClient(ctx)
+	if err != nil {
+		return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+	}
+
+	body := &issueFieldValueRESTRequest{IssueFieldValues: entries}
+	apiURL := fmt.Sprintf("repos/%s/%s/issues/%d", owner, repo, issueNumber)
+	req, err := client.NewRequest(ctx, "PATCH", apiURL, body)
+	if err != nil {
+		return utils.NewToolResultErrorFromErr("failed to create request", err), nil, nil
+	}
+
+	issue := &github.Issue{}
+	resp, err := client.Do(req, issue)
+	if err != nil {
+		return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to set issue field values", resp, err), nil, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r, err := json.Marshal(MinimalResponse{
+		ID:  fmt.Sprintf("%d", issue.GetID()),
+		URL: issue.GetHTMLURL(),
+	})
+	if err != nil {
+		return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
+	}
+	return utils.NewToolResultText(string(r)), nil, nil
 }


### PR DESCRIPTION
Follow-up to #2557.

## Summary
When `set_issue_fields` is called with a `rationale` or `is_suggestion`, route the request through the REST `PATCH /repos/{owner}/{repo}/issues/{issue_number}` endpoint instead of the GraphQL `setIssueFieldValue` mutation, since GraphQL does not currently support those parameters.

## Why
#2557 added `rationale` and `is_suggestion` to the `set_issue_fields` tool, but the GraphQL mutation does not accept those inputs. The REST update-issue endpoint does (the same way `update_issue_labels` already uses it for labels with rationale).

## What changed
- `pkg/github/issues_granular.go`:
  - In `GranularSetIssueFields`, set a `needsREST` flag when any field has a non-empty `rationale` or `is_suggestion: true`. Existing GraphQL parsing/dispatch is unchanged otherwise.
  - When `needsREST` is set, dispatch via a new `setIssueFieldsViaREST` helper:
    - Calls the existing `fetchIssueFields` to resolve each field's integer database ID and (for single-select fields) option name.
    - PATCHes the issue with body shape `{ "issue_field_values": [ { "field_id": <int>, "value": "<string>", "rationale": "...", "suggest": true } ] }`.
    - Returns an error if `delete: true` is combined with `rationale`/`is_suggestion` (not supported on the REST shape).
- `pkg/github/granular_tools_test.go`: updated the two rationale/suggest test cases to mock the new REST flow (GraphQL field-defs query + REST PATCH) instead of the GraphQL mutation.

No tool schema changes.

## MCP impact
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

The tool's input/output schema is unchanged; only the underlying transport changes when `rationale`/`is_suggestion` is set.

## Prompts tested (tool changes only)
N/A — input schema unchanged.

## Security / limits
- [x] No security or limits impact

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
