### PR TITLE
Add release event dispatcher workflow

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,71 @@
+name: Dispatch release events
+
+# Fires a `repository_dispatch` on release events to an optional downstream
+# repository, configured at runtime via the `RELEASE_AUTOMATION_REPO`
+# repository variable. When the variable is not set, this workflow is a no-op,
+# so adopters and forks pay no overhead unless they opt in.
+#
+# Event types emitted:
+#   mcp-server-release-drafted   on release: { types: [created] }
+#   mcp-server-released          on release: { types: [published] }
+#
+# Prereleases are skipped for both event types.
+#
+# Required when RELEASE_AUTOMATION_REPO is set:
+#   Variable  RELEASE_AUTOMATION_REPO        owner/repo of the downstream repo
+#   Secret    RELEASE_AUTOMATION_DISPATCH_PAT  PAT with actions:write on that repo
+
+on:
+  release:
+    types: [created, published]
+
+permissions: {}
+
+concurrency:
+  group: release-dispatch-${{ github.event.release.id }}-${{ github.event.action }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: ${{ vars.RELEASE_AUTOMATION_REPO != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve event type
+        id: event
+        env:
+          ACTION: ${{ github.event.action }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            echo "::notice::Skipping prerelease"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$ACTION" in
+            created)   echo "type=mcp-server-release-drafted" >> "$GITHUB_OUTPUT" ;;
+            published) echo "type=mcp-server-released"        >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::notice::Unhandled release action: $ACTION"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Send repository_dispatch
+        if: steps.event.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_DISPATCH_PAT }}
+          TARGET_REPO: ${{ vars.RELEASE_AUTOMATION_REPO }}
+          EVENT_TYPE: ${{ steps.event.outputs.type }}
+          TAG: ${{ github.event.release.tag_name }}
+          URL: ${{ github.event.release.html_url }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::RELEASE_AUTOMATION_DISPATCH_PAT secret is not set"
+            exit 1
+          fi
+          gh api "repos/${TARGET_REPO}/dispatches" \
+            -f "event_type=${EVENT_TYPE}" \
+            -F "client_payload[tag]=${TAG}" \
+            -F "client_payload[url]=${URL}"


### PR DESCRIPTION
## What

Adds an **opt-in** workflow that fires `repository_dispatch` on release events to a downstream repository, when one is configured via the `RELEASE_AUTOMATION_REPO` repository variable. When the variable is unset, the workflow is a no-op — so forks and other adopters pay no overhead unless they explicitly opt in.

## Event types emitted

| Trigger | Event type | Skipped on |
|---------|-----------|------------|
| `release: { types: [created] }` | `mcp-server-release-drafted` | `prerelease == true` |
| `release: { types: [published] }` | `mcp-server-released` | `prerelease == true` |

The downstream payload is `{ tag, url }` only — no other release data crosses the boundary.

## Required when opting in

| Kind | Name | Purpose |
|------|------|---------|
| Variable | `RELEASE_AUTOMATION_REPO` | `owner/repo` of the downstream repository |
| Secret | `RELEASE_AUTOMATION_DISPATCH_PAT` | PAT (or GitHub App token) with `actions: write` on that repo |

If the variable is unset, the dispatch job is skipped with no action. If the variable is set but the secret is missing, the job fails with a clear error.

## Why this exists

Allows release events from this repository to drive downstream automation (e.g. dependency bumps, downstream test runs, notifications) without coupling that automation's logic into this repository. The downstream repository owns its own behavior; this workflow just signals the event.

## Testing

- With `RELEASE_AUTOMATION_REPO` unset: no-op confirmed (job's `if:` evaluates false).
- With it set: published release fires `mcp-server-released` to the target repo, observable in that repo's Actions tab as a `repository_dispatch` event.

## Concurrency

Scoped per `(release_id, action)` so re-edits of the same release don't fan out.
