### PR TITLE
fix: accept omitted tool arguments for zero-param tools like get_me

### DIFF
--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -139,6 +139,48 @@ func Test_GetMe(t *testing.T) {
 	}
 }
 
+func Test_GetMe_OmittedArguments(t *testing.T) {
+	t.Parallel()
+
+	serverTool := GetMe(translations.NullTranslationHelper)
+
+	mockUser := &github.User{
+		Login:     github.Ptr("testuser"),
+		Name:      github.Ptr("Test User"),
+		HTMLURL:   github.Ptr("https://github.com/testuser"),
+		CreatedAt: &github.Timestamp{Time: time.Now()},
+	}
+	mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+		GetUser: mockResponse(t, http.StatusOK, mockUser),
+	})
+	deps := BaseDeps{Client: mustNewGHClient(t, mockedClient), Obsv: stubExporters()}
+	handler := serverTool.Handler(deps)
+
+	tests := []struct {
+		name      string
+		arguments json.RawMessage
+	}{
+		{name: "nil arguments", arguments: nil},
+		{name: "empty byte slice", arguments: json.RawMessage{}},
+		{name: "explicit empty object", arguments: json.RawMessage(`{}`)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			request := createMCPRequestWithRawArguments(tc.arguments)
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			require.NoError(t, err)
+			require.False(t, result.IsError)
+
+			textContent := getTextResult(t, result)
+			var returnedUser MinimalUser
+			err = json.Unmarshal([]byte(textContent.Text), &returnedUser)
+			require.NoError(t, err)
+			assert.Equal(t, "testuser", returnedUser.Login)
+		})
+	}
+}
+
 func Test_GetMe_IFC_FeatureFlag(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -324,6 +324,16 @@ func createMCPRequest(args any) mcp.CallToolRequest {
 	}
 }
 
+// createMCPRequestWithRawArguments creates a CallToolRequest with the given raw JSON arguments.
+// Use nil or an empty slice to simulate clients that omit the arguments field.
+func createMCPRequestWithRawArguments(args json.RawMessage) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: args,
+		},
+	}
+}
+
 // Well-known MCP client names used in tests.
 const (
 	ClientNameVSCodeInsiders = "Visual Studio Code - Insiders"

--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -334,6 +334,16 @@ func createMCPRequest(args any) mcp.CallToolRequest {
 	}
 }
 
+// createMCPRequestWithRawArguments creates a CallToolRequest with the given raw JSON arguments.
+// Use nil or an empty slice to simulate clients that omit the arguments field.
+func createMCPRequestWithRawArguments(args json.RawMessage) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: args,
+		},
+	}
+}
+
 // Well-known MCP client names used in tests.
 const (
 	ClientNameVSCodeInsiders = "Visual Studio Code - Insiders"

--- a/pkg/inventory/server_tool.go
+++ b/pkg/inventory/server_tool.go
@@ -133,7 +133,12 @@ func NewServerToolWithContextHandler[In any, Out any](tool mcp.Tool, toolset Too
 		HandlerFunc: func(_ any) mcp.ToolHandler {
 			return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				var arguments In
-				if err := json.Unmarshal(req.Params.Arguments, &arguments); err != nil {
+				args := req.Params.Arguments
+				// Some MCP clients omit arguments for zero-parameter tools; treat as {}.
+				if len(args) == 0 {
+					args = json.RawMessage(`{}`)
+				}
+				if err := json.Unmarshal(args, &arguments); err != nil {
 					return &mcp.CallToolResult{
 						Content: []mcp.Content{
 							&mcp.TextContent{Text: fmt.Sprintf("invalid arguments: %s", err)},

--- a/pkg/inventory/server_tool.go
+++ b/pkg/inventory/server_tool.go
@@ -1,6 +1,7 @@
 package inventory
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -210,18 +211,29 @@ func NewServerToolWithContextHandler[In any, Out any](tool mcp.Tool, toolset Too
 		HandlerFunc: func(_ any) mcp.ToolHandler {
 			return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				var arguments In
-				if err := json.Unmarshal(req.Params.Arguments, &arguments); err != nil {
-					return &mcp.CallToolResult{
-						Content: []mcp.Content{
-							&mcp.TextContent{Text: fmt.Sprintf("invalid arguments: %s", err)},
-						},
-						IsError: true,
-					}, nil
+				args := req.Params.Arguments
+				if len(args) == 0 {
+					args = json.RawMessage(`{}`)
+				}
+				if bytes.Equal(bytes.TrimSpace(args), []byte("null")) {
+					return invalidArgumentsResult("arguments must be a JSON object"), nil
+				}
+				if err := json.Unmarshal(args, &arguments); err != nil {
+					return invalidArgumentsResult(err.Error()), nil
 				}
 				resp, _, err := handler(ctx, req, arguments)
 				return resp, err
 			}
 		},
+	}
+}
+
+func invalidArgumentsResult(message string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("invalid arguments: %s", message)},
+		},
+		IsError: true,
 	}
 }
 

--- a/pkg/inventory/server_tool_test.go
+++ b/pkg/inventory/server_tool_test.go
@@ -78,3 +78,93 @@ func TestNewServerToolWithContextHandler_ValidArguments_Succeeds(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "success: octocat/hello-world", textContent.Text)
 }
+
+func TestNewServerToolWithContextHandler_EmptyArguments_TreatedAsEmptyObject(t *testing.T) {
+	tool := NewServerToolWithContextHandler(
+		mcp.Tool{Name: "zero_arg_tool"},
+		testToolsetMetadata("test"),
+		func(_ context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			if len(args) != 0 {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{
+						&mcp.TextContent{Text: "expected empty arguments"},
+					},
+					IsError: true,
+				}, nil, nil
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "ok"},
+				},
+			}, args, nil
+		},
+	)
+
+	handler := tool.HandlerFunc(nil)
+
+	tests := []struct {
+		name      string
+		arguments json.RawMessage
+	}{
+		{name: "nil arguments", arguments: nil},
+		{name: "empty byte slice", arguments: json.RawMessage{}},
+		{name: "explicit empty object", arguments: json.RawMessage(`{}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := handler(context.Background(), &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Name:      "zero_arg_tool",
+					Arguments: tt.arguments,
+				},
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.IsError)
+		})
+	}
+}
+
+func TestNewServerToolWithContextHandler_EmptyArguments_TypedEmptyStruct(t *testing.T) {
+	type emptyArgs struct{}
+
+	tool := NewServerToolWithContextHandler(
+		mcp.Tool{Name: "typed_zero_arg_tool"},
+		testToolsetMetadata("test"),
+		func(_ context.Context, _ *mcp.CallToolRequest, args emptyArgs) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "ok"},
+				},
+			}, args, nil
+		},
+	)
+
+	handler := tool.HandlerFunc(nil)
+
+	tests := []struct {
+		name      string
+		arguments json.RawMessage
+	}{
+		{name: "nil arguments", arguments: nil},
+		{name: "empty byte slice", arguments: json.RawMessage{}},
+		{name: "explicit empty object", arguments: json.RawMessage(`{}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := handler(context.Background(), &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Name:      "typed_zero_arg_tool",
+					Arguments: tt.arguments,
+				},
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.IsError)
+		})
+	}
+}

