### PR TITLE
Fix GraphQL call using the wrong case for method derivation

### DIFF
--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -1583,7 +1583,7 @@ func createIterationField(ctx context.Context, gqlClient *githubv4.Client, owner
 					ID   string
 					Name string
 				} `graphql:"... on ProjectV2IterationField"`
-			}
+			} `graphql:"projectV2Field"`
 		} `graphql:"createProjectV2Field(input: $input)"`
 	}
 
@@ -1616,7 +1616,7 @@ func createIterationField(ctx context.Context, gqlClient *githubv4.Client, owner
 						}
 					}
 				} `graphql:"... on ProjectV2IterationField"`
-			}
+			} `graphql:"projectV2Field"`
 		} `graphql:"updateProjectV2Field(input: $input)"`
 	}
 

--- a/pkg/github/projects_v2_test.go
+++ b/pkg/github/projects_v2_test.go
@@ -174,7 +174,7 @@ func createFieldMatcher() githubv4mock.Matcher {
 						ID   string
 						Name string
 					} `graphql:"... on ProjectV2IterationField"`
-				}
+				} `graphql:"projectV2Field"`
 			} `graphql:"createProjectV2Field(input: $input)"`
 		}{},
 		githubv4.CreateProjectV2FieldInput{
@@ -242,7 +242,7 @@ func Test_ProjectsWrite_CreateIterationField(t *testing.T) {
 									}
 								}
 							} `graphql:"... on ProjectV2IterationField"`
-						}
+						} `graphql:"projectV2Field"`
 					} `graphql:"updateProjectV2Field(input: $input)"`
 				}{},
 				UpdateProjectV2FieldInput{
@@ -319,7 +319,7 @@ func Test_ProjectsWrite_CreateIterationField(t *testing.T) {
 									}
 								}
 							} `graphql:"... on ProjectV2IterationField"`
-						}
+						} `graphql:"projectV2Field"`
 					} `graphql:"updateProjectV2Field(input: $input)"`
 				}{},
 				UpdateProjectV2FieldInput{
@@ -403,7 +403,7 @@ func Test_ProjectsWrite_CreateIterationField(t *testing.T) {
 									}
 								}
 							} `graphql:"... on ProjectV2IterationField"`
-						}
+						} `graphql:"projectV2Field"`
 					} `graphql:"updateProjectV2Field(input: $input)"`
 				}{},
 				UpdateProjectV2FieldInput{


### PR DESCRIPTION
## Summary
Fixes `create_iteration_field`, which failed at runtime because the GraphQL mutation selected `projectV2field` (lowercase) instead of the schema's `projectV2Field`.

## Why
The inner `ProjectV2Field` struct fields in createIterationField had no `graphql:` tag, so shurcooL/githubv4 auto-derived the selection name and mis-cased the word boundary after the embedded `V2`, producing `projectV2field`. GitHub's API rejected this, blocking iteration field creation entirely.

Fixes #

## What changed
- Added explicit `` `graphql:"projectV2Field"` `` tags to the `createProjectV2Field` and `updateProjectV2Field` mutation structs in projects.go.
- Made the test matchers in projects_v2_test.go schema-faithful (tagged `projectV2Field`) so they reproduce the bug and guard against the casing regression.

## MCP impact
- [x] No tool or API changes — tool schema is unchanged; this is a runtime GraphQL fix only.

## Prompts tested (tool changes only)
- N/A (no tool schema changes)

## Security / limits
- [x] No security or limits impact

## Tool renaming
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with lint
- [x] Tested locally with test

## Docs
- [x] Not needed