### PR TITLE
Support type intent (rationale/confidence/suggestion) in issue write …

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ The following sets of tools are available:
   - `state`: New state (string, optional)
   - `state_reason`: Reason for the state change. Ignored unless state is changed. (string, optional)
   - `title`: Issue title (string, optional)
-  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string, optional)
+  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string|object, optional)
 
 - **list_issue_types** - List available issue types
   - **Required OAuth Scopes**: `read:org`

--- a/cmd/github-mcp-server/generate_docs.go
+++ b/cmd/github-mcp-server/generate_docs.go
@@ -268,13 +268,21 @@ func writeToolDoc(buf *strings.Builder, tool inventory.ServerTool) {
 			var typeStr string
 
 			// Get the type and description
-			switch prop.Type {
-			case "array":
+			switch {
+			case prop.Type == "array":
 				if prop.Items != nil {
 					typeStr = prop.Items.Type + "[]"
 				} else {
 					typeStr = "array"
 				}
+			case prop.Type == "" && len(prop.OneOf) > 0:
+				var branchTypes []string
+				for _, branch := range prop.OneOf {
+					if branch.Type != "" && !slices.Contains(branchTypes, branch.Type) {
+						branchTypes = append(branchTypes, branch.Type)
+					}
+				}
+				typeStr = strings.Join(branchTypes, "|")
 			default:
 				typeStr = prop.Type
 			}

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -69,7 +69,7 @@ runtime behavior (such as output formatting) won't appear here.
   - `state`: New state (string, optional)
   - `state_reason`: Reason for the state change. Ignored unless state is changed. (string, optional)
   - `title`: Issue title (string, optional)
-  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string, optional)
+  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string|object, optional)
 
 ### `remote_mcp_issue_fields`
 
@@ -92,7 +92,7 @@ runtime behavior (such as output formatting) won't appear here.
   - `state`: New state (string, optional)
   - `state_reason`: Reason for the state change. Ignored unless state is changed. (string, optional)
   - `title`: Issue title (string, optional)
-  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string, optional)
+  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string|object, optional)
 
 - **list_issue_fields** - List issue fields
   - **Required OAuth Scopes**: `repo`, `read:org`
@@ -199,11 +199,11 @@ runtime behavior (such as output formatting) won't appear here.
 - **update_issue_type** - Update Issue Type
   - **Required OAuth Scopes**: `repo`
   - `confidence`: How confident you are in this choice. Use 'high' for clear signal or explicit user request, 'medium' for reasonable inference with some ambiguity, 'low' for best guess with limited signal. (string, optional)
-  - `is_suggestion`: If true, this issue type change is sent to the API as a suggestion (suggest:true) rather than an applied value. Whether the type is applied or recorded as a proposal is determined by the API. (boolean, optional)
+  - `is_suggestion`: If true, this value is sent to the API as a suggestion rather than an applied value. Whether it is applied or recorded as a proposal is determined by the API. Only honored when updating an existing issue. (boolean, optional)
   - `issue_number`: The issue number to update (number, required)
   - `issue_type`: The issue type to set (string, required)
   - `owner`: Repository owner (username or organization) (string, required)
-  - `rationale`: One concise sentence explaining what specifically about the issue led you to choose this type. State the concrete signal (e.g. 'Reports a crash when saving' → bug, 'Asks for dark mode support' → feature). (string, optional)
+  - `rationale`: A concise explanation of what specifically about the issue led you to this choice. State the concrete signal (e.g. 'Reports a crash when saving' → bug). (string, optional)
   - `repo`: Repository name (string, required)
 
 ### `pull_requests_granular`

--- a/docs/insiders-features.md
+++ b/docs/insiders-features.md
@@ -63,7 +63,7 @@ The list below is generated from the Go source. It covers tool **inventory and s
   - `state`: New state (string, optional)
   - `state_reason`: Reason for the state change. Ignored unless state is changed. (string, optional)
   - `title`: Issue title (string, optional)
-  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string, optional)
+  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string|object, optional)
 
 ### `remote_mcp_issue_fields`
 
@@ -86,7 +86,7 @@ The list below is generated from the Go source. It covers tool **inventory and s
   - `state`: New state (string, optional)
   - `state_reason`: Reason for the state change. Ignored unless state is changed. (string, optional)
   - `title`: Issue title (string, optional)
-  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string, optional)
+  - `type`: Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter. (string|object, optional)
 
 - **list_issue_fields** - List issue fields
   - **Required OAuth Scopes**: `repo`, `read:org`

