### PR TITLE
fix: accept empty/missing arguments for zero-param tools (get_me)

### DIFF
--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -139,6 +139,47 @@ func Test_GetMe(t *testing.T) {
 	}
 }
 
+func Test_GetMe_OmittedArguments(t *testing.T) {
+	t.Parallel()
+
+	serverTool := GetMe(translations.NullTranslationHelper)
+
+	mockUser := &github.User{
+		Login:     github.Ptr("testuser"),
+		Name:      github.Ptr("Test User"),
+		HTMLURL:   github.Ptr("https://github.com/testuser"),
+		CreatedAt: &github.Timestamp{Time: time.Now()},
+	}
+	mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+		GetUser: mockResponse(t, http.StatusOK, mockUser),
+	})
+	deps := BaseDeps{Client: mustNewGHClient(t, mockedClient), Obsv: stubExporters()}
+	handler := serverTool.Handler(deps)
+
+	tests := []struct {
+		name      string
+		arguments json.RawMessage
+	}{
+		{name: "nil arguments", arguments: nil},
+		{name: "empty byte slice", arguments: json.RawMessage{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			request := createMCPRequestWithRawArguments(tc.arguments)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			require.NoError(t, err)
+			require.False(t, result.IsError)
+
+			textContent := getTextResult(t, result)
+			var returnedUser MinimalUser
+			err = json.Unmarshal([]byte(textContent.Text), &returnedUser)
+			require.NoError(t, err)
+			assert.Equal(t, "testuser", returnedUser.Login)
+		})
+	}
+}
+
 func Test_GetMe_IFC_FeatureFlag(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -323,6 +323,16 @@ func createMCPRequest(args any) mcp.CallToolRequest {
 	}
 }
 
+// createMCPRequestWithRawArguments creates a CallToolRequest with the given raw JSON arguments.
+// Use nil or an empty slice to simulate clients that omit the arguments field.
+func createMCPRequestWithRawArguments(args json.RawMessage) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: args,
+		},
+	}
+}
+
 // Well-known MCP client names used in tests.
 const (
 	ClientNameVSCodeInsiders = "Visual Studio Code - Insiders"

--- a/pkg/inventory/server_tool.go
+++ b/pkg/inventory/server_tool.go
@@ -133,7 +133,11 @@ func NewServerToolWithContextHandler[In any, Out any](tool mcp.Tool, toolset Too
 		HandlerFunc: func(_ any) mcp.ToolHandler {
 			return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				var arguments In
-				if err := json.Unmarshal(req.Params.Arguments, &arguments); err != nil {
+				args := req.Params.Arguments
+				if len(args) == 0 {
+					args = json.RawMessage(`{}`)
+				}
+				if err := json.Unmarshal(args, &arguments); err != nil {
 					return &mcp.CallToolResult{
 						Content: []mcp.Content{
 							&mcp.TextContent{Text: fmt.Sprintf("invalid arguments: %s", err)},

--- a/pkg/inventory/server_tool_test.go
+++ b/pkg/inventory/server_tool_test.go
@@ -78,3 +78,43 @@ func TestNewServerToolWithContextHandler_ValidArguments_Succeeds(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "success: octocat/hello-world", textContent.Text)
 }
+
+func TestNewServerToolWithContextHandler_EmptyArguments_TreatedAsEmptyObject(t *testing.T) {
+	tool := NewServerToolWithContextHandler(
+		mcp.Tool{Name: "zero_arg_tool"},
+		testToolsetMetadata("test"),
+		func(_ context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "ok"},
+				},
+			}, args, nil
+		},
+	)
+
+	handler := tool.HandlerFunc(nil)
+
+	tests := []struct {
+		name      string
+		arguments json.RawMessage
+	}{
+		{name: "nil arguments", arguments: nil},
+		{name: "empty byte slice", arguments: json.RawMessage{}},
+		{name: "explicit empty object", arguments: json.RawMessage(`{}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := handler(context.Background(), &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Name:      "zero_arg_tool",
+					Arguments: tt.arguments,
+				},
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.IsError)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Treat nil or empty `arguments` on `tools/call` as `{}` before JSON unmarshaling
- Fixes `get_me` and other zero-parameter tools when clients omit `arguments` entirely

Fixes #2587

## Test plan
- [x] `go test ./pkg/inventory/...`
- [x] `TestNewServerToolWithContextHandler_EmptyArguments_TreatedAsEmptyObject` (nil, empty byte slice, explicit `{}`)