### PR TITLE
feat: implement cursor pagination for dependabot alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,8 +717,8 @@ The following sets of tools are available:
 - **list_dependabot_alerts** - List dependabot alerts
   - **Required OAuth Scopes**: `security_events`
   - **Accepted OAuth Scopes**: `repo`, `security_events`
+  - `after`: Forward pagination cursor from the previous response's pageInfo.nextCursor. (string, optional)
   - `owner`: The owner of the repository. (string, required)
-  - `page`: Page number for pagination (min 1) (number, optional)
   - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
   - `repo`: The name of the repository. (string, required)
   - `severity`: Filter dependabot alerts by severity (string, optional)

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ The following sets of tools are available:
 - **list_dependabot_alerts** - List dependabot alerts
   - **Required OAuth Scopes**: `security_events`
   - **Accepted OAuth Scopes**: `repo`, `security_events`
-  - `after`: Omit for the first page. For subsequent pages, use pageInfo.nextCursor from the previous response. (string, optional)
+  - `after`: Cursor for pagination. Use the cursor from the previous response. (string, optional)
   - `owner`: The owner of the repository. (string, required)
   - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
   - `repo`: The name of the repository. (string, required)
@@ -755,7 +755,7 @@ The following sets of tools are available:
 
 - **get_discussion_comments** - Get discussion comments
   - **Required OAuth Scopes**: `repo`
-  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `after`: Cursor for pagination. Use the cursor from the previous response. (string, optional)
   - `discussionNumber`: Discussion Number (number, required)
   - `includeReplies`: When true, each top-level comment will include its replies nested within it (up to 100 replies per comment, which is the GitHub API maximum). Defaults to false. (boolean, optional)
   - `owner`: Repository owner (string, required)
@@ -769,7 +769,7 @@ The following sets of tools are available:
 
 - **list_discussions** - List discussions
   - **Required OAuth Scopes**: `repo`
-  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `after`: Cursor for pagination. Use the cursor from the previous response. (string, optional)
   - `category`: Optional filter by discussion category ID. If provided, only discussions with this category are listed. (string, optional)
   - `direction`: Order direction. (string, optional)
   - `orderBy`: Order discussions by field. If provided, the 'direction' also needs to be provided. (string, optional)
@@ -881,7 +881,7 @@ The following sets of tools are available:
 
 - **list_issues** - List issues
   - **Required OAuth Scopes**: `repo`
-  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `after`: Cursor for pagination. Use the cursor from the previous response. (string, optional)
   - `direction`: Order direction. If provided, the 'orderBy' also needs to be provided. (string, optional)
   - `labels`: Filter by labels (string[], optional)
   - `orderBy`: Order issues by field. If provided, the 'direction' also needs to be provided. (string, optional)

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ The following sets of tools are available:
 - **list_dependabot_alerts** - List dependabot alerts
   - **Required OAuth Scopes**: `security_events`
   - **Accepted OAuth Scopes**: `repo`, `security_events`
-  - `after`: Forward pagination cursor from the previous response's pageInfo.nextCursor. (string, optional)
+  - `after`: Omit for the first page. For subsequent pages, use pageInfo.nextCursor from the previous response. (string, optional)
   - `owner`: The owner of the repository. (string, required)
   - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
   - `repo`: The name of the repository. (string, required)

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -102,7 +102,7 @@ runtime behavior (such as output formatting) won't appear here.
 
 - **list_issues** - List issues
   - **Required OAuth Scopes**: `repo`
-  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `after`: Cursor for pagination. Use the cursor from the previous response. (string, optional)
   - `direction`: Order direction. If provided, the 'orderBy' also needs to be provided. (string, optional)
   - `field_filters`: Filter by custom issue field values. Each entry takes a field_name and a value; the server looks up the field and coerces the value to its type (single-select option name, text, number, or YYYY-MM-DD date). (object[], optional)
   - `labels`: Filter by labels (string[], optional)

--- a/docs/insiders-features.md
+++ b/docs/insiders-features.md
@@ -96,7 +96,7 @@ The list below is generated from the Go source. It covers tool **inventory and s
 
 - **list_issues** - List issues
   - **Required OAuth Scopes**: `repo`
-  - `after`: Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs. (string, optional)
+  - `after`: Cursor for pagination. Use the cursor from the previous response. (string, optional)
   - `direction`: Order direction. If provided, the 'orderBy' also needs to be provided. (string, optional)
   - `field_filters`: Filter by custom issue field values. Each entry takes a field_name and a value; the server looks up the field and coerces the value to its type (single-select option name, text, number, or YYYY-MM-DD date). (object[], optional)
   - `labels`: Filter by labels (string[], optional)