--- a/pkg/github/__toolsnaps__/issue_write.snap
+++ b/pkg/github/__toolsnaps__/issue_write.snap
@@ -118,7 +118,42 @@
       },
       "type": {
         "description": "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter.",
-        "type": "string"
+        "oneOf": [
+          {
+            "description": "Issue type name",
+            "type": "string"
+          },
+          {
+            "properties": {
+              "confidence": {
+                "description": "How confident you are in this choice. Use 'high' for clear signal or explicit user request, 'medium' for reasonable inference with some ambiguity, 'low' for best guess with limited signal.",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "type": "string"
+              },
+              "is_suggestion": {
+                "description": "If true, this value is sent to the API as a suggestion rather than an applied value. Whether it is applied or recorded as a proposal is determined by the API. Only honored when updating an existing issue.",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Issue type name",
+                "type": "string"
+              },
+              "rationale": {
+                "description": "A concise explanation of what specifically about the issue led you to this choice. State the concrete signal (e.g. 'Reports a crash when saving' → bug).",
+                "maxLength": 280,
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ]
       }
     },
     "required": [

--- a/pkg/github/__toolsnaps__/issue_write_ff_remote_mcp_issue_fields.snap
+++ b/pkg/github/__toolsnaps__/issue_write_ff_remote_mcp_issue_fields.snap
@@ -154,7 +154,42 @@
       },
       "type": {
         "description": "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter.",
-        "type": "string"
+        "oneOf": [
+          {
+            "description": "Issue type name",
+            "type": "string"
+          },
+          {
+            "properties": {
+              "confidence": {
+                "description": "How confident you are in this choice. Use 'high' for clear signal or explicit user request, 'medium' for reasonable inference with some ambiguity, 'low' for best guess with limited signal.",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "type": "string"
+              },
+              "is_suggestion": {
+                "description": "If true, this value is sent to the API as a suggestion rather than an applied value. Whether it is applied or recorded as a proposal is determined by the API. Only honored when updating an existing issue.",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Issue type name",
+                "type": "string"
+              },
+              "rationale": {
+                "description": "A concise explanation of what specifically about the issue led you to this choice. State the concrete signal (e.g. 'Reports a crash when saving' → bug).",
+                "maxLength": 280,
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ]
       }
     },
     "required": [

--- a/pkg/github/__toolsnaps__/update_issue_type.snap
+++ b/pkg/github/__toolsnaps__/update_issue_type.snap
@@ -17,7 +17,7 @@
         "type": "string"
       },
       "is_suggestion": {
-        "description": "If true, this issue type change is sent to the API as a suggestion (suggest:true) rather than an applied value. Whether the type is applied or recorded as a proposal is determined by the API.",
+        "description": "If true, this value is sent to the API as a suggestion rather than an applied value. Whether it is applied or recorded as a proposal is determined by the API. Only honored when updating an existing issue.",
         "type": "boolean"
       },
       "issue_number": {
@@ -34,7 +34,7 @@
         "type": "string"
       },
       "rationale": {
-        "description": "One concise sentence explaining what specifically about the issue led you to choose this type. State the concrete signal (e.g. 'Reports a crash when saving' → bug, 'Asks for dark mode support' → feature).",
+        "description": "A concise explanation of what specifically about the issue led you to this choice. State the concrete signal (e.g. 'Reports a crash when saving' → bug).",
         "maxLength": 280,
         "type": "string"
       },

--- a/pkg/github/granular_tools_test.go
+++ b/pkg/github/granular_tools_test.go
@@ -707,7 +707,7 @@ func TestGranularUpdateIssueTypeInvalidRationale(t *testing.T) {
 				"issue_type":   "feature",
 				"rationale":    strings.Repeat("a", 281),
 			},
-			expectedErrText: "parameter rationale must be 280 characters or less",
+			expectedErrText: "rationale must be 280 characters or less",
 		},
 	}
 

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -1793,6 +1794,29 @@ func issueWriteHasNonFormParams(args map[string]any) bool {
 	return false
 }
 
+// issueWriteTypeSchema returns the schema for the issue_write "type" property,
+// which accepts either a plain type name (string) or an object carrying intent
+// metadata (a "name" plus optional rationale/confidence/is_suggestion), mirroring
+// the labels schema so a type can be applied or suggested with reasoning.
+func issueWriteTypeSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Description: "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter.",
+		OneOf: []*jsonschema.Schema{
+			{Type: "string", Description: "Issue type name"},
+			{
+				Type: "object",
+				Properties: withIntentProperties(map[string]*jsonschema.Schema{
+					"name": {
+						Type:        "string",
+						Description: "Issue type name",
+					},
+				}),
+				Required: []string{"name"},
+			},
+		},
+	}
+}
+
 // IssueWrite is the FeatureFlagIssueFields-enabled variant of issue_write
 // (with the issue_fields parameter). LegacyIssueWrite is served when the flag
 // is off. Both register under the tool name "issue_write"; exactly one is
@@ -1877,10 +1901,7 @@ Options are:
 						Type:        "number",
 						Description: "Milestone number",
 					},
-					"type": {
-						Type:        "string",
-						Description: "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter.",
-					},
+					"type": issueWriteTypeSchema(),
 					"state": {
 						Type:        "string",
 						Description: "New state",
@@ -2004,8 +2025,8 @@ Options are:
 				milestoneNum = milestone
 			}
 
-			// Get optional type
-			issueType, err := OptionalParam[string](args, "type")
+			// Get optional type (plain name or an object carrying intent)
+			issueType, issueTypePayload, issueTypeHasIntent, _, err := parseValueParamWithIntent(args, "type", "name", "value")
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
@@ -2069,6 +2090,9 @@ Options are:
 				}
 				if labelsHaveIntent {
 					updateOpts.LabelsWithIntent = labelsPayload
+				}
+				if issueTypeHasIntent {
+					updateOpts.TypeWithIntent = issueTypePayload
 				}
 				result, err := UpdateIssue(ctx, client, gqlClient, owner, repo, issueNumber, title, body, assignees, labels, milestoneNum, issueType, issueFieldValues, fieldIDsToDelete, state, stateReason, duplicateOf, updateOpts)
 				return result, nil, err
@@ -2165,10 +2189,7 @@ Options are:
 						Type:        "number",
 						Description: "Milestone number",
 					},
-					"type": {
-						Type:        "string",
-						Description: "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter.",
-					},
+					"type": issueWriteTypeSchema(),
 					"state": {
 						Type:        "string",
 						Description: "New state",
@@ -2257,8 +2278,8 @@ Options are:
 				milestoneNum = milestone
 			}
 
-			// Get optional type
-			issueType, err := OptionalParam[string](args, "type")
+			// Get optional type (plain name or an object carrying intent)
+			issueType, issueTypePayload, issueTypeHasIntent, _, err := parseValueParamWithIntent(args, "type", "name", "value")
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
@@ -2307,6 +2328,9 @@ Options are:
 				}
 				if labelsHaveIntent {
 					updateOpts.LabelsWithIntent = labelsPayload
+				}
+				if issueTypeHasIntent {
+					updateOpts.TypeWithIntent = issueTypePayload
 				}
 				result, err := UpdateIssue(ctx, client, gqlClient, owner, repo, issueNumber, title, body, assignees, labels, milestoneNum, issueType, nil, nil, state, stateReason, duplicateOf, updateOpts)
 				return result, nil, err
@@ -2383,13 +2407,18 @@ type UpdateIssueOptions struct {
 	// per-label rationale and suggestion intent are preserved. When set, it
 	// takes precedence over the labels slice.
 	LabelsWithIntent []any
+	// TypeWithIntent, when non-nil, sends the type in object form (a
+	// valueWithIntent) via a custom request so type rationale and suggestion
+	// intent are preserved. When set, it takes precedence over the issueType
+	// string.
+	TypeWithIntent any
 }
 
