### PR TITLE
feat: add upvoteCount to list_discussions and get_discussion

### DIFF
--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/go-viper/mapstructure/v2"
-	"github.com/google/go-github/v87/github"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
@@ -56,6 +55,7 @@ type NodeFragment struct {
 	Closed         githubv4.Boolean
 	IsAnswered     githubv4.Boolean
 	AnswerChosenAt *githubv4.DateTime
+	UpvoteCount    githubv4.Int
 	Author         struct {
 		Login githubv4.String
 	}
@@ -94,22 +94,6 @@ type WithCategoryNoOrder struct {
 	Repository struct {
 		Discussions DiscussionFragment `graphql:"discussions(first: $first, after: $after, categoryId: $categoryId)"`
 	} `graphql:"repository(owner: $owner, name: $repo)"`
-}
-
-func fragmentToDiscussion(fragment NodeFragment) *github.Discussion {
-	return &github.Discussion{
-		Number:    github.Ptr(int(fragment.Number)),
-		Title:     github.Ptr(string(fragment.Title)),
-		HTMLURL:   github.Ptr(string(fragment.URL)),
-		CreatedAt: &github.Timestamp{Time: fragment.CreatedAt.Time},
-		UpdatedAt: &github.Timestamp{Time: fragment.UpdatedAt.Time},
-		User: &github.User{
-			Login: github.Ptr(string(fragment.Author.Login)),
-		},
-		DiscussionCategory: &github.DiscussionCategory{
-			Name: github.Ptr(string(fragment.Category.Name)),
-		},
-	}
 }
 
 func getQueryType(useOrdering bool, categoryID *githubv4.ID) any {
@@ -245,13 +229,28 @@ func ListDiscussions(t translations.TranslationHelperFunc) inventory.ServerTool 
 			}
 
 			// Extract and convert all discussion nodes using the common interface
-			var discussions []*github.Discussion
+			var discussions []map[string]any
 			var pageInfo PageInfoFragment
 			var totalCount githubv4.Int
 			if queryResult, ok := discussionQuery.(DiscussionQueryResult); ok {
 				fragment := queryResult.GetDiscussionFragment()
 				for _, node := range fragment.Nodes {
-					discussions = append(discussions, fragmentToDiscussion(node))
+					d := map[string]any{
+						"number":      int(node.Number),
+						"title":       string(node.Title),
+						"url":         string(node.URL),
+						"createdAt":   node.CreatedAt.Time,
+						"updatedAt":   node.UpdatedAt.Time,
+						"closed":      bool(node.Closed),
+						"isAnswered":  bool(node.IsAnswered),
+						"upvoteCount": int(node.UpvoteCount),
+						"author":      map[string]any{"login": string(node.Author.Login)},
+						"category":    map[string]any{"name": string(node.Category.Name)},
+					}
+					if node.AnswerChosenAt != nil {
+						d["answerChosenAt"] = node.AnswerChosenAt.Time
+					}
+					discussions = append(discussions, d)
 				}
 				pageInfo = fragment.PageInfo
 				totalCount = fragment.TotalCount
@@ -337,6 +336,7 @@ func GetDiscussion(t translations.TranslationHelperFunc) inventory.ServerTool {
 						Closed         githubv4.Boolean
 						IsAnswered     githubv4.Boolean
 						AnswerChosenAt *githubv4.DateTime
+						UpvoteCount    githubv4.Int
 						URL            githubv4.String `graphql:"url"`
 						Category       struct {
 							Name githubv4.String
@@ -359,13 +359,14 @@ func GetDiscussion(t translations.TranslationHelperFunc) inventory.ServerTool {
 			// so we use map[string]interface{} for the response (consistent with other functions
 			// like ListDiscussions and GetDiscussionComments).
 			response := map[string]any{
-				"number":     int(d.Number),
-				"title":      string(d.Title),
-				"body":       string(d.Body),
-				"url":        string(d.URL),
-				"closed":     bool(d.Closed),
-				"isAnswered": bool(d.IsAnswered),
-				"createdAt":  d.CreatedAt.Time,
+				"number":       int(d.Number),
+				"title":        string(d.Title),
+				"body":         string(d.Body),
+				"url":          string(d.URL),
+				"closed":       bool(d.Closed),
+				"isAnswered":   bool(d.IsAnswered),
+				"createdAt":    d.CreatedAt.Time,
+				"upvoteCount":  int(d.UpvoteCount),
 				"category": map[string]any{
 					"name": string(d.Category.Name),
 				},

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -18,89 +18,96 @@ import (
 
 var (
 	discussionsGeneral = []map[string]any{
-		{"number": 1, "title": "Discussion 1 title", "createdAt": "2023-01-01T00:00:00Z", "updatedAt": "2023-01-01T00:00:00Z", "closed": false, "isAnswered": false, "author": map[string]any{"login": "user1"}, "url": "https://github.com/owner/repo/discussions/1", "category": map[string]any{"name": "General"}},
-		{"number": 3, "title": "Discussion 3 title", "createdAt": "2023-03-01T00:00:00Z", "updatedAt": "2023-02-01T00:00:00Z", "closed": false, "isAnswered": false, "author": map[string]any{"login": "user1"}, "url": "https://github.com/owner/repo/discussions/3", "category": map[string]any{"name": "General"}},
+		{"number": 1, "title": "Discussion 1 title", "createdAt": "2023-01-01T00:00:00Z", "updatedAt": "2023-01-01T00:00:00Z", "closed": false, "isAnswered": false, "upvoteCount": 5, "author": map[string]any{"login": "user1"}, "url": "https://github.com/owner/repo/discussions/1", "category": map[string]any{"name": "General"}},
+		{"number": 3, "title": "Discussion 3 title", "createdAt": "2023-03-01T00:00:00Z", "updatedAt": "2023-02-01T00:00:00Z", "closed": false, "isAnswered": false, "upvoteCount": 10, "author": map[string]any{"login": "user1"}, "url": "https://github.com/owner/repo/discussions/3", "category": map[string]any{"name": "General"}},
 	}
 	discussionsAll = []map[string]any{
 		{
-			"number":     1,
-			"title":      "Discussion 1 title",
-			"createdAt":  "2023-01-01T00:00:00Z",
-			"updatedAt":  "2023-01-01T00:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"author":     map[string]any{"login": "user1"},
-			"url":        "https://github.com/owner/repo/discussions/1",
-			"category":   map[string]any{"name": "General"},
+			"number":      1,
+			"title":       "Discussion 1 title",
+			"createdAt":   "2023-01-01T00:00:00Z",
+			"updatedAt":   "2023-01-01T00:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 5,
+			"author":      map[string]any{"login": "user1"},
+			"url":         "https://github.com/owner/repo/discussions/1",
+			"category":    map[string]any{"name": "General"},
 		},
 		{
-			"number":     2,
-			"title":      "Discussion 2 title",
-			"createdAt":  "2023-02-01T00:00:00Z",
-			"updatedAt":  "2023-02-01T00:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"author":     map[string]any{"login": "user2"},
-			"url":        "https://github.com/owner/repo/discussions/2",
-			"category":   map[string]any{"name": "Questions"},
+			"number":      2,
+			"title":       "Discussion 2 title",
+			"createdAt":   "2023-02-01T00:00:00Z",
+			"updatedAt":   "2023-02-01T00:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 3,
+			"author":      map[string]any{"login": "user2"},
+			"url":         "https://github.com/owner/repo/discussions/2",
+			"category":    map[string]any{"name": "Questions"},
 		},
 		{
-			"number":     3,
-			"title":      "Discussion 3 title",
-			"createdAt":  "2023-03-01T00:00:00Z",
-			"updatedAt":  "2023-03-01T00:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"author":     map[string]any{"login": "user3"},
-			"url":        "https://github.com/owner/repo/discussions/3",
-			"category":   map[string]any{"name": "General"},
+			"number":      3,
+			"title":       "Discussion 3 title",
+			"createdAt":   "2023-03-01T00:00:00Z",
+			"updatedAt":   "2023-03-01T00:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 10,
+			"author":      map[string]any{"login": "user3"},
+			"url":         "https://github.com/owner/repo/discussions/3",
+			"category":    map[string]any{"name": "General"},
 		},
 	}
 
 	discussionsOrgLevel = []map[string]any{
 		{
-			"number":     1,
-			"title":      "Org Discussion 1 - Community Guidelines",
-			"createdAt":  "2023-01-15T00:00:00Z",
-			"updatedAt":  "2023-01-15T00:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"author":     map[string]any{"login": "org-admin"},
-			"url":        "https://github.com/owner/.github/discussions/1",
-			"category":   map[string]any{"name": "Announcements"},
+			"number":      1,
+			"title":       "Org Discussion 1 - Community Guidelines",
+			"createdAt":   "2023-01-15T00:00:00Z",
+			"updatedAt":   "2023-01-15T00:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 15,
+			"author":      map[string]any{"login": "org-admin"},
+			"url":         "https://github.com/owner/.github/discussions/1",
+			"category":    map[string]any{"name": "Announcements"},
 		},
 		{
-			"number":     2,
-			"title":      "Org Discussion 2 - Roadmap 2023",
-			"createdAt":  "2023-02-20T00:00:00Z",
-			"updatedAt":  "2023-02-20T00:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"author":     map[string]any{"login": "org-admin"},
-			"url":        "https://github.com/owner/.github/discussions/2",
-			"category":   map[string]any{"name": "General"},
+			"number":      2,
+			"title":       "Org Discussion 2 - Roadmap 2023",
+			"createdAt":   "2023-02-20T00:00:00Z",
+			"updatedAt":   "2023-02-20T00:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 8,
+			"author":      map[string]any{"login": "org-admin"},
+			"url":         "https://github.com/owner/.github/discussions/2",
+			"category":    map[string]any{"name": "General"},
 		},
 		{
-			"number":     3,
-			"title":      "Org Discussion 3 - Roadmap 2024",
-			"createdAt":  "2023-02-20T00:00:00Z",
-			"updatedAt":  "2023-02-20T00:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"author":     map[string]any{"login": "org-admin"},
-			"url":        "https://github.com/owner/.github/discussions/3",
-			"category":   map[string]any{"name": "General"},
+			"number":      3,
+			"title":       "Org Discussion 3 - Roadmap 2024",
+			"createdAt":   "2023-02-20T00:00:00Z",
+			"updatedAt":   "2023-02-20T00:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 12,
+			"author":      map[string]any{"login": "org-admin"},
+			"url":         "https://github.com/owner/.github/discussions/3",
+			"category":    map[string]any{"name": "General"},
 		},
 		{
-			"number":     4,
-			"title":      "Org Discussion 4 - Roadmap 2025",
-			"createdAt":  "2023-02-20T00:00:00Z",
-			"updatedAt":  "2023-02-20T00:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"author":     map[string]any{"login": "org-admin"},
-			"url":        "https://github.com/owner/.github/discussions/4",
-			"category":   map[string]any{"name": "General"},
+			"number":      4,
+			"title":       "Org Discussion 4 - Roadmap 2025",
+			"createdAt":   "2023-02-20T00:00:00Z",
+			"updatedAt":   "2023-02-20T00:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 7,
+			"author":      map[string]any{"login": "org-admin"},
+			"url":         "https://github.com/owner/.github/discussions/4",
+			"category":    map[string]any{"name": "General"},
 		},
 	}
 
@@ -407,10 +414,10 @@ func Test_ListDiscussions(t *testing.T) {
 	}
 
 	// Define the actual query strings that match the implementation
-	qBasicNoOrder := "query($after:String$first:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
-	qWithCategoryNoOrder := "query($after:String$categoryId:ID!$first:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after, categoryId: $categoryId){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
-	qBasicWithOrder := "query($after:String$first:Int!$orderByDirection:OrderDirection!$orderByField:DiscussionOrderField!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after, orderBy: { field: $orderByField, direction: $orderByDirection }){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
-	qWithCategoryAndOrder := "query($after:String$categoryId:ID!$first:Int!$orderByDirection:OrderDirection!$orderByField:DiscussionOrderField!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after, categoryId: $categoryId, orderBy: { field: $orderByField, direction: $orderByDirection }){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
+	qBasicNoOrder := "query($after:String$first:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,upvoteCount,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
+	qWithCategoryNoOrder := "query($after:String$categoryId:ID!$first:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after, categoryId: $categoryId){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,upvoteCount,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
+	qBasicWithOrder := "query($after:String$first:Int!$orderByDirection:OrderDirection!$orderByField:DiscussionOrderField!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after, orderBy: { field: $orderByField, direction: $orderByDirection }){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,upvoteCount,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
+	qWithCategoryAndOrder := "query($after:String$categoryId:ID!$first:Int!$orderByDirection:OrderDirection!$orderByField:DiscussionOrderField!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussions(first: $first, after: $after, categoryId: $categoryId, orderBy: { field: $orderByField, direction: $orderByDirection }){nodes{number,title,createdAt,updatedAt,closed,isAnswered,answerChosenAt,upvoteCount,author{login},category{name},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -463,7 +470,7 @@ func Test_ListDiscussions(t *testing.T) {
 
 			// Parse the structured response with pagination info
 			var response struct {
-				Discussions []*github.Discussion `json:"discussions"`
+				Discussions []map[string]any `json:"discussions"`
 				PageInfo    struct {
 					HasNextPage     bool   `json:"hasNextPage"`
 					HasPreviousPage bool   `json:"hasPreviousPage"`
@@ -479,14 +486,21 @@ func Test_ListDiscussions(t *testing.T) {
 
 			// Verify order if verifyOrder function is provided
 			if tc.verifyOrder != nil {
-				tc.verifyOrder(t, response.Discussions)
+				// Convert map responses to github.Discussion for compatibility with verifyOrder functions
+				discussions := make([]*github.Discussion, len(response.Discussions))
+				for i, d := range response.Discussions {
+					number := int(d["number"].(float64))
+					discussions[i] = &github.Discussion{Number: &number}
+				}
+				tc.verifyOrder(t, discussions)
 			}
 
 			// Verify that all returned discussions have a category if filtered
 			if _, hasCategory := tc.reqParams["category"]; hasCategory {
 				for _, discussion := range response.Discussions {
-					require.NotNil(t, discussion.DiscussionCategory, "Discussion should have category")
-					assert.NotEmpty(t, *discussion.DiscussionCategory.Name, "Discussion should have category name")
+					require.NotNil(t, discussion["category"], "Discussion should have category")
+					category := discussion["category"].(map[string]any)
+					assert.NotEmpty(t, category["name"], "Discussion should have category name")
 				}
 			}
 		})
@@ -509,7 +523,7 @@ func Test_GetDiscussion(t *testing.T) {
 	assert.ElementsMatch(t, schema.Required, []string{"owner", "repo", "discussionNumber"})
 
 	// Use exact string query that matches implementation output
-	qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,title,body,createdAt,closed,isAnswered,answerChosenAt,url,category{name}}}}"
+	qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,title,body,createdAt,closed,isAnswered,answerChosenAt,upvoteCount,url,category{name}}}}"
 
 	vars := map[string]any{
 		"owner":            "owner",
@@ -527,24 +541,26 @@ func Test_GetDiscussion(t *testing.T) {
 			name: "successful retrieval",
 			response: githubv4mock.DataResponse(map[string]any{
 				"repository": map[string]any{"discussion": map[string]any{
-					"number":     1,
-					"title":      "Test Discussion Title",
-					"body":       "This is a test discussion",
-					"url":        "https://github.com/owner/repo/discussions/1",
-					"createdAt":  "2025-04-25T12:00:00Z",
-					"closed":     false,
-					"isAnswered": false,
-					"category":   map[string]any{"name": "General"},
+					"number":      1,
+					"title":       "Test Discussion Title",
+					"body":        "This is a test discussion",
+					"url":         "https://github.com/owner/repo/discussions/1",
+					"createdAt":   "2025-04-25T12:00:00Z",
+					"closed":      false,
+					"isAnswered":  false,
+					"upvoteCount": 42,
+					"category":    map[string]any{"name": "General"},
 				}},
 			}),
 			expectError: false,
 			expected: map[string]any{
-				"number":     float64(1),
-				"title":      "Test Discussion Title",
-				"body":       "This is a test discussion",
-				"url":        "https://github.com/owner/repo/discussions/1",
-				"closed":     false,
-				"isAnswered": false,
+				"number":      float64(1),
+				"title":       "Test Discussion Title",
+				"body":        "This is a test discussion",
+				"url":         "https://github.com/owner/repo/discussions/1",
+				"closed":      false,
+				"isAnswered":  false,
+				"upvoteCount": float64(42),
 			},
 		},
 		{
@@ -582,6 +598,7 @@ func Test_GetDiscussion(t *testing.T) {
 			assert.Equal(t, tc.expected["url"], out["url"])
 			assert.Equal(t, tc.expected["closed"], out["closed"])
 			assert.Equal(t, tc.expected["isAnswered"], out["isAnswered"])
+			assert.Equal(t, tc.expected["upvoteCount"], out["upvoteCount"])
 			// Check category is present
 			category, ok := out["category"].(map[string]any)
 			require.True(t, ok)
@@ -594,7 +611,7 @@ func Test_GetDiscussionWithStringNumber(t *testing.T) {
 	// Test that WeakDecode handles string discussionNumber from MCP clients
 	toolDef := GetDiscussion(translations.NullTranslationHelper)
 
-	qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,title,body,createdAt,closed,isAnswered,answerChosenAt,url,category{name}}}}"
+	qGetDiscussion := "query($discussionNumber:Int!$owner:String!$repo:String!){repository(owner: $owner, name: $repo){discussion(number: $discussionNumber){number,title,body,createdAt,closed,isAnswered,answerChosenAt,upvoteCount,url,category{name}}}}"
 
 	vars := map[string]any{
 		"owner":            "owner",
@@ -604,14 +621,15 @@ func Test_GetDiscussionWithStringNumber(t *testing.T) {
 
 	matcher := githubv4mock.NewQueryMatcher(qGetDiscussion, vars, githubv4mock.DataResponse(map[string]any{
 		"repository": map[string]any{"discussion": map[string]any{
-			"number":     1,
-			"title":      "Test Discussion Title",
-			"body":       "This is a test discussion",
-			"url":        "https://github.com/owner/repo/discussions/1",
-			"createdAt":  "2025-04-25T12:00:00Z",
-			"closed":     false,
-			"isAnswered": false,
-			"category":   map[string]any{"name": "General"},
+			"number":      1,
+			"title":       "Test Discussion Title",
+			"body":        "This is a test discussion",
+			"url":         "https://github.com/owner/repo/discussions/1",
+			"createdAt":   "2025-04-25T12:00:00Z",
+			"closed":      false,
+			"isAnswered":  false,
+			"upvoteCount": 42,
+			"category":    map[string]any{"name": "General"},
 		}},
 	}))
 	httpClient := githubv4mock.NewMockedHTTPClient(matcher)


### PR DESCRIPTION
## Summary

Adds `upvoteCount` to the `list_discussions` and `get_discussion` tool responses. This field is on the `Discussion` type in GitHub's GraphQL API and is the primary signal for gauging community demand on feature-request discussions; without it, agents triaging feature requests have only comment count or last-activity date as proxies.

## Why

The `NodeFragment` struct in `pkg/github/discussions.go` does not include `UpvoteCount`, so the GraphQL queries for both tools never request it. For `get_discussion`, the inline anonymous struct similarly omits it. For `list_discussions`, the conversion path `NodeFragment` -> `fragmentToDiscussion` -> `*github.Discussion` also drops the field because go-github's `Discussion` type does not expose `upvoteCount` (it is a GraphQL-only field).

Fixes #2661

## What changed

- `pkg/github/discussions.go`: Added `UpvoteCount githubv4.Int` to `NodeFragment` and to `get_discussion`'s inline struct. Added `"upvoteCount"` to the `get_discussion` response map. Changed `list_discussions` to build response maps directly from `NodeFragment` instead of converting through `*github.Discussion`, surfacing `upvoteCount` along with `isAnswered`, `closed`, and `answerChosenAt` that were previously lost in conversion. Removed the now-unused `fragmentToDiscussion` helper and the `go-github` import.
- `pkg/github/discussions_test.go`: Updated `Test_ListDiscussions` and `Test_GetDiscussion` to include `upvoteCount` in mock data, query matchers, and response assertions.

### Response key changes in `list_discussions`

The old `list_discussions` path converted GraphQL results through `fragmentToDiscussion` into `*github.Discussion`, which serialized with REST-style JSON tags (`html_url`, `user`). The new path builds maps directly from `NodeFragment`, using the same key names as `get_discussion` already uses (`url`, `author`). This aligns the two discussion tools with each other and with the underlying GraphQL field names. Full mapping:

| Before | After | Reason |
| --- | --- | --- |
| `html_url` | `url` | Matches `get_discussion` and GraphQL `url` field |
| `user.login` | `author.login` | Matches `get_discussion` pattern and GraphQL `author` field |

## MCP impact

- [ ] No tool or API changes
- [x] Tool schema or behavior changed
`list_discussions` and `get_discussion` now include `upvoteCount`; `list_discussions` also changes response keys from `html_url` / `user.login` to `url` / `author.login` and surfaces `closed`, `isAnswered`, and `answerChosenAt`. Tool names, parameters, descriptions, and annotations are unchanged, so toolsnaps and generated docs are unaffected.
- [ ] New tool added

## Prompts tested (tool changes only)

- "List recent discussions in owner/repo and include their upvote counts."
- "Get discussion #1 in owner/repo and show whether it is answered and how many upvotes it has."

## Security / limits

- [ ] No security or limits impact
- [x] Auth / permissions considered
The additional discussion fields are available through the existing `read:discussion` scope; no new OAuth scope or permission check is added.
- [x] Data exposure, filtering, or token/size limits considered
The response includes additional discussion fields already returned by GitHub's GraphQL API for authorized discussion reads, and does not add extra API calls or pagination changes.

## Tool renaming

- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

## Lint & tests

- [ ] Linted locally with `./script/lint`
Not run locally.
- [ ] Tested locally with `./script/test`
Not run locally. The full race suite was not run locally.

- `go test -race ./pkg/github -run 'Test_(ListDiscussions|GetDiscussion)$'` - covers: upvoteCount presence and correct value in both list and get responses; isAnswered and closed now surfaced in list_discussions; query matcher includes upvoteCount field.

## Docs

- [x] Not needed
Tool names, parameters, descriptions, and annotations are unchanged. Toolsnaps and generated docs are unaffected.