--- a/pkg/github/__toolsnaps__/get_discussion_comments.snap
+++ b/pkg/github/__toolsnaps__/get_discussion_comments.snap
@@ -7,7 +7,7 @@
   "inputSchema": {
     "properties": {
       "after": {
-        "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.",
+        "description": "Cursor for pagination. Use the cursor from the previous response.",
         "type": "string"
       },
       "discussionNumber": {

--- a/pkg/github/__toolsnaps__/list_dependabot_alerts.snap
+++ b/pkg/github/__toolsnaps__/list_dependabot_alerts.snap
@@ -6,14 +6,13 @@
   "description": "List dependabot alerts in a GitHub repository.",
   "inputSchema": {
     "properties": {
+      "after": {
+        "description": "Forward pagination cursor from the previous response's pageInfo.nextCursor.",
+        "type": "string"
+      },
       "owner": {
         "description": "The owner of the repository.",
         "type": "string"
-      },
-      "page": {
-        "description": "Page number for pagination (min 1)",
-        "minimum": 1,
-        "type": "number"
       },
       "perPage": {
         "description": "Results per page for pagination (min 1, max 100)",

--- a/pkg/github/__toolsnaps__/list_dependabot_alerts.snap
+++ b/pkg/github/__toolsnaps__/list_dependabot_alerts.snap
@@ -7,7 +7,7 @@
   "inputSchema": {
     "properties": {
       "after": {
-        "description": "Omit for the first page. For subsequent pages, use pageInfo.nextCursor from the previous response.",
+        "description": "Cursor for pagination. Use the cursor from the previous response.",
         "type": "string"
       },
       "owner": {

--- a/pkg/github/__toolsnaps__/list_dependabot_alerts.snap
+++ b/pkg/github/__toolsnaps__/list_dependabot_alerts.snap
@@ -7,7 +7,7 @@
   "inputSchema": {
     "properties": {
       "after": {
-        "description": "Forward pagination cursor from the previous response's pageInfo.nextCursor.",
+        "description": "Omit for the first page. For subsequent pages, use pageInfo.nextCursor from the previous response.",
         "type": "string"
       },
       "owner": {

--- a/pkg/github/__toolsnaps__/list_discussions.snap
+++ b/pkg/github/__toolsnaps__/list_discussions.snap
@@ -7,7 +7,7 @@
   "inputSchema": {
     "properties": {
       "after": {
-        "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.",
+        "description": "Cursor for pagination. Use the cursor from the previous response.",
         "type": "string"
       },
       "category": {

--- a/pkg/github/__toolsnaps__/list_issues.snap
+++ b/pkg/github/__toolsnaps__/list_issues.snap
@@ -7,7 +7,7 @@
   "inputSchema": {
     "properties": {
       "after": {
-        "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.",
+        "description": "Cursor for pagination. Use the cursor from the previous response.",
         "type": "string"
       },
       "direction": {

--- a/pkg/github/__toolsnaps__/list_issues_ff_remote_mcp_issue_fields.snap
+++ b/pkg/github/__toolsnaps__/list_issues_ff_remote_mcp_issue_fields.snap
@@ -7,7 +7,7 @@
   "inputSchema": {
     "properties": {
       "after": {
-        "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.",
+        "description": "Cursor for pagination. Use the cursor from the previous response.",
         "type": "string"
       },
       "direction": {

--- a/pkg/github/dependabot.go
+++ b/pkg/github/dependabot.go
@@ -121,10 +121,6 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 		Required: []string{"owner", "repo"},
 	}
 	WithCursorPagination(schema)
-	// The Dependabot alerts REST endpoint uses cursor pagination via the response's
-	// Link header (surfaced as pageInfo.nextCursor), not GraphQL. Override the shared
-	// cursor description, which otherwise refers to a GraphQL PageInfo.
-	schema.Properties["after"].Description = "Omit for the first page. For subsequent pages, use pageInfo.nextCursor from the previous response."
 
 	return NewTool(
 		ToolsetMetadataDependabot,

--- a/pkg/github/dependabot.go
+++ b/pkg/github/dependabot.go
@@ -124,7 +124,7 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 	// The Dependabot alerts REST endpoint uses cursor pagination via the response's
 	// Link header (surfaced as pageInfo.nextCursor), not GraphQL. Override the shared
 	// cursor description, which otherwise refers to a GraphQL PageInfo.
-	schema.Properties["after"].Description = "Forward pagination cursor from the previous response's pageInfo.nextCursor."
+	schema.Properties["after"].Description = "Omit for the first page. For subsequent pages, use pageInfo.nextCursor from the previous response."
 
 	return NewTool(
 		ToolsetMetadataDependabot,

--- a/pkg/github/dependabot.go
+++ b/pkg/github/dependabot.go
@@ -120,7 +120,11 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 		},
 		Required: []string{"owner", "repo"},
 	}
-	WithPagination(schema)
+	WithCursorPagination(schema)
+	// The Dependabot alerts REST endpoint uses cursor pagination via the response's
+	// Link header (surfaced as pageInfo.nextCursor), not GraphQL. Override the shared
+	// cursor description, which otherwise refers to a GraphQL PageInfo.
+	schema.Properties["after"].Description = "Forward pagination cursor from the previous response's pageInfo.nextCursor."
 
 	return NewTool(
 		ToolsetMetadataDependabot,
@@ -152,7 +156,7 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
-			pagination, err := OptionalPaginationParams(args)
+			pagination, err := OptionalCursorPaginationParams(args)
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
@@ -165,9 +169,9 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 			alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, owner, repo, &github.ListAlertsOptions{
 				State:    ToStringPtr(state),
 				Severity: ToStringPtr(severity),
-				ListOptions: github.ListOptions{
-					Page:    pagination.Page,
+				ListCursorOptions: github.ListCursorOptions{
 					PerPage: pagination.PerPage,
+					After:   pagination.After,
 				},
 			})
 			if err != nil {
@@ -187,7 +191,12 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list alerts", resp, body), nil, nil
 			}
 
-			r, err := json.Marshal(alerts)
+			response := map[string]any{
+				"alerts":   alerts,
+				"pageInfo": buildPageInfo(resp),
+			}
+
+			r, err := json.Marshal(response)
 			if err != nil {
 				return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, err
 			}

--- a/pkg/github/dependabot_test.go
+++ b/pkg/github/dependabot_test.go
@@ -154,19 +154,19 @@ func Test_ListDependabotAlerts(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		mockedClient   *http.Client
-		requestArgs    map[string]any
-		expectError    bool
-		expectedAlerts []*github.DependabotAlert
-		expectedErrMsg string
+		name               string
+		mockedClient       *http.Client
+		requestArgs        map[string]any
+		expectError        bool
+		expectedAlerts     []*github.DependabotAlert
+		expectedNextCursor string
+		expectedErrMsg     string
 	}{
 		{
 			name: "successful open alerts listing",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
 					"state":    "open",
-					"page":     "1",
 					"per_page": "30",
 				}).andThen(
 					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&criticalAlert}),
@@ -185,7 +185,6 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
 					"severity": "high",
-					"page":     "1",
 					"per_page": "30",
 				}).andThen(
 					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&highSeverityAlert}),
@@ -203,7 +202,6 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			name: "successful all alerts listing",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
-					"page":     "1",
 					"per_page": "30",
 				}).andThen(
 					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&criticalAlert, &highSeverityAlert}),
@@ -217,10 +215,10 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			expectedAlerts: []*github.DependabotAlert{&criticalAlert, &highSeverityAlert},
 		},
 		{
-			name: "successful alerts listing with custom pagination",
+			name: "successful alerts listing with cursor pagination",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
-					"page":     "3",
+					"after":    "Y3Vyc29yOnYyOpK5",
 					"per_page": "100",
 				}).andThen(
 					mockResponse(t, http.StatusOK, []*github.DependabotAlert{&criticalAlert}),
@@ -229,11 +227,34 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			requestArgs: map[string]any{
 				"owner":   "owner",
 				"repo":    "repo",
-				"page":    float64(3),
+				"after":   "Y3Vyc29yOnYyOpK5",
 				"perPage": float64(100),
 			},
 			expectError:    false,
 			expectedAlerts: []*github.DependabotAlert{&criticalAlert},
+		},
+		{
+			name: "successful alerts listing surfaces next page cursor",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				GetReposDependabotAlertsByOwnerByRepo: expectQueryParams(t, map[string]string{
+					"per_page": "30",
+				}).andThen(
+					func(w http.ResponseWriter, _ *http.Request) {
+						w.Header().Set("Link", `<https://api.github.com/repos/owner/repo/dependabot/alerts?after=nextcursor123&per_page=30>; rel="next"`)
+						w.WriteHeader(http.StatusOK)
+						b, err := json.Marshal([]*github.DependabotAlert{&criticalAlert})
+						require.NoError(t, err)
+						_, _ = w.Write(b)
+					},
+				),
+			}),
+			requestArgs: map[string]any{
+				"owner": "owner",
+				"repo":  "repo",
+			},
+			expectError:        false,
+			expectedAlerts:     []*github.DependabotAlert{&criticalAlert},
+			expectedNextCursor: "nextcursor123",
 		},
 		{
 			name: "alerts listing fails",
@@ -291,11 +312,17 @@ func Test_ListDependabotAlerts(t *testing.T) {
 			textContent := getTextResult(t, result)
 
 			// Unmarshal and verify the result
-			var returnedAlerts []*github.DependabotAlert
-			err = json.Unmarshal([]byte(textContent.Text), &returnedAlerts)
+			var returnedResult struct {
+				Alerts   []*github.DependabotAlert `json:"alerts"`
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					NextCursor  string `json:"nextCursor"`
+				} `json:"pageInfo"`
+			}
+			err = json.Unmarshal([]byte(textContent.Text), &returnedResult)
 			assert.NoError(t, err)
-			assert.Len(t, returnedAlerts, len(tc.expectedAlerts))
-			for i, alert := range returnedAlerts {
+			assert.Len(t, returnedResult.Alerts, len(tc.expectedAlerts))
+			for i, alert := range returnedResult.Alerts {
 				assert.Equal(t, *tc.expectedAlerts[i].Number, *alert.Number)
 				assert.Equal(t, *tc.expectedAlerts[i].HTMLURL, *alert.HTMLURL)
 				assert.Equal(t, *tc.expectedAlerts[i].State, *alert.State)
@@ -304,6 +331,8 @@ func Test_ListDependabotAlerts(t *testing.T) {
 					assert.Equal(t, *tc.expectedAlerts[i].SecurityAdvisory.Severity, *alert.SecurityAdvisory.Severity)
 				}
 			}
+			assert.Equal(t, tc.expectedNextCursor, returnedResult.PageInfo.NextCursor)
+			assert.Equal(t, tc.expectedNextCursor != "", returnedResult.PageInfo.HasNextPage)
 		})
 	}
 }

--- a/pkg/github/params.go
+++ b/pkg/github/params.go
@@ -376,7 +376,7 @@ func WithCursorPagination(schema *jsonschema.Schema) *jsonschema.Schema {
 
 	schema.Properties["after"] = &jsonschema.Schema{
 		Type:        "string",
-		Description: "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.",
+		Description: "Cursor for pagination. Use the cursor from the previous response.",
 	}
 
 	return schema
@@ -433,6 +433,22 @@ func OptionalCursorPaginationParams(args map[string]any) (CursorPaginationParams
 type CursorPaginationParams struct {
 	PerPage int
 	After   string
+}
+
+type pageInfo struct {
+	HasNextPage     bool   `json:"hasNextPage"`
+	HasPreviousPage bool   `json:"hasPreviousPage"`
+	NextCursor      string `json:"nextCursor,omitempty"`
+	PrevCursor      string `json:"prevCursor,omitempty"`
+}
+
+func buildPageInfo(resp *github.Response) pageInfo {
+	return pageInfo{
+		HasNextPage:     resp.After != "",
+		HasPreviousPage: resp.Before != "",
+		NextCursor:      resp.After,
+		PrevCursor:      resp.Before,
+	}
 }
 
 // ToGraphQLParams converts cursor pagination parameters to GraphQL-specific parameters.

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -1350,13 +1350,6 @@ func getProjectStatusUpdate(ctx context.Context, gqlClient *githubv4.Client, sta
 	return utils.NewToolResultText(string(r)), nil, nil
 }
 
-type pageInfo struct {
-	HasNextPage     bool   `json:"hasNextPage"`
-	HasPreviousPage bool   `json:"hasPreviousPage"`
-	NextCursor      string `json:"nextCursor,omitempty"`
-	PrevCursor      string `json:"prevCursor,omitempty"`
-}
-
 // validateAndConvertToInt64 ensures the value is a number and converts it to int64.
 func validateAndConvertToInt64(value any) (int64, error) {
 	switch v := value.(type) {
@@ -1405,15 +1398,6 @@ func buildUpdateProjectItem(input map[string]any) (*github.UpdateProjectItemOpti
 	}
 
 	return payload, nil
-}
-
-func buildPageInfo(resp *github.Response) pageInfo {
-	return pageInfo{
-		HasNextPage:     resp.After != "",
-		HasPreviousPage: resp.Before != "",
-		NextCursor:      resp.After,
-		PrevCursor:      resp.Before,
-	}
 }
 
 func extractPaginationOptionsFromArgs(args map[string]any) (github.ListProjectsPaginationOptions, error) {


### PR DESCRIPTION


<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes #2649 #2648 

## What changed
<!-- Bullet list of concrete changes. -->
Fixes `list_dependabot_alerts` pagination by switching it from page-based pagination to cursor-based pagination.

- Removed the unsupported `page` parameter from `list_dependabot_alerts`.
- Added cursor pagination support using `after` and `perPage`.
- Updated the tool response to include `pageInfo`, so callers can use `pageInfo.nextCursor` for the next page.
- Updated tests, toolsnap, and generated docs.

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Updated (README / docs / examples)