--- a/pkg/inventory/server_tool_test.go
+++ b/pkg/inventory/server_tool_test.go
@@ -81,6 +81,113 @@ func TestNewServerToolWithContextHandler_ValidArguments_Succeeds(t *testing.T) {
 	assert.Equal(t, "success: octocat/hello-world", textContent.Text)
 }
 
+func TestNewServerToolWithContextHandler_ArgumentObjects(t *testing.T) {
+	type emptyArgs struct{}
+
+	handlerCalled := false
+	tool := NewServerToolWithContextHandler(
+		mcp.Tool{Name: "zero_arg_tool"},
+		testToolsetMetadata("test"),
+		func(_ context.Context, _ *mcp.CallToolRequest, _ emptyArgs) (*mcp.CallToolResult, any, error) {
+			handlerCalled = true
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+			}, nil, nil
+		},
+	)
+	handler := tool.HandlerFunc(nil)
+
+	tests := []struct {
+		name        string
+		arguments   json.RawMessage
+		wantError   bool
+		wantMessage string
+		wantHandler bool
+	}{
+		{
+			name:        "nil arguments",
+			arguments:   nil,
+			wantHandler: true,
+		},
+		{
+			name:        "zero-length arguments",
+			arguments:   json.RawMessage{},
+			wantHandler: true,
+		},
+		{
+			name:        "empty object",
+			arguments:   json.RawMessage(`{}`),
+			wantHandler: true,
+		},
+		{
+			name:        "null",
+			arguments:   json.RawMessage(`null`),
+			wantError:   true,
+			wantMessage: "arguments must be a JSON object",
+		},
+		{
+			name:        "malformed JSON",
+			arguments:   json.RawMessage(`{not valid json`),
+			wantError:   true,
+			wantMessage: "invalid character",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlerCalled = false
+			result, err := handler(context.Background(), &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{
+					Name:      "zero_arg_tool",
+					Arguments: tt.arguments,
+				},
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantError, result.IsError)
+			assert.Equal(t, tt.wantHandler, handlerCalled)
+			if tt.wantMessage != "" {
+				textContent, ok := result.Content[0].(*mcp.TextContent)
+				require.True(t, ok)
+				assert.Contains(t, textContent.Text, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestNewServerToolWithContextHandler_OmittedArgumentsReachRequiredParameterValidation(t *testing.T) {
+	tool := NewServerToolWithContextHandler(
+		mcp.Tool{Name: "parameterized_tool"},
+		testToolsetMetadata("test"),
+		func(_ context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			if _, ok := args["owner"]; !ok {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: "missing required parameter: owner"}},
+					IsError: true,
+				}, nil, nil
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+			}, nil, nil
+		},
+	)
+
+	result, err := tool.HandlerFunc(nil)(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "parameterized_tool",
+			Arguments: nil,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsError)
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, textContent.Text, "missing required parameter: owner")
+}
+
 func TestServerToolRegisterFuncAppliesMiddleware(t *testing.T) {
 	tool := NewServerTool(
 		mcp.Tool{


### PR DESCRIPTION
## Summary
- Treat nil or empty `arguments` on `tools/call` as `{}` before JSON unmarshaling in `NewServerToolWithContextHandler`
- Fixes `get_me` and other zero-parameter tools when MCP clients omit the `arguments` field entirely instead of sending `{}`

Closes #2587

## Problem
Some MCP clients omit the `arguments` field (or send an empty byte slice) when calling tools that declare no required parameters. The server previously attempted to unmarshal nil/empty input directly, producing `invalid arguments: unexpected end of JSON input` before the handler ran.

`get_me` is the most visible affected tool because its schema declares no required arguments, yet strict clients that omit `arguments` could not call it successfully.

## Changes
- `pkg/inventory/server_tool.go`: normalize empty `arguments` to `{}` before unmarshaling
- `pkg/inventory/server_tool_test.go`: cover nil, empty byte slice, and explicit `{}` inputs
- `pkg/github/context_tools_test.go`: integration test for `get_me` with omitted arguments
- `pkg/github/helper_test.go`: add `createMCPRequestWithRawArguments` test helper

## Test plan
- [x] `go test ./pkg/inventory/... -run EmptyArguments`
- [x] `go test ./pkg/github/... -run 'GetMe|OmittedArguments'`