### PR TITLE
MCP Apps: Open created issue/PR link via host open-link capability

### DIFF
--- a/ui/src/apps/issue-write/App.tsx
+++ b/ui/src/apps/issue-write/App.tsx
@@ -33,12 +33,14 @@ function SuccessView({
   repo,
   submittedTitle,
   isUpdate,
+  openLink,
 }: {
   issue: IssueResult;
   owner: string;
   repo: string;
   submittedTitle: string;
   isUpdate: boolean;
+  openLink: (url: string) => Promise<void>;
 }) {
   const issueUrl = issue.html_url || issue.url || issue.URL || "#";
 
@@ -87,6 +89,14 @@ function SuccessView({
             href={issueUrl}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={(e) => {
+              if (issueUrl === "#") return;
+              // MCP Apps run in a sandboxed iframe where a plain anchor may be
+              // blocked, so route the click through the host's open-link
+              // capability (falls back to window.open).
+              e.preventDefault();
+              void openLink(issueUrl);
+            }}
             style={{
               fontWeight: 600,
               fontSize: "14px",
@@ -121,7 +131,7 @@ function CreateIssueApp() {
   const [error, setError] = useState<string | null>(null);
   const [successIssue, setSuccessIssue] = useState<IssueResult | null>(null);
 
-  const { app, error: appError, toolInput, callTool, hostContext, setModelContext } = useMcpApp({
+  const { app, error: appError, toolInput, callTool, hostContext, setModelContext, openLink } = useMcpApp({
     appName: "github-mcp-server-issue-write",
   });
 
@@ -232,6 +242,7 @@ function CreateIssueApp() {
         repo={repo}
         submittedTitle={title}
         isUpdate={isUpdateMode}
+        openLink={openLink}
       />
     );
   }

--- a/ui/src/apps/issue-write/App.tsx
+++ b/ui/src/apps/issue-write/App.tsx
@@ -90,11 +90,11 @@ function SuccessView({
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => {
-              if (issueUrl === "#") return;
               // MCP Apps run in a sandboxed iframe where a plain anchor may be
               // blocked, so route the click through the host's open-link
               // capability (falls back to window.open).
               e.preventDefault();
+              if (issueUrl === "#") return;
               void openLink(issueUrl);
             }}
             style={{

--- a/ui/src/apps/pr-write/App.tsx
+++ b/ui/src/apps/pr-write/App.tsx
@@ -36,11 +36,13 @@ function SuccessView({
   owner,
   repo,
   submittedTitle,
+  openLink,
 }: {
   pr: PRResult;
   owner: string;
   repo: string;
   submittedTitle: string;
+  openLink: (url: string) => Promise<void>;
 }) {
   const prUrl = pr.html_url || pr.url || pr.URL || "#";
 
@@ -89,6 +91,14 @@ function SuccessView({
             href={prUrl}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={(e) => {
+              if (prUrl === "#") return;
+              // MCP Apps run in a sandboxed iframe where a plain anchor may be
+              // blocked, so route the click through the host's open-link
+              // capability (falls back to window.open).
+              e.preventDefault();
+              void openLink(prUrl);
+            }}
             style={{
               fontWeight: 600,
               fontSize: "14px",
@@ -126,7 +136,7 @@ function CreatePRApp() {
   const [isDraft, setIsDraft] = useState(false);
   const [maintainerCanModify, setMaintainerCanModify] = useState(true);
 
-  const { app, error: appError, toolInput, callTool, hostContext, setModelContext } = useMcpApp({
+  const { app, error: appError, toolInput, callTool, hostContext, setModelContext, openLink } = useMcpApp({
     appName: "github-mcp-server-create-pull-request",
   });
 
@@ -199,7 +209,7 @@ function CreatePRApp() {
   if (successPR) {
     return (
       <AppProvider hostContext={hostContext}>
-        <SuccessView pr={successPR} owner={owner} repo={repo} submittedTitle={submittedTitle} />
+        <SuccessView pr={successPR} owner={owner} repo={repo} submittedTitle={submittedTitle} openLink={openLink} />
       </AppProvider>
     );
   }

--- a/ui/src/apps/pr-write/App.tsx
+++ b/ui/src/apps/pr-write/App.tsx
@@ -92,11 +92,11 @@ function SuccessView({
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => {
-              if (prUrl === "#") return;
               // MCP Apps run in a sandboxed iframe where a plain anchor may be
               // blocked, so route the click through the host's open-link
               // capability (falls back to window.open).
               e.preventDefault();
+              if (prUrl === "#") return;
               void openLink(prUrl);
             }}
             style={{

--- a/ui/src/hooks/useMcpApp.ts
+++ b/ui/src/hooks/useMcpApp.ts
@@ -106,7 +106,12 @@ export function useMcpApp({
         window.open(url, "_blank", "noopener,noreferrer");
         return;
       }
-      await app.openLink({ url });
+      const result = await app.openLink({ url });
+      // The host may deny the request (e.g. blocked domain or user cancelled).
+      // Fall back to a direct window.open so the link still works.
+      if (result?.isError) {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
     },
     [app]
   );


### PR DESCRIPTION
## What

When a user creates or updates an issue/PR via the MCP App form, the success view shows a link to the result. Clicking it now opens the URL in the user's browser via the host's `ui/open-link` capability, instead of relying on a plain `target="_blank"` anchor.

## Why

MCP Apps render inside a **sandboxed iframe**, where ordinary `target="_blank"` navigation can be blocked by the host. In those hosts, clicking the success link did nothing. The MCP Apps spec provides `ui/open-link` precisely so an app can ask the host to open an external URL.

## How

- The success-view links in `issue-write` and `pr-write` now call `openLink(url)` on click (`preventDefault` + host request). `openLink` was already exposed by `useMcpApp` (sends `ui/open-link`).
- `useMcpApp.openLink` now also falls back to `window.open` when the host **denies** the request (`result.isError`), in addition to the existing fallback when no app connection is present.
- The `href` is retained so right-click / copy-link and native fallback still work, and the handler no-ops when the URL is unavailable (`"#"`).

## Notes

- No server-side changes; UI-only.
- Type-checks and builds clean (`tsc --noEmit`, `npm run build`). No UI test suite exists in this package.
- Host must advertise the `openLinks` capability for the in-browser open; otherwise the `window.open` fallback applies.