### PR TITLE
fix: return get_files patches as raw text to avoid double-encoding

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -383,7 +383,45 @@ func GetPullRequestFiles(ctx context.Context, client *github.Client, owner, repo
 
 	minimalFiles := convertToMinimalPRFiles(files)
 
-	return MarshalledTextResult(minimalFiles), nil
+	type fileMeta struct {
+		Filename         string `json:"filename"`
+		Status           string `json:"status,omitempty"`
+		Additions        int    `json:"additions,omitempty"`
+		Deletions        int    `json:"deletions,omitempty"`
+		Changes          int    `json:"changes,omitempty"`
+		PreviousFilename string `json:"previous_filename,omitempty"`
+	}
+
+	metas := make([]fileMeta, len(minimalFiles))
+	for i, f := range minimalFiles {
+		metas[i] = fileMeta{
+			Filename:         f.Filename,
+			Status:           f.Status,
+			Additions:        f.Additions,
+			Deletions:        f.Deletions,
+			Changes:          f.Changes,
+			PreviousFilename: f.PreviousFilename,
+		}
+	}
+
+	metaJSON, err := json.Marshal(metas)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal file metadata: %w", err)
+	}
+
+	contents := []mcp.Content{
+		&mcp.TextContent{Text: string(metaJSON)},
+	}
+
+	for _, f := range minimalFiles {
+		if f.Patch != "" {
+			contents = append(contents, &mcp.TextContent{
+				Text: fmt.Sprintf("filename: %s\n%s", f.Filename, f.Patch),
+			})
+		}
+	}
+
+	return &mcp.CallToolResult{Content: contents}, nil
 }
 
 func GetPullRequestCommits(ctx context.Context, client *github.Client, owner, repo string, pullNumber int, pagination PaginationParams) (*mcp.CallToolResult, error) {

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v87/github"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -1242,20 +1242,45 @@ func Test_GetPullRequestFiles(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, result.IsError)
 
-			// Parse the result and get the text content if no error
-			textContent := getTextResult(t, result)
+			// Verify multi-content response
+			assert.NotNil(t, result)
+			require.Len(t, result.Content, 3) // 1 metadata + 2 patches
 
-			// Unmarshal and verify the result
-			var returnedFiles []MinimalPRFile
-			err = json.Unmarshal([]byte(textContent.Text), &returnedFiles)
+			// Verify Content[0] is metadata JSON
+			metaContent, ok := result.Content[0].(*mcp.TextContent)
+			require.True(t, ok, "expected first content to be TextContent")
+
+			var returnedMetas []map[string]any
+			err = json.Unmarshal([]byte(metaContent.Text), &returnedMetas)
 			require.NoError(t, err)
-			assert.Len(t, returnedFiles, len(tc.expectedFiles))
-			for i, file := range returnedFiles {
-				assert.Equal(t, tc.expectedFiles[i].GetFilename(), file.Filename)
-				assert.Equal(t, tc.expectedFiles[i].GetStatus(), file.Status)
-				assert.Equal(t, tc.expectedFiles[i].GetAdditions(), file.Additions)
-				assert.Equal(t, tc.expectedFiles[i].GetDeletions(), file.Deletions)
-			}
+			assert.Len(t, returnedMetas, len(tc.expectedFiles))
+
+			// Verify metadata content for first file
+			assert.Equal(t, "file1.go", returnedMetas[0]["filename"])
+			assert.Equal(t, "modified", returnedMetas[0]["status"])
+			assert.Equal(t, float64(10), returnedMetas[0]["additions"])
+			assert.Equal(t, float64(5), returnedMetas[0]["deletions"])
+			assert.Equal(t, float64(15), returnedMetas[0]["changes"])
+			assert.Nil(t, returnedMetas[0]["patch"], "metadata should not contain patch field")
+
+			// Verify metadata content for second file
+			assert.Equal(t, "file2.go", returnedMetas[1]["filename"])
+			assert.Equal(t, "added", returnedMetas[1]["status"])
+			assert.Equal(t, float64(20), returnedMetas[1]["additions"])
+			assert.Equal(t, float64(20), returnedMetas[1]["changes"])
+			assert.Nil(t, returnedMetas[1]["patch"], "metadata should not contain patch field")
+
+			// Verify Content[1] is patch for file1.go
+			patch1Content, ok := result.Content[1].(*mcp.TextContent)
+			require.True(t, ok, "expected second content to be TextContent")
+			assert.Contains(t, patch1Content.Text, "filename: file1.go")
+			assert.Contains(t, patch1Content.Text, "@@ -1,5 +1,10 @@")
+
+			// Verify Content[2] is patch for file2.go
+			patch2Content, ok := result.Content[2].(*mcp.TextContent)
+			require.True(t, ok, "expected third content to be TextContent")
+			assert.Contains(t, patch2Content.Text, "filename: file2.go")
+			assert.Contains(t, patch2Content.Text, "@@ -0,0 +1,20 @@")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes `get_files`, which double-encodes per-file patch content by marshaling the entire file array to JSON (escaping newlines) and then wrapping that JSON string in a `TextContent` field that the MCP transport JSON-encodes again, roughly doubling escape overhead on patch content and pushing moderate PRs past token limits.

## Why

`GetPullRequestFiles` passes the `[]MinimalPRFile` slice (including each file's `Patch` string) to `MarshalledTextResult`, which calls `json.Marshal` to produce a JSON array, then wraps it in `NewToolResultText`. On the MCP wire, `TextContent.Text` is JSON-encoded a second time, so every `\n` in every patch becomes `\\n` (4 bytes instead of 1). For a ~73 KB diff, this inflates the payload to 125 KB+, exceeding tool response token limits on PRs that are not unusually large.

`get_diff` is not affected: it already returns raw diff text via `NewToolResultText(string(raw))`, which gets only the single unavoidable MCP wire encoding.

Fixes #2242

## What changed

- `pkg/github/pullrequests.go`: `GetPullRequestFiles` now returns a multi-content `CallToolResult`. Content[0] is a JSON array of file metadata (filename, status, additions, deletions, changes, previous_filename) without patches. Content[1..N] are raw `TextContent` blocks, one per file with a non-empty patch, containing the filename as a header followed by the patch text. Patches are no longer embedded inside a JSON string value, eliminating the double-encoding.
- `pkg/github/pullrequests_test.go`: `Test_GetPullRequestFiles` verifies the multi-content response structure: metadata JSON in Content[0], raw patch text blocks in Content[1..N], and no patch field in the metadata JSON.

## MCP impact

- [ ] No tool or API changes
- [x] Tool schema or behavior changed
The tool's response format changes from a single JSON text block with embedded patch strings to multiple text content blocks: metadata JSON plus raw patch text. Tool parameters, name, description, and annotations are unchanged, so toolsnaps and generated docs are unaffected.
- [ ] New tool added

## Prompts tested (tool changes only)

- "Show me the files changed in PR #123 on owner/repo"
- "What patches were applied in pull request #456?"

## Security / limits

- [ ] No security or limits impact
- [x] Auth / permissions considered
The tool continues to use the existing pull request file API path and repo permission requirements; no new scope or permission check is added.
- [x] Data exposure, filtering, or token/size limits considered
This returns the same file metadata and patch content in separate content blocks, reducing encoding overhead without adding fields or API calls.

## Tool renaming

- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

## Lint & tests

- [ ] Linted locally with `./script/lint`
Not run locally.
- [ ] Tested locally with `./script/test`
Not run locally. The full race suite was not run locally.

- `go test -race ./pkg/github -run Test_GetPullRequestFiles` - covers: multi-content response structure, metadata-only JSON without patches, raw patch text blocks with filename headers, pagination, and error cases.

## Docs

- [x] Not needed
Tool parameters and schema are unchanged. The response format change is behavioral, not schema-level. Toolsnaps are unaffected.