-// issueRequestWithLabels marshals an IssueRequest into a generic map and sets
-// the labels field to the provided object-form payload (a mix of plain label
-// names and valueWithIntent objects). This lets an issue update carry per-label
-// rationale and suggestion intent that github.IssueRequest cannot represent.
-func issueRequestWithLabels(issueRequest *github.IssueRequest, labels []any) (map[string]any, error) {
+// issueRequestWithIntentOverrides marshals an IssueRequest into a generic map and
+// applies the given overrides (object-form fields that github.IssueRequest cannot
+// represent, e.g. labels or type carrying per-value rationale and suggestion
+// intent). This lets an issue update carry intent metadata on the wire.
+func issueRequestWithIntentOverrides(issueRequest *github.IssueRequest, overrides map[string]any) (map[string]any, error) {
 	data, err := json.Marshal(issueRequest)
 	if err != nil {
 		return nil, err
@@ -2398,7 +2427,7 @@ func issueRequestWithLabels(issueRequest *github.IssueRequest, labels []any) (ma
 	if err := json.Unmarshal(data, &payload); err != nil {
 		return nil, err
 	}
-	payload["labels"] = labels
+	maps.Copy(payload, overrides)
 	return payload, nil
 }
 
@@ -2412,6 +2441,9 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 		updateOptions.LabelsProvided = updateOptions.LabelsProvided || opt.LabelsProvided
 		if len(opt.LabelsWithIntent) > 0 {
 			updateOptions.LabelsWithIntent = opt.LabelsWithIntent
+		}
+		if opt.TypeWithIntent != nil {
+			updateOptions.TypeWithIntent = opt.TypeWithIntent
 		}
 	}
 
@@ -2441,7 +2473,7 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 		issueRequest.Milestone = &milestoneNum
 	}
 
-	if issueType != "" {
+	if issueType != "" && updateOptions.TypeWithIntent == nil {
 		issueRequest.Type = github.Ptr(issueType)
 	}
 
@@ -2473,11 +2505,18 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 	var updatedIssue *github.Issue
 	var resp *github.Response
 	var err error
-	if len(updateOptions.LabelsWithIntent) > 0 {
-		// Send labels in object form so per-label rationale and suggestion intent
-		// are preserved. Marshal the standard request (labels omitted), then inject
-		// the object-form labels into the payload.
-		payload, mErr := issueRequestWithLabels(issueRequest, updateOptions.LabelsWithIntent)
+	if len(updateOptions.LabelsWithIntent) > 0 || updateOptions.TypeWithIntent != nil {
+		// Send values that carry intent (labels and/or type) in object form so
+		// their rationale and suggestion intent are preserved. Marshal the standard
+		// request (those fields omitted), then inject the object-form values.
+		overrides := map[string]any{}
+		if len(updateOptions.LabelsWithIntent) > 0 {
+			overrides["labels"] = updateOptions.LabelsWithIntent
+		}
+		if updateOptions.TypeWithIntent != nil {
+			overrides["type"] = updateOptions.TypeWithIntent
+		}
+		payload, mErr := issueRequestWithIntentOverrides(issueRequest, overrides)
 		if mErr != nil {
 			return utils.NewToolResultErrorFromErr("failed to build issue update request", mErr), nil
 		}

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -439,6 +439,44 @@ func parseParamWithIntent(args map[string]any, param, identityField string) (ide
 	return identities, payload, hasIntent, true, nil
 }
 
+// parseValueParamWithIntent parses a single-value parameter that accepts either
+// a plain string or an object carrying intent metadata. param is the argument
+// key (e.g. "type"); inputField is the identity key read from the object (e.g.
+// "name"); wireField is the identity key used in the object-form payload sent to
+// the API (e.g. "value"). For most value types inputField and wireField match.
+//
+// It returns the plain identity (intent stripped), the wire payload (the plain
+// identity string, or a valueWithIntent object when intent is present), whether
+// the value carried intent, whether the parameter was provided at all, and an
+// error. It mirrors parseParamWithIntent for value types that travel as a single
+// named object rather than an array.
+func parseValueParamWithIntent(args map[string]any, param, inputField, wireField string) (identity string, payload any, hasIntent bool, provided bool, err error) {
+	raw, ok := args[param]
+	if !ok || raw == nil {
+		return "", nil, false, false, nil
+	}
+
+	switch v := raw.(type) {
+	case string:
+		return v, v, false, true, nil
+	case map[string]any:
+		id, idErr := RequiredParam[string](v, inputField)
+		if idErr != nil {
+			return "", nil, false, true, fmt.Errorf("%s object must have a '%s' string", param, inputField)
+		}
+		intent, itemHasIntent, intentErr := parseValueIntent(v)
+		if intentErr != nil {
+			return "", nil, false, true, intentErr
+		}
+		if itemHasIntent {
+			return id, valueWithIntent{identityKey: wireField, identity: id, valueIntent: intent}, true, true, nil
+		}
+		return id, id, false, true, nil
+	default:
+		return "", nil, false, true, fmt.Errorf("%s must be a string or an object with '%s' and optional 'rationale', 'confidence', and/or 'is_suggestion'", param, inputField)
+	}
+}
+
 // GranularUpdateIssueLabels creates a tool to update an issue's labels.
 func GranularUpdateIssueLabels(t translations.TranslationHelperFunc) inventory.ServerTool {
 	st := NewTool(
@@ -594,19 +632,11 @@ func GranularUpdateIssueMilestone(t translations.TranslationHelperFunc) inventor
 	)
 }
 
-// issueTypeWithIntent represents the object form of the issue type field,
-// allowing a rationale, confidence level, and/or suggest flag to be sent alongside the type name.
-type issueTypeWithIntent struct {
-	Value      string `json:"value"`
-	Rationale  string `json:"rationale,omitempty"`
-	Confidence string `json:"confidence,omitempty"`
-	Suggest    bool   `json:"suggest,omitempty"`
-}
-
-// issueTypeUpdateRequest is a custom request body for updating an issue type
-// with optional intent metadata, using the object form that the REST API accepts.
-type issueTypeUpdateRequest struct {
-	Type issueTypeWithIntent `json:"type"`
+// typeUpdateRequest is a custom request body for updating an issue's type with
+// optional intent metadata, using the object form that the REST API accepts:
+// {"type": {"value": ..., "rationale": ..., "confidence": ..., "suggest": ...}}.
+type typeUpdateRequest struct {
+	Type valueWithIntent `json:"type"`
 }
 
 // GranularUpdateIssueType creates a tool to update an issue's type.
@@ -624,7 +654,7 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
-				Properties: map[string]*jsonschema.Schema{
+				Properties: withIntentProperties(map[string]*jsonschema.Schema{
 					"owner": {
 						Type:        "string",
 						Description: "Repository owner (username or organization)",
@@ -642,23 +672,7 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 						Type:        "string",
 						Description: "The issue type to set",
 					},
-					"rationale": {
-						Type: "string",
-						Description: "One concise sentence explaining what specifically about the issue led you to choose this type. " +
-							"State the concrete signal (e.g. 'Reports a crash when saving' → bug, 'Asks for dark mode support' → feature).",
-						MaxLength: jsonschema.Ptr(280),
-					},
-					"confidence": {
-						Type:        "string",
-						Description: "How confident you are in this choice. Use 'high' for clear signal or explicit user request, 'medium' for reasonable inference with some ambiguity, 'low' for best guess with limited signal.",
-						Enum:        []any{"low", "medium", "high"},
-					},
-					"is_suggestion": {
-						Type: "boolean",
-						Description: "If true, this issue type change is sent to the API as a suggestion (suggest:true) rather than an applied value. " +
-							"Whether the type is applied or recorded as a proposal is determined by the API.",
-					},
-				},
+				}),
 				Required: []string{"owner", "repo", "issue_number", "issue_type"},
 			},
 		},
@@ -680,22 +694,7 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
-			rationale, err := OptionalParam[string](args, "rationale")
-			if err != nil {
-				return utils.NewToolResultError(err.Error()), nil, nil
-			}
-			rationale = strings.TrimSpace(rationale)
-			if len([]rune(rationale)) > 280 {
-				return utils.NewToolResultError("parameter rationale must be 280 characters or less"), nil, nil
-			}
-			confidence, err := OptionalParam[string](args, "confidence")
-			if err != nil {
-				return utils.NewToolResultError(err.Error()), nil, nil
-			}
-			if confidence != "" && confidence != "low" && confidence != "medium" && confidence != "high" {
-				return utils.NewToolResultError("confidence must be one of: low, medium, high"), nil, nil
-			}
-			isSuggestion, err := OptionalParam[bool](args, "is_suggestion")
+			intent, hasIntent, err := parseValueIntent(args)
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
@@ -706,14 +705,9 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 			}
 
 			var body any
-			if rationale != "" || isSuggestion || confidence != "" {
-				body = &issueTypeUpdateRequest{
-					Type: issueTypeWithIntent{
-						Value:      issueType,
-						Rationale:  rationale,
-						Confidence: confidence,
-						Suggest:    isSuggestion,
-					},
+			if hasIntent {
+				body = &typeUpdateRequest{
+					Type: valueWithIntent{identityKey: "value", identity: issueType, valueIntent: intent},
 				}
 			} else {
 				body = &github.IssueRequest{Type: &issueType}

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -3626,6 +3626,132 @@ func Test_IssueWrite_UpdateLabelsWithIntentErrors(t *testing.T) {
 	}
 }
 
+func Test_IssueWrite_UpdateTypeWithIntent(t *testing.T) {
+	serverTool := IssueWrite(translations.NullTranslationHelper)
+	updatedIssue := &github.Issue{
+		Number:  github.Ptr(1),
+		HTMLURL: github.Ptr("https://github.com/owner/repo/issues/1"),
+	}
+
+	tests := []struct {
+		name        string
+		issueType   any
+		expectedReq map[string]any
+	}{
+		{
+			name:      "plain type name sent as string",
+			issueType: "bug",
+			expectedReq: map[string]any{
+				"type": "bug",
+			},
+		},
+		{
+			name:      "type object without intent sent as string",
+			issueType: map[string]any{"name": "bug"},
+			expectedReq: map[string]any{
+				"type": "bug",
+			},
+		},
+		{
+			name:      "suggested type without rationale",
+			issueType: map[string]any{"name": "bug", "is_suggestion": true},
+			expectedReq: map[string]any{
+				"type": map[string]any{"value": "bug", "suggest": true},
+			},
+		},
+		{
+			name:      "applied type with rationale",
+			issueType: map[string]any{"name": "feature", "rationale": "Asks for dark mode support"},
+			expectedReq: map[string]any{
+				"type": map[string]any{"value": "feature", "rationale": "Asks for dark mode support"},
+			},
+		},
+		{
+			name:      "suggested type with rationale and confidence",
+			issueType: map[string]any{"name": "bug", "rationale": "Reports a crash when saving", "confidence": "high", "is_suggestion": true},
+			expectedReq: map[string]any{
+				"type": map[string]any{"value": "bug", "rationale": "Reports a crash when saving", "confidence": "high", "suggest": true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PatchReposIssuesByOwnerByRepoByIssueNumber: expectRequestBody(t, tc.expectedReq).
+					andThen(mockResponse(t, http.StatusOK, updatedIssue)),
+			}))
+			deps := BaseDeps{
+				Client:    client,
+				GQLClient: githubv4.NewClient(githubv4mock.NewMockedHTTPClient()),
+			}
+			handler := serverTool.Handler(deps)
+
+			request := createMCPRequest(map[string]any{
+				"method":       "update",
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+				"type":         tc.issueType,
+			})
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			require.NoError(t, err)
+			if result.IsError {
+				t.Fatalf("unexpected error result: %s", getErrorResult(t, result).Text)
+			}
+		})
+	}
+}
+
+func Test_IssueWrite_UpdateTypeWithIntentErrors(t *testing.T) {
+	serverTool := IssueWrite(translations.NullTranslationHelper)
+
+	tests := []struct {
+		name            string
+		issueType       any
+		expectedErrText string
+	}{
+		{
+			name:            "rationale too long",
+			issueType:       map[string]any{"name": "bug", "rationale": strings.Repeat("a", 281)},
+			expectedErrText: "rationale must be 280 characters or less",
+		},
+		{
+			name:            "invalid confidence value",
+			issueType:       map[string]any{"name": "bug", "confidence": "very_high"},
+			expectedErrText: "confidence must be one of: low, medium, high",
+		},
+		{
+			name:            "type object missing name",
+			issueType:       map[string]any{"rationale": "no name provided"},
+			expectedErrText: "type object must have a 'name' string",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := BaseDeps{
+				Client:    mustNewGHClient(t, MockHTTPClientWithHandlers(nil)),
+				GQLClient: githubv4.NewClient(githubv4mock.NewMockedHTTPClient()),
+			}
+			handler := serverTool.Handler(deps)
+
+			request := createMCPRequest(map[string]any{
+				"method":       "update",
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+				"type":         tc.issueType,
+			})
+			result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+			require.NoError(t, err)
+
+			errorContent := getErrorResult(t, result)
+			assert.Contains(t, errorContent.Text, tc.expectedErrText)
+		})
+	}
+}
+
 func Test_ParseISOTimestamp(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->
Extend the general `issue_write` tool so the type can be sent either as a plain string or as an object with optional rationale (<=280 chars), `is_suggestion` and `confidence`. 
- should go in after https://github.com/github/github-mcp-server/pull/2656v

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

Add intent value for types in the MCP when updating an issue 

<img width="518" height="208" alt="image" src="https://github.com/user-attachments/assets/bc134c32-6d6b-4595-a450-cddc55f29c9b" />


## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes https://github.com/github/plan-track-agentic-toolkit/issues/350

## What changed
<!-- Bullet list of concrete changes. -->
- issue_write tool now supports issue_type suggestions
 

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [x] Updated (README / docs / examples)
