### PR TITLE
Annotate read tools with ifc labels

### DIFF
--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/github/github-mcp-server/internal/profiler"
 	buffer "github.com/github/github-mcp-server/pkg/buffer"
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -354,6 +355,14 @@ Use this tool to list workflows in a repository, or list workflow runs, jobs, an
 				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
 
+			// attachIFC adds the IFC label to a successful Actions result when
+			// IFC labels are enabled. Workflow definitions, runs, jobs,
+			// artifacts and logs echo attacker-influenceable run output, so
+			// integrity is untrusted; confidentiality follows repo visibility.
+			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
+				return attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, r, ifc.LabelActionsResult)
+			}
+
 			var resourceIDInt int64
 			var parseErr error
 			switch method {
@@ -376,13 +385,17 @@ Use this tool to list workflows in a repository, or list workflow runs, jobs, an
 
 			switch method {
 			case actionsMethodListWorkflows:
-				return listWorkflows(ctx, client, owner, repo, pagination)
+				result, payload, err := listWorkflows(ctx, client, owner, repo, pagination)
+				return attachIFC(result), payload, err
 			case actionsMethodListWorkflowRuns:
-				return listWorkflowRuns(ctx, client, args, owner, repo, resourceID, pagination)
+				result, payload, err := listWorkflowRuns(ctx, client, args, owner, repo, resourceID, pagination)
+				return attachIFC(result), payload, err
 			case actionsMethodListWorkflowJobs:
-				return listWorkflowJobs(ctx, client, args, owner, repo, resourceIDInt, pagination)
+				result, payload, err := listWorkflowJobs(ctx, client, args, owner, repo, resourceIDInt, pagination)
+				return attachIFC(result), payload, err
 			case actionsMethodListWorkflowArtifacts:
-				return listWorkflowArtifacts(ctx, client, owner, repo, resourceIDInt, pagination)
+				result, payload, err := listWorkflowArtifacts(ctx, client, owner, repo, resourceIDInt, pagination)
+				return attachIFC(result), payload, err
 			default:
 				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}
@@ -465,6 +478,14 @@ Use this tool to get details about individual workflows, workflow runs, jobs, an
 				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
 			}
 
+			// attachIFC adds the IFC label to a successful Actions result when
+			// IFC labels are enabled. Workflow runs, jobs, artifacts, usage,
+			// and log URLs reflect attacker-influenceable run output, so
+			// integrity is untrusted; confidentiality follows repo visibility.
+			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
+				return attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, r, ifc.LabelActionsResult)
+			}
+
 			var resourceIDInt int64
 			var parseErr error
 			switch method {
@@ -480,17 +501,23 @@ Use this tool to get details about individual workflows, workflow runs, jobs, an
 
 			switch method {
 			case actionsMethodGetWorkflow:
-				return getWorkflow(ctx, client, owner, repo, resourceID)
+				result, payload, err := getWorkflow(ctx, client, owner, repo, resourceID)
+				return attachIFC(result), payload, err
 			case actionsMethodGetWorkflowRun:
-				return getWorkflowRun(ctx, client, owner, repo, resourceIDInt)
+				result, payload, err := getWorkflowRun(ctx, client, owner, repo, resourceIDInt)
+				return attachIFC(result), payload, err
 			case actionsMethodGetWorkflowJob:
-				return getWorkflowJob(ctx, client, owner, repo, resourceIDInt)
+				result, payload, err := getWorkflowJob(ctx, client, owner, repo, resourceIDInt)
+				return attachIFC(result), payload, err
 			case actionsMethodDownloadWorkflowArtifact:
-				return downloadWorkflowArtifact(ctx, client, owner, repo, resourceIDInt)
+				result, payload, err := downloadWorkflowArtifact(ctx, client, owner, repo, resourceIDInt)
+				return attachIFC(result), payload, err
 			case actionsMethodGetWorkflowRunUsage:
-				return getWorkflowRunUsage(ctx, client, owner, repo, resourceIDInt)
+				result, payload, err := getWorkflowRunUsage(ctx, client, owner, repo, resourceIDInt)
+				return attachIFC(result), payload, err
 			case actionsMethodGetWorkflowRunLogsURL:
-				return getWorkflowRunLogsURL(ctx, client, owner, repo, resourceIDInt)
+				result, payload, err := getWorkflowRunLogsURL(ctx, client, owner, repo, resourceIDInt)
+				return attachIFC(result), payload, err
 			default:
 				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}
@@ -719,12 +746,22 @@ For single job logs, provide job_id. For all failed jobs in a run, provide run_i
 				return utils.NewToolResultError("job_id is required when failed_only is false"), nil, nil
 			}
 
+			// attachIFC adds the IFC label to a successful result when IFC
+			// labels are enabled. Job logs echo attacker-influenceable run
+			// output, so integrity is untrusted; confidentiality follows repo
+			// visibility.
+			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
+				return attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, r, ifc.LabelActionsResult)
+			}
+
 			if failedOnly && runID > 0 {
 				// Handle failed-only mode: get logs for all failed jobs in the workflow run
-				return handleFailedJobLogs(ctx, client, owner, repo, int64(runID), returnContent, tailLines, deps.GetContentWindowSize())
+				result, payload, err := handleFailedJobLogs(ctx, client, owner, repo, int64(runID), returnContent, tailLines, deps.GetContentWindowSize())
+				return attachIFC(result), payload, err
 			} else if jobID > 0 {
 				// Handle single job mode
-				return handleSingleJobLogs(ctx, client, owner, repo, int64(jobID), returnContent, tailLines, deps.GetContentWindowSize())
+				result, payload, err := handleSingleJobLogs(ctx, client, owner, repo, int64(jobID), returnContent, tailLines, deps.GetContentWindowSize())
+				return attachIFC(result), payload, err
 			}
 
 			return utils.NewToolResultError("Either job_id must be provided for single job logs, or run_id with failed_only=true for failed job logs"), nil, nil

--- a/pkg/github/code_scanning.go
+++ b/pkg/github/code_scanning.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -88,7 +89,12 @@ func GetCodeScanningAlert(t translations.TranslationHelperFunc) inventory.Server
 				return utils.NewToolResultErrorFromErr("failed to marshal alert", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Code scanning alerts are access-restricted regardless of repo
+			// visibility and embed attacker-influenceable code snippets, so the
+			// label is always private-untrusted.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelSecurityAlert())
+			return result, nil, nil
 		},
 	)
 }
@@ -208,7 +214,12 @@ func ListCodeScanningAlerts(t translations.TranslationHelperFunc) inventory.Serv
 				return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Code scanning alerts are access-restricted regardless of repo
+			// visibility and embed attacker-influenceable code snippets, so the
+			// label is always private-untrusted.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelSecurityAlert())
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/context_tools.go
+++ b/pkg/github/context_tools.go
@@ -106,12 +106,7 @@ func GetMe(t translations.TranslationHelperFunc) inventory.ServerTool {
 			}
 
 			result := MarshalledTextResult(minimalUser)
-			if deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
-				if result.Meta == nil {
-					result.Meta = mcp.Meta{}
-				}
-				result.Meta["ifc"] = ifc.LabelGetMe()
-			}
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelGetMe())
 			return result, nil, nil
 		},
 	)
@@ -221,7 +216,12 @@ func GetTeams(t translations.TranslationHelperFunc) inventory.ServerTool {
 				organizations = append(organizations, orgTeams)
 			}
 
-			return MarshalledTextResult(organizations), nil, nil
+			result := MarshalledTextResult(organizations)
+			// Team membership is maintained by GitHub and cannot be forged by
+			// outside contributors (trusted). Org team rosters are visible only
+			// to org members, so confidentiality is private.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelTeam())
+			return result, nil, nil
 		},
 	)
 }
@@ -292,7 +292,12 @@ func GetTeamMembers(t translations.TranslationHelperFunc) inventory.ServerTool {
 				members = append(members, string(member.Login))
 			}
 
-			return MarshalledTextResult(members), nil, nil
+			result := MarshalledTextResult(members)
+			// Team membership is maintained by GitHub and cannot be forged by
+			// outside contributors (trusted). A team's member roster is visible
+			// only to org members, so confidentiality is private.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelTeam())
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/context_tools_test.go
+++ b/pkg/github/context_tools_test.go
@@ -199,7 +199,9 @@ func Test_GetMe_IFC_FeatureFlag(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "trusted", ifcMap["integrity"])
-		assert.Equal(t, "public", ifcMap["confidentiality"])
+		// get_me returns the caller's private repo/gist counts, which are not
+		// part of the public profile, so confidentiality is private.
+		assert.Equal(t, "private", ifcMap["confidentiality"])
 	})
 }
 

--- a/pkg/github/dependabot.go
+++ b/pkg/github/dependabot.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -89,7 +90,12 @@ func GetDependabotAlert(t translations.TranslationHelperFunc) inventory.ServerTo
 				return utils.NewToolResultErrorFromErr("failed to marshal alert", err), nil, err
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Dependabot alerts are access-restricted regardless of repo
+			// visibility and embed attacker-influenceable advisory text, so the
+			// label is always private-untrusted.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelSecurityAlert())
+			return result, nil, nil
 		},
 	)
 }
@@ -197,7 +203,12 @@ func ListDependabotAlerts(t translations.TranslationHelperFunc) inventory.Server
 				return utils.NewToolResultErrorFromErr("failed to marshal alerts", err), nil, err
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Dependabot alerts are access-restricted regardless of repo
+			// visibility and embed attacker-influenceable advisory text, so the
+			// label is always private-untrusted.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelSecurityAlert())
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -272,7 +273,11 @@ func ListDiscussions(t translations.TranslationHelperFunc) inventory.ServerTool 
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to marshal discussions: %w", err)
 			}
-			return utils.NewToolResultText(string(out)), nil, nil
+			result := utils.NewToolResultText(string(out))
+			// Discussion content is user-authored (untrusted); confidentiality
+			// follows repo visibility.
+			result = attachRepoVisibilityIFCLabelLazy(ctx, deps, owner, repo, result, ifc.LabelListIssues)
+			return result, nil, nil
 		},
 	)
 }
@@ -376,7 +381,11 @@ func GetDiscussion(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal discussion: %w", err)
 			}
 
-			return utils.NewToolResultText(string(out)), nil, nil
+			result := utils.NewToolResultText(string(out))
+			// Discussion content is user-authored (untrusted); confidentiality
+			// follows repo visibility.
+			result = attachRepoVisibilityIFCLabelLazy(ctx, deps, params.Owner, params.Repo, result, ifc.LabelListIssues)
+			return result, nil, nil
 		},
 	)
 }
@@ -580,7 +589,11 @@ func GetDiscussionComments(t translations.TranslationHelperFunc) inventory.Serve
 				return nil, nil, fmt.Errorf("failed to marshal comments: %w", err)
 			}
 
-			return utils.NewToolResultText(string(out)), nil, nil
+			result := utils.NewToolResultText(string(out))
+			// Discussion comments are user-authored (untrusted); confidentiality
+			// follows repo visibility.
+			result = attachRepoVisibilityIFCLabelLazy(ctx, deps, params.Owner, params.Repo, result, ifc.LabelListIssues)
+			return result, nil, nil
 		},
 	)
 }
@@ -1084,7 +1097,11 @@ func ListDiscussionCategories(t translations.TranslationHelperFunc) inventory.Se
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to marshal discussion categories: %w", err)
 			}
-			return utils.NewToolResultText(string(out)), nil, nil
+			result := utils.NewToolResultText(string(out))
+			// Discussion categories are repo-defined structural metadata
+			// (trusted); confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabelLazy(ctx, deps, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/feature_flags.go
+++ b/pkg/github/feature_flags.go
@@ -36,7 +36,6 @@ var AllowedFeatureFlags = []string{
 var InsidersFeatureFlags = []string{
 	MCPAppsFeatureFlag,
 	FeatureFlagCSVOutput,
-	FeatureFlagIFCLabels,
 	FeatureFlagIssueFields,
 }
 

--- a/pkg/github/feature_flags_test.go
+++ b/pkg/github/feature_flags_test.go
@@ -162,10 +162,10 @@ func TestResolveFeatureFlags(t *testing.T) {
 			expectedFlags:   InsidersFeatureFlags,
 		},
 		{
-			name:            "insiders mode enables internal-only flags",
+			name:            "insiders mode does not auto-enable ifc labels",
 			enabledFeatures: nil,
 			insidersMode:    true,
-			expectedFlags:   []string{FeatureFlagIFCLabels},
+			unexpectedFlags: []string{FeatureFlagIFCLabels},
 		},
 		{
 			name:            "ifc_labels can be directly enabled",

--- a/pkg/github/gists.go
+++ b/pkg/github/gists.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -99,7 +100,15 @@ func ListGists(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Gist contents are user-authored (untrusted); confidentiality is
+			// the IFC join of each gist's own public/secret flag.
+			visibilities := make([]bool, 0, len(gists))
+			for _, g := range gists {
+				visibilities = append(visibilities, g.GetPublic())
+			}
+			result = attachJoinedIFCLabel(ctx, deps, result, visibilities, ifc.LabelGistList)
+			return result, nil, nil
 		},
 	)
 }
@@ -157,7 +166,11 @@ func GetGist(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Gist contents are user-authored (untrusted); confidentiality
+			// derives from the gist's own public/secret flag.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelGist(gist.GetPublic()))
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/git.go
+++ b/pkg/github/git.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -171,7 +172,13 @@ func GetRepositoryTree(t translations.TranslationHelperFunc) inventory.ServerToo
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// The repository tree exposes committed file structure; in public
+			// repos anyone can land content via a PR (untrusted), in private
+			// repos only collaborators can (trusted). Confidentiality follows
+			// repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelCommitContents)
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/ifc_labels.go
+++ b/pkg/github/ifc_labels.go
@@ -1,0 +1,154 @@
+package github
+
+import (
+	"context"
+
+	"github.com/github/github-mcp-server/pkg/ifc"
+	"github.com/google/go-github/v87/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// setIFCLabel writes the given IFC security label into a tool result's _meta
+// under the "ifc" key, allocating the Meta map if necessary.
+func setIFCLabel(r *mcp.CallToolResult, label ifc.SecurityLabel) {
+	if r.Meta == nil {
+		r.Meta = mcp.Meta{}
+	}
+	r.Meta["ifc"] = label
+}
+
+// attachStaticIFCLabel attaches a fixed IFC label to a successful tool result
+// when IFC labels are enabled. It is used by tools whose label does not depend
+// on any repository visibility lookup (e.g. security alerts, global
+// advisories, team membership, notification subjects).
+//
+// Error results are left untouched, and the label is omitted entirely when the
+// IFC feature flag is disabled.
+func attachStaticIFCLabel(ctx context.Context, deps ToolDependencies, r *mcp.CallToolResult, label ifc.SecurityLabel) *mcp.CallToolResult {
+	if r == nil || r.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
+		return r
+	}
+	setIFCLabel(r, label)
+	return r
+}
+
+// attachRepoVisibilityIFCLabel attaches an IFC label derived from a single
+// repository's visibility to a successful tool result when IFC labels are
+// enabled. The concrete label is produced by labelFn, which receives whether
+// the repository is private.
+//
+// The repository visibility is resolved via FetchRepoIsPrivate. Consistent
+// with the other IFC-labeled tools, if the visibility lookup fails the label
+// is omitted rather than risking a misclassification. Error results and the
+// disabled-feature case are left untouched.
+func attachRepoVisibilityIFCLabel(
+	ctx context.Context,
+	deps ToolDependencies,
+	client *github.Client,
+	owner, repo string,
+	r *mcp.CallToolResult,
+	labelFn func(isPrivate bool) ifc.SecurityLabel,
+) *mcp.CallToolResult {
+	if r == nil || r.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
+		return r
+	}
+	isPrivate, err := FetchRepoIsPrivate(ctx, client, owner, repo)
+	if err != nil {
+		return r
+	}
+	setIFCLabel(r, labelFn(isPrivate))
+	return r
+}
+
+// ifcSearchPostProcessOption returns a searchOption that attaches IFC labels to
+// a multi-repository search result. The feature-flag check is centralized here
+// (mirroring the attach* helpers above) rather than in each search tool
+// handler: when IFC labels are disabled it returns a no-op option, so callers
+// can pass it unconditionally to searchHandler.
+func ifcSearchPostProcessOption(ctx context.Context, deps ToolDependencies) searchOption {
+	if !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
+		return func(*searchConfig) {}
+	}
+	return withSearchPostProcess(searchIssuesIFCPostProcess(deps))
+}
+
+// attachRepoVisibilityIFCLabelLazy is like attachRepoVisibilityIFCLabel but
+// resolves the REST client itself, only when IFC labels are enabled. It is used
+// by tools whose handler holds a GraphQL client (or no client yet) and would
+// otherwise have to acquire a REST client solely to compute the label. The
+// feature-flag check is centralized here so callers can invoke it
+// unconditionally; if the client cannot be obtained or the visibility lookup
+// fails, the label is omitted rather than risking a misclassification.
+func attachRepoVisibilityIFCLabelLazy(
+	ctx context.Context,
+	deps ToolDependencies,
+	owner, repo string,
+	r *mcp.CallToolResult,
+	labelFn func(isPrivate bool) ifc.SecurityLabel,
+) *mcp.CallToolResult {
+	if r == nil || r.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
+		return r
+	}
+	client, err := deps.GetClient(ctx)
+	if err != nil {
+		return r
+	}
+	return attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, r, labelFn)
+}
+
+// attachJoinedIFCLabel attaches an IFC label computed by joining a set of
+// per-item visibilities (true == private for repositories, true == public for
+// gists) when IFC labels are enabled. joinFn is the lattice join for the
+// relevant item kind (e.g. ifc.LabelSearchIssues or ifc.LabelGistList). The
+// visibility slice is cheap to build from an already-fetched response, so
+// callers may construct it unconditionally and let this helper own the
+// feature-flag gate.
+func attachJoinedIFCLabel(
+	ctx context.Context,
+	deps ToolDependencies,
+	r *mcp.CallToolResult,
+	visibilities []bool,
+	joinFn func([]bool) ifc.SecurityLabel,
+) *mcp.CallToolResult {
+	if r == nil || r.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
+		return r
+	}
+	setIFCLabel(r, joinFn(visibilities))
+	return r
+}
+
+// newRepoVisibilityIFCLabeler returns a closure that attaches a repo-visibility
+// IFC label to a tool result, for handlers that have several return paths and
+// want to label each one. The returned function owns the feature-flag gate (so
+// callers invoke it unconditionally) and caches the repository visibility
+// lookup across calls, so a handler that returns from many branches only pays
+// for one FetchRepoIsPrivate call. A failed visibility lookup is not cached, so
+// a later return path can retry; on persistent failure the label is omitted
+// rather than risking a misclassification.
+func newRepoVisibilityIFCLabeler(
+	ctx context.Context,
+	deps ToolDependencies,
+	client *github.Client,
+	owner, repo string,
+	labelFn func(isPrivate bool) ifc.SecurityLabel,
+) func(*mcp.CallToolResult) *mcp.CallToolResult {
+	var (
+		known     bool
+		isPrivate bool
+	)
+	return func(r *mcp.CallToolResult) *mcp.CallToolResult {
+		if r == nil || r.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
+			return r
+		}
+		if !known {
+			p, err := FetchRepoIsPrivate(ctx, client, owner, repo)
+			if err != nil {
+				return r
+			}
+			isPrivate = p
+			known = true
+		}
+		setIFCLabel(r, labelFn(isPrivate))
+		return r
+	}
+}

--- a/pkg/github/issue_fields.go
+++ b/pkg/github/issue_fields.go
@@ -8,6 +8,7 @@ import (
 
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -155,7 +156,17 @@ func ListIssueFields(t translations.TranslationHelperFunc) inventory.ServerTool 
 				return utils.NewToolResultErrorFromErr("failed to marshal issue fields", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Issue field definitions are repo/org structural metadata
+			// (trusted). When scoped to a specific repo, confidentiality
+			// follows that repo's visibility; for an org-level lookup (no
+			// repo) it is conservatively treated as private.
+			if repo == "" {
+				result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelRepoMetadata(true))
+			} else {
+				result = attachRepoVisibilityIFCLabelLazy(ctx, deps, owner, repo, result, ifc.LabelRepoMetadata)
+			}
+			return result, nil, nil
 		})
 	st.FeatureFlagEnable = FeatureFlagIssueFields
 	return st

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -804,20 +804,7 @@ Options are:
 			// attachIFC adds the IFC label to a successful tool result when
 			// IFC labels are enabled. If the visibility lookup fails the
 			// label is omitted rather than misclassifying the result.
-			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
-				if r == nil || r.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
-					return r
-				}
-				isPrivate, err := FetchRepoIsPrivate(ctx, client, owner, repo)
-				if err != nil {
-					return r
-				}
-				if r.Meta == nil {
-					r.Meta = mcp.Meta{}
-				}
-				r.Meta["ifc"] = ifc.LabelListIssues(isPrivate)
-				return r
-			}
+			attachIFC := newRepoVisibilityIFCLabeler(ctx, deps, client, owner, repo, ifc.LabelListIssues)
 
 			switch method {
 			case "get":
@@ -1132,7 +1119,13 @@ func ListIssueTypes(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultErrorFromErr("failed to marshal issue types", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Issue types are org-defined structural metadata (trusted, not
+			// attacker-authored). They are scoped to an organization rather
+			// than a single repo, so confidentiality is conservatively treated
+			// as private (restricted to org members).
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelRepoMetadata(true))
+			return result, nil, nil
 		})
 }
 
@@ -1511,11 +1504,7 @@ func SearchIssues(t translations.TranslationHelperFunc) inventory.ServerTool {
 		},
 		[]scopes.Scope{scopes.Repo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-			var options []searchOption
-			if deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
-				options = append(options, withSearchPostProcess(searchIssuesIFCPostProcess(deps)))
-			}
-			result, err := searchIssuesHandler(ctx, deps, args, options...)
+			result, err := searchIssuesHandler(ctx, deps, args, ifcSearchPostProcessOption(ctx, deps))
 			return result, nil, err
 		})
 }
@@ -2769,12 +2758,7 @@ func ListIssues(t translations.TranslationHelperFunc) inventory.ServerTool {
 			}
 
 			result := MarshalledTextResult(resp)
-			if deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
-				if result.Meta == nil {
-					result.Meta = mcp.Meta{}
-				}
-				result.Meta["ifc"] = ifc.LabelListIssues(isPrivate)
-			}
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelListIssues(isPrivate))
 			return result, nil, nil
 		})
 	st.FeatureFlagEnable = FeatureFlagIssueFields
@@ -2972,12 +2956,7 @@ func LegacyListIssues(t translations.TranslationHelperFunc) inventory.ServerTool
 			}
 
 			result := MarshalledTextResult(resp)
-			if deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
-				if result.Meta == nil {
-					result.Meta = mcp.Meta{}
-				}
-				result.Meta["ifc"] = ifc.LabelListIssues(isPrivate)
-			}
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelListIssues(isPrivate))
 			return result, nil, nil
 		})
 	st.FeatureFlagDisable = []string{FeatureFlagIssueFields}

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -105,7 +106,11 @@ func GetLabel(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal label: %w", err)
 			}
 
-			return utils.NewToolResultText(string(out)), nil, nil
+			result := utils.NewToolResultText(string(out))
+			// Labels are structural repo metadata defined by collaborators
+			// (trusted); confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabelLazy(ctx, deps, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }
@@ -204,7 +209,11 @@ func ListLabels(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal labels: %w", err)
 			}
 
-			return utils.NewToolResultText(string(out)), nil, nil
+			result := utils.NewToolResultText(string(out))
+			// Labels are structural repo metadata defined by collaborators
+			// (trusted); confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabelLazy(ctx, deps, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/notifications.go
+++ b/pkg/github/notifications.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -386,7 +387,13 @@ func GetNotificationDetails(t translations.TranslationHelperFunc) inventory.Serv
 				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// A notification subject points at an issue, PR, comment, or
+			// discussion whose content is user-authored (untrusted). It is
+			// delivered to a specific recipient and may reference private
+			// repositories, so confidentiality is private.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelNotificationDetails())
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -227,9 +228,19 @@ Use this tool to list projects for a user or organization, or list project field
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
+			// attachIFC adds the IFC label to a successful result when IFC
+			// labels are enabled. Project titles, item content, field
+			// definitions, and status updates are user-authored free text
+			// (untrusted); confidentiality is conservatively private since the
+			// project's public flag is not available across every sub-result.
+			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
+				return attachStaticIFCLabel(ctx, deps, r, ifc.LabelProject(false))
+			}
+
 			switch method {
 			case projectsMethodListProjects:
-				return listProjects(ctx, client, args, owner, ownerType)
+				result, payload, err := listProjects(ctx, client, args, owner, ownerType)
+				return attachIFC(result), payload, err
 			default:
 				// All other methods require project_number and ownerType detection
 				if ownerType == "" {
@@ -245,15 +256,18 @@ Use this tool to list projects for a user or organization, or list project field
 
 				switch method {
 				case projectsMethodListProjectFields:
-					return listProjectFields(ctx, client, args, owner, ownerType)
+					result, payload, err := listProjectFields(ctx, client, args, owner, ownerType)
+					return attachIFC(result), payload, err
 				case projectsMethodListProjectItems:
-					return listProjectItems(ctx, client, args, owner, ownerType)
+					result, payload, err := listProjectItems(ctx, client, args, owner, ownerType)
+					return attachIFC(result), payload, err
 				case projectsMethodListProjectStatusUpdates:
 					gqlClient, err := deps.GetGQLClient(ctx)
 					if err != nil {
 						return utils.NewToolResultError(err.Error()), nil, nil
 					}
-					return listProjectStatusUpdates(ctx, gqlClient, args, owner, ownerType)
+					result, payload, err := listProjectStatusUpdates(ctx, gqlClient, args, owner, ownerType)
+					return attachIFC(result), payload, err
 				default:
 					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 				}
@@ -332,6 +346,14 @@ Use this tool to get details about individual projects, project fields, and proj
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
+			// attachIFC adds the IFC label to a successful result when IFC
+			// labels are enabled. Project data is user-authored free text
+			// (untrusted); confidentiality is conservatively private since the
+			// project's public flag is not available across every sub-result.
+			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
+				return attachStaticIFCLabel(ctx, deps, r, ifc.LabelProject(false))
+			}
+
 			// Handle get_project_status_update early — it only needs status_update_id
 			if method == projectsMethodGetProjectStatusUpdate {
 				statusUpdateID, err := RequiredParam[string](args, "status_update_id")
@@ -342,7 +364,8 @@ Use this tool to get details about individual projects, project fields, and proj
 				if err != nil {
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
-				return getProjectStatusUpdate(ctx, gqlClient, statusUpdateID)
+				result, payload, err := getProjectStatusUpdate(ctx, gqlClient, statusUpdateID)
+				return attachIFC(result), payload, err
 			}
 
 			owner, err := RequiredParam[string](args, "owner")
@@ -375,13 +398,15 @@ Use this tool to get details about individual projects, project fields, and proj
 
 			switch method {
 			case projectsMethodGetProject:
-				return getProject(ctx, client, owner, ownerType, projectNumber)
+				result, payload, err := getProject(ctx, client, owner, ownerType, projectNumber)
+				return attachIFC(result), payload, err
 			case projectsMethodGetProjectField:
 				fieldID, err := RequiredBigInt(args, "field_id")
 				if err != nil {
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
-				return getProjectField(ctx, client, owner, ownerType, projectNumber, fieldID)
+				result, payload, err := getProjectField(ctx, client, owner, ownerType, projectNumber, fieldID)
+				return attachIFC(result), payload, err
 			case projectsMethodGetProjectItem:
 				itemID, err := RequiredBigInt(args, "item_id")
 				if err != nil {
@@ -391,7 +416,8 @@ Use this tool to get details about individual projects, project fields, and proj
 				if err != nil {
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
-				return getProjectItem(ctx, client, owner, ownerType, projectNumber, itemID, fields)
+				result, payload, err := getProjectItem(ctx, client, owner, ownerType, projectNumber, itemID, fields)
+				return attachIFC(result), payload, err
 			default:
 				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shurcooL/githubv4"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/octicons"
 	"github.com/github/github-mcp-server/pkg/sanitize"
@@ -106,19 +107,29 @@ Possible options:
 				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
 
+			// attachIFC adds the IFC label to a successful tool result when
+			// IFC labels are enabled. Pull request content (descriptions,
+			// diffs, comments, reviews) is user-authored and therefore
+			// untrusted; confidentiality follows repo visibility. If the
+			// visibility lookup fails the label is omitted rather than
+			// misclassifying the result.
+			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
+				return attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, r, ifc.LabelListIssues)
+			}
+
 			switch method {
 			case "get":
 				result, err := GetPullRequest(ctx, client, deps, owner, repo, pullNumber)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			case "get_diff":
 				result, err := GetPullRequestDiff(ctx, client, owner, repo, pullNumber)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			case "get_status":
 				result, err := GetPullRequestStatus(ctx, client, owner, repo, pullNumber)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			case "get_files":
 				result, err := GetPullRequestFiles(ctx, client, owner, repo, pullNumber, pagination)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			case "get_review_comments":
 				gqlClient, err := deps.GetGQLClient(ctx)
 				if err != nil {
@@ -129,16 +140,16 @@ Possible options:
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
 				result, err := GetPullRequestReviewComments(ctx, gqlClient, deps, owner, repo, pullNumber, cursorPagination)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			case "get_reviews":
 				result, err := GetPullRequestReviews(ctx, client, deps, owner, repo, pullNumber, pagination)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			case "get_comments":
 				result, err := GetIssueComments(ctx, client, deps, owner, repo, pullNumber, pagination)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			case "get_check_runs":
 				result, err := GetPullRequestCheckRuns(ctx, client, owner, repo, pullNumber, pagination)
-				return result, nil, err
+				return attachIFC(result), nil, err
 			default:
 				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
 			}
@@ -1276,7 +1287,11 @@ func ListPullRequests(t translations.TranslationHelperFunc) inventory.ServerTool
 				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Pull request titles/bodies are user-authored (untrusted);
+			// confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelListIssues)
+			return result, nil, nil
 		})
 }
 
@@ -1446,7 +1461,7 @@ func SearchPullRequests(t translations.TranslationHelperFunc) inventory.ServerTo
 		},
 		[]scopes.Scope{scopes.Repo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-			result, err := searchHandler(ctx, deps.GetClient, args, "pr", "failed to search pull requests")
+			result, err := searchHandler(ctx, deps.GetClient, args, "pr", "failed to search pull requests", ifcSearchPostProcessOption(ctx, deps))
 			return result, nil, err
 		})
 }

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1806,8 +1806,21 @@ func ListReleases(t translations.TranslationHelperFunc) inventory.ServerTool {
 
 			result := utils.NewToolResultText(string(r))
 			// Releases are published by collaborators with push access, so
-			// integrity is trusted. Confidentiality follows repo visibility.
-			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			// integrity is trusted. Confidentiality follows repo visibility,
+			// but draft releases are visible only to push-access users and are
+			// not world-readable even on a public repo, so the result is only
+			// public when no returned release is a draft.
+			hasDraft := false
+			for _, mr := range minimalReleases {
+				if mr.Draft {
+					hasDraft = true
+					break
+				}
+			}
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result,
+				func(isPrivate bool) ifc.SecurityLabel {
+					return ifc.LabelRelease(isPrivate, hasDraft)
+				})
 			return result, nil, nil
 		},
 	)
@@ -1876,8 +1889,13 @@ func GetLatestRelease(t translations.TranslationHelperFunc) inventory.ServerTool
 
 			result := utils.NewToolResultText(string(r))
 			// Releases are published by collaborators with push access, so
-			// integrity is trusted. Confidentiality follows repo visibility.
-			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			// integrity is trusted. The "latest release" endpoint never returns
+			// a draft, but the draft flag is honored defensively: a draft is
+			// not world-readable even on a public repo.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result,
+				func(isPrivate bool) ifc.SecurityLabel {
+					return ifc.LabelRelease(isPrivate, release.GetDraft())
+				})
 			return result, nil, nil
 		},
 	)
@@ -1957,8 +1975,13 @@ func GetReleaseByTag(t translations.TranslationHelperFunc) inventory.ServerTool 
 
 			result := utils.NewToolResultText(string(r))
 			// Releases are published by collaborators with push access, so
-			// integrity is trusted. Confidentiality follows repo visibility.
-			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			// integrity is trusted. A release fetched by tag may be a draft,
+			// which is visible only to push-access users and not world-readable
+			// even on a public repo, so a draft forces private confidentiality.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result,
+				func(isPrivate bool) ifc.SecurityLabel {
+					return ifc.LabelRelease(isPrivate, release.GetDraft())
+				})
 			return result, nil, nil
 		},
 	)
@@ -2343,9 +2366,10 @@ func ListRepositoryCollaborators(t translations.TranslationHelperFunc) inventory
 
 			callResult := MarshalledTextResult(response)
 			// The collaborator roster is GitHub-maintained membership data
-			// (trusted, not attacker-authored). Confidentiality follows repo
-			// visibility — collaborators of a private repo are not public.
-			callResult = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, callResult, ifc.LabelRepoMetadata)
+			// (trusted, not attacker-authored). Listing collaborators requires
+			// push access, so the roster is never world-readable — not even on
+			// a public repo — hence always private confidentiality.
+			callResult = attachStaticIFCLabel(ctx, deps, callResult, ifc.LabelCollaboratorRoster())
 			return callResult, nil, nil
 		},
 	)

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -118,7 +118,13 @@ func GetCommit(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Commit content is reachable from the repo's history; in public
+			// repos anyone can land it via a PR (untrusted), in private repos
+			// only collaborators can (trusted). Confidentiality follows repo
+			// visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelCommitContents)
+			return result, nil, nil
 		},
 	)
 }
@@ -265,7 +271,12 @@ func ListCommits(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Commit content is reachable from the repo's history; integrity
+			// follows the same public-untrusted / private-trusted rule as file
+			// contents. Confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelCommitContents)
+			return result, nil, nil
 		},
 	)
 }
@@ -352,7 +363,12 @@ func ListBranches(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Branches are structural repo metadata that only collaborators
+			// with push access can create, so integrity is trusted.
+			// Confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }
@@ -752,28 +768,7 @@ func GetFileContents(t translations.TranslationHelperFunc) inventory.ServerTool 
 			// each. If the visibility lookup fails we skip the label rather
 			// than misclassify the result; the failure is not cached so a
 			// later return path can retry.
-			var (
-				ifcLabelKnown bool
-				ifcIsPrivate  bool
-			)
-			attachIFC := func(r *mcp.CallToolResult) *mcp.CallToolResult {
-				if r == nil || r.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
-					return r
-				}
-				if !ifcLabelKnown {
-					isPrivate, err := FetchRepoIsPrivate(ctx, client, owner, repo)
-					if err != nil {
-						return r
-					}
-					ifcIsPrivate = isPrivate
-					ifcLabelKnown = true
-				}
-				if r.Meta == nil {
-					r.Meta = mcp.Meta{}
-				}
-				r.Meta["ifc"] = ifc.LabelGetFileContents(ifcIsPrivate)
-				return r
-			}
+			attachIFC := newRepoVisibilityIFCLabeler(ctx, deps, client, owner, repo, ifc.LabelGetFileContents)
 
 			rawOpts, fallbackUsed, err := resolveGitReference(ctx, client, owner, repo, ref, sha)
 			if err != nil {
@@ -1609,7 +1604,12 @@ func ListTags(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Tags are structural repo metadata created by collaborators with
+			// push access, so integrity is trusted. Confidentiality follows
+			// repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }
@@ -1689,7 +1689,9 @@ func GetTag(t translations.TranslationHelperFunc) inventory.ServerTool {
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 				}
-				return utils.NewToolResultText(string(r)), nil, nil
+				result := utils.NewToolResultText(string(r))
+				result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+				return result, nil, nil
 			}
 
 			tagObj, resp, err := client.Git.GetTag(ctx, owner, repo, *ref.Object.SHA)
@@ -1715,7 +1717,12 @@ func GetTag(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// An annotated tag object is structural repo metadata created by a
+			// collaborator with push access. Confidentiality follows repo
+			// visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }
@@ -1797,7 +1804,11 @@ func ListReleases(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Releases are published by collaborators with push access, so
+			// integrity is trusted. Confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }
@@ -1863,7 +1874,11 @@ func GetLatestRelease(t translations.TranslationHelperFunc) inventory.ServerTool
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Releases are published by collaborators with push access, so
+			// integrity is trusted. Confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }
@@ -1940,7 +1955,11 @@ func GetReleaseByTag(t translations.TranslationHelperFunc) inventory.ServerTool 
 				return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Releases are published by collaborators with push access, so
+			// integrity is trusted. Confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoMetadata)
+			return result, nil, nil
 		},
 	)
 }
@@ -2072,7 +2091,18 @@ func ListStarredRepositories(t translations.TranslationHelperFunc) inventory.Ser
 				return nil, nil, fmt.Errorf("failed to marshal starred repositories: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// A starred-repository listing exposes repository data across many
+			// repos; reuse the multi-repo join shared with search_repositories
+			// (untrusted integrity; confidentiality private if any matched repo
+			// is private). Visibility is read directly from the response, so no
+			// extra API call is needed.
+			visibilities := make([]bool, 0, len(minimalRepos))
+			for _, mr := range minimalRepos {
+				visibilities = append(visibilities, mr.Private)
+			}
+			result = attachJoinedIFCLabel(ctx, deps, result, visibilities, ifc.LabelSearchIssues)
+			return result, nil, nil
 		},
 	)
 }
@@ -2311,7 +2341,12 @@ func ListRepositoryCollaborators(t translations.TranslationHelperFunc) inventory
 				"lastPage":  resp.LastPage,
 			}
 
-			return MarshalledTextResult(response), nil, nil
+			callResult := MarshalledTextResult(response)
+			// The collaborator roster is GitHub-maintained membership data
+			// (trusted, not attacker-authored). Confidentiality follows repo
+			// visibility — collaborators of a private repo are not public.
+			callResult = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, callResult, ifc.LabelRepoMetadata)
+			return callResult, nil, nil
 		},
 	)
 }

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -3838,6 +3838,107 @@ func Test_GetReleaseByTag(t *testing.T) {
 	}
 }
 
+// Test_GetReleaseByTag_IFC_FeatureFlag verifies the IFC label on
+// get_release_by_tag. The label is only present when the ifc_labels flag is
+// enabled, and confidentiality is public only for a non-draft release on a
+// public repo. A draft release is visible only to push-access users, so even
+// on a public repo it must be labeled private. Guards against the same
+// under-classification fixed for repository security advisories.
+func Test_GetReleaseByTag_IFC_FeatureFlag(t *testing.T) {
+	t.Parallel()
+
+	serverTool := GetReleaseByTag(translations.NullTranslationHelper)
+
+	makeRelease := func(draft bool) *github.RepositoryRelease {
+		return &github.RepositoryRelease{
+			ID:      github.Ptr(int64(1)),
+			TagName: github.Ptr("v1.0.0"),
+			Name:    github.Ptr("v1.0.0"),
+			Draft:   github.Ptr(draft),
+		}
+	}
+
+	makeMockClient := func(isPrivate bool, release *github.RepositoryRelease) *http.Client {
+		return MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposReleasesTagsByOwnerByRepoByTag: mockResponse(t, http.StatusOK, release),
+			GetReposByOwnerByRepo: mockResponse(t, http.StatusOK, map[string]any{
+				"name":    "repo",
+				"private": isPrivate,
+			}),
+		})
+	}
+
+	reqParams := map[string]any{"owner": "owner", "repo": "repo", "tag": "v1.0.0"}
+
+	readIFC := func(t *testing.T, result *mcp.CallToolResult) (map[string]any, bool) {
+		t.Helper()
+		if result.Meta == nil {
+			return nil, false
+		}
+		label, ok := result.Meta["ifc"]
+		if !ok {
+			return nil, false
+		}
+		labelJSON, err := json.Marshal(label)
+		require.NoError(t, err)
+		var labelMap map[string]any
+		require.NoError(t, json.Unmarshal(labelJSON, &labelMap))
+		return labelMap, true
+	}
+
+	t.Run("feature flag disabled omits ifc label", func(t *testing.T) {
+		t.Parallel()
+		deps := BaseDeps{Client: mustNewGHClient(t, makeMockClient(false, makeRelease(false)))}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		assert.Nil(t, result.Meta)
+	})
+
+	t.Run("public repo with published release is public", func(t *testing.T) {
+		t.Parallel()
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeMockClient(false, makeRelease(false))),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		label, ok := readIFC(t, result)
+		require.True(t, ok)
+		assert.Equal(t, "trusted", label["integrity"])
+		assert.Equal(t, "public", label["confidentiality"])
+	})
+
+	t.Run("public repo with draft release is private", func(t *testing.T) {
+		t.Parallel()
+		// Reviewer-class scenario: a draft release on a public repo is not
+		// world-readable, so the label must not be public.
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeMockClient(false, makeRelease(true))),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		label, ok := readIFC(t, result)
+		require.True(t, ok)
+		assert.Equal(t, "trusted", label["integrity"])
+		assert.Equal(t, "private", label["confidentiality"], "draft release on public repo must be private")
+	})
+}
+
 func Test_looksLikeSHA(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -620,6 +620,127 @@ func Test_GetFileContents_IFC_InsidersMode(t *testing.T) {
 	})
 }
 
+// Test_GetCommit_IFC_FeatureFlag verifies that the IFC security label is only
+// attached to get_commit results when the ifc_labels feature flag is enabled,
+// and that the label content matches the commit-contents rule (untrusted on
+// public repos, trusted on private). It also confirms the label is omitted
+// when the repository visibility lookup fails, so the result is never
+// misclassified. get_commit is representative of every tool wired through the
+// shared attachRepoVisibilityIFCLabel helper.
+func Test_GetCommit_IFC_FeatureFlag(t *testing.T) {
+	t.Parallel()
+
+	serverTool := GetCommit(translations.NullTranslationHelper)
+
+	mockCommit := &github.RepositoryCommit{
+		SHA:     github.Ptr("abc123def456"),
+		Commit:  &github.Commit{Message: github.Ptr("First commit")},
+		HTMLURL: github.Ptr("https://github.com/owner/repo/commit/abc123def456"),
+	}
+
+	makeMockClient := func(isPrivate bool) *http.Client {
+		return MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposCommitsByOwnerByRepoByRef: mockResponse(t, http.StatusOK, mockCommit),
+			GetReposByOwnerByRepo: mockResponse(t, http.StatusOK, map[string]any{
+				"name":    "repo",
+				"private": isPrivate,
+			}),
+		})
+	}
+
+	reqParams := map[string]any{
+		"owner": "owner",
+		"repo":  "repo",
+		"sha":   "abc123def456",
+	}
+
+	t.Run("feature flag disabled omits ifc label from result meta", func(t *testing.T) {
+		deps := BaseDeps{
+			Client: mustNewGHClient(t, makeMockClient(false)),
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		assert.Nil(t, result.Meta, "result meta should be nil when IFC labels are disabled")
+	})
+
+	t.Run("feature flag enabled on public repo emits public untrusted label", func(t *testing.T) {
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeMockClient(false)),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcLabel, ok := result.Meta["ifc"]
+		require.True(t, ok, "result meta should contain ifc key")
+
+		ifcJSON, err := json.Marshal(ifcLabel)
+		require.NoError(t, err)
+		var ifcMap map[string]any
+		require.NoError(t, json.Unmarshal(ifcJSON, &ifcMap))
+
+		assert.Equal(t, "untrusted", ifcMap["integrity"])
+		assert.Equal(t, "public", ifcMap["confidentiality"])
+	})
+
+	t.Run("feature flag enabled on private repo emits private trusted label", func(t *testing.T) {
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeMockClient(true)),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		require.NotNil(t, result.Meta)
+		ifcLabel, ok := result.Meta["ifc"]
+		require.True(t, ok, "result meta should contain ifc key")
+
+		ifcJSON, err := json.Marshal(ifcLabel)
+		require.NoError(t, err)
+		var ifcMap map[string]any
+		require.NoError(t, json.Unmarshal(ifcJSON, &ifcMap))
+
+		assert.Equal(t, "trusted", ifcMap["integrity"])
+		assert.Equal(t, "private", ifcMap["confidentiality"])
+	})
+
+	t.Run("feature flag enabled skips ifc label when visibility lookup fails", func(t *testing.T) {
+		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposCommitsByOwnerByRepoByRef: mockResponse(t, http.StatusOK, mockCommit),
+			GetReposByOwnerByRepo:             mockResponse(t, http.StatusInternalServerError, "boom"),
+		})
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, mockedClient),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "tool call should still succeed when visibility lookup fails")
+
+		if result.Meta != nil {
+			_, hasIFC := result.Meta["ifc"]
+			assert.False(t, hasIFC, "ifc label should be omitted when visibility lookup fails")
+		}
+	})
+}
+
 func Test_ForkRepository(t *testing.T) {
 	// Verify tool definition once
 	serverTool := ForkRepository(translations.NullTranslationHelper)

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -163,22 +163,22 @@ func SearchRepositories(t translations.TranslationHelperFunc) inventory.ServerTo
 			}
 
 			callResult := utils.NewToolResultText(string(r))
-			if deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
-				attachSearchRepositoriesIFCLabel(result.Repositories, callResult)
-			}
+			attachSearchRepositoriesIFCLabel(ctx, deps, result.Repositories, callResult)
 			return callResult, nil, nil
 		},
 	)
 }
 
 // attachSearchRepositoriesIFCLabel joins per-repository IFC labels across
-// every matched repository and attaches the result to callResult. Visibility
-// is read directly from the search response — no extra API call. The join
-// math is shared with search_issues via ifc.LabelSearchIssues: integrity is
-// always untrusted; confidentiality is private if any matched repository is
-// private, otherwise public.
-func attachSearchRepositoriesIFCLabel(repos []*github.Repository, callResult *mcp.CallToolResult) {
-	if callResult == nil || callResult.IsError {
+// every matched repository and attaches the result to callResult when IFC
+// labels are enabled. Visibility is read directly from the search response —
+// no extra API call. The join math is shared with search_issues via
+// ifc.LabelSearchIssues: integrity is always untrusted; confidentiality is
+// private if any matched repository is private, otherwise public. The
+// feature-flag check is centralized here (mirroring the attach* helpers in
+// ifc_labels.go) so the handler can call this unconditionally.
+func attachSearchRepositoriesIFCLabel(ctx context.Context, deps ToolDependencies, repos []*github.Repository, callResult *mcp.CallToolResult) {
+	if callResult == nil || callResult.IsError || !deps.IsFeatureEnabled(ctx, FeatureFlagIFCLabels) {
 		return
 	}
 
@@ -187,10 +187,7 @@ func attachSearchRepositoriesIFCLabel(repos []*github.Repository, callResult *mc
 		visibilities = append(visibilities, repo.GetPrivate())
 	}
 
-	if callResult.Meta == nil {
-		callResult.Meta = mcp.Meta{}
-	}
-	callResult.Meta["ifc"] = ifc.LabelSearchIssues(visibilities)
+	setIFCLabel(callResult, ifc.LabelSearchIssues(visibilities))
 }
 
 // SearchCode creates a tool to search for code across GitHub repositories.
@@ -304,7 +301,18 @@ func SearchCode(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			callResult := utils.NewToolResultText(string(r))
+			// Code search spans repositories and exposes file contents
+			// (untrusted). Confidentiality is the IFC join across every matched
+			// repository's visibility, read directly from the search response.
+			visibilities := make([]bool, 0, len(result.CodeResults))
+			for _, code := range result.CodeResults {
+				if code.Repository != nil {
+					visibilities = append(visibilities, code.Repository.GetPrivate())
+				}
+			}
+			callResult = attachJoinedIFCLabel(ctx, deps, callResult, visibilities, ifc.LabelSearchIssues)
+			return callResult, nil, nil
 		},
 	)
 }
@@ -392,7 +400,11 @@ func userOrOrgHandler(ctx context.Context, accountType string, deps ToolDependen
 	if err != nil {
 		return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
 	}
-	return utils.NewToolResultText(string(r)), nil, nil
+	callResult := utils.NewToolResultText(string(r))
+	// User and organization search returns public profile information that is
+	// authored by the account holders themselves, so it is public-untrusted.
+	callResult = attachStaticIFCLabel(ctx, deps, callResult, ifc.PublicUntrusted())
+	return callResult, nil, nil
 }
 
 // SearchUsers creates a tool to search for GitHub users.
@@ -580,7 +592,18 @@ func SearchCommits(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultErrorFromErr("failed to marshal response", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			callResult := utils.NewToolResultText(string(r))
+			// Commit search spans repositories and exposes commit content
+			// (untrusted). Confidentiality is the IFC join across every matched
+			// repository's visibility, read directly from the search response.
+			visibilities := make([]bool, 0, len(result.Commits))
+			for _, commit := range result.Commits {
+				if commit.Repository != nil {
+					visibilities = append(visibilities, commit.Repository.GetPrivate())
+				}
+			}
+			callResult = attachJoinedIFCLabel(ctx, deps, callResult, visibilities, ifc.LabelSearchIssues)
+			return callResult, nil, nil
 		},
 	)
 }

--- a/pkg/github/secret_scanning.go
+++ b/pkg/github/secret_scanning.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -89,7 +90,12 @@ func GetSecretScanningAlert(t translations.TranslationHelperFunc) inventory.Serv
 				return nil, nil, fmt.Errorf("failed to marshal alert: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Secret scanning alerts are access-restricted regardless of repo
+			// visibility and surface the matched secret material itself, so the
+			// label is always private-untrusted.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelSecurityAlert())
+			return result, nil, nil
 		},
 	)
 }
@@ -199,7 +205,12 @@ func ListSecretScanningAlerts(t translations.TranslationHelperFunc) inventory.Se
 				return nil, nil, fmt.Errorf("failed to marshal alerts: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Secret scanning alerts are access-restricted regardless of repo
+			// visibility and surface the matched secret material itself, so the
+			// label is always private-untrusted.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelSecurityAlert())
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/security_advisories.go
+++ b/pkg/github/security_advisories.go
@@ -314,9 +314,15 @@ func ListRepositorySecurityAdvisories(t translations.TranslationHelperFunc) inve
 			}
 
 			result := utils.NewToolResultText(string(r))
-			// Repository advisories carry externally authored prose (untrusted);
-			// confidentiality follows repo visibility.
-			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepositorySecurityAdvisory)
+			// Repository advisories carry externally authored prose (untrusted).
+			// Confidentiality follows repo visibility, but draft/triage/closed
+			// advisories are not world-readable even on a public repo, so the
+			// result is only public when every returned advisory is published.
+			allPublished := allAdvisoriesPublished(advisories)
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result,
+				func(isPrivate bool) ifc.SecurityLabel {
+					return ifc.LabelRepositorySecurityAdvisory(isPrivate, allPublished)
+				})
 			return result, nil, nil
 		},
 	)
@@ -476,9 +482,25 @@ func ListOrgRepositorySecurityAdvisories(t translations.TranslationHelperFunc) i
 			result := utils.NewToolResultText(string(r))
 			// Org-wide advisory listings span the organization's repositories
 			// (including private ones) and are restricted to org members, so
-			// they are conservatively labeled private-untrusted.
-			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelRepositorySecurityAdvisory(true))
+			// they are conservatively labeled private-untrusted (isPrivate=true,
+			// which forces private regardless of publication state).
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelRepositorySecurityAdvisory(true, false))
 			return result, nil, nil
 		},
 	)
+}
+
+// allAdvisoriesPublished reports whether every advisory in the slice is in the
+// "published" state. Repository security advisories can also be in draft,
+// triage, or closed states, none of which are world-readable even on a public
+// repository. An empty slice is treated as published (true) since there is no
+// non-public content to protect. Used to decide whether a repository advisory
+// listing may carry a public confidentiality label.
+func allAdvisoriesPublished(advisories []*github.SecurityAdvisory) bool {
+	for _, advisory := range advisories {
+		if advisory.GetState() != "published" {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/github/security_advisories.go
+++ b/pkg/github/security_advisories.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -203,7 +204,12 @@ func ListGlobalSecurityAdvisories(t translations.TranslationHelperFunc) inventor
 				return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Global advisories come from the world-readable GitHub Advisory
+			// Database (public) but contain externally authored prose
+			// (untrusted).
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelGlobalSecurityAdvisory())
+			return result, nil, nil
 		},
 	)
 }
@@ -307,7 +313,11 @@ func ListRepositorySecurityAdvisories(t translations.TranslationHelperFunc) inve
 				return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Repository advisories carry externally authored prose (untrusted);
+			// confidentiality follows repo visibility.
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepositorySecurityAdvisory)
+			return result, nil, nil
 		},
 	)
 }
@@ -364,7 +374,11 @@ func GetGlobalSecurityAdvisory(t translations.TranslationHelperFunc) inventory.S
 				return nil, nil, fmt.Errorf("failed to marshal advisory: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// A global advisory is world-readable (public) but externally
+			// authored (untrusted).
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelGlobalSecurityAdvisory())
+			return result, nil, nil
 		},
 	)
 }
@@ -459,7 +473,12 @@ func ListOrgRepositorySecurityAdvisories(t translations.TranslationHelperFunc) i
 				return nil, nil, fmt.Errorf("failed to marshal advisories: %w", err)
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			result := utils.NewToolResultText(string(r))
+			// Org-wide advisory listings span the organization's repositories
+			// (including private ones) and are restricted to org members, so
+			// they are conservatively labeled private-untrusted.
+			result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelRepositorySecurityAdvisory(true))
+			return result, nil, nil
 		},
 	)
 }

--- a/pkg/github/security_advisories_test.go
+++ b/pkg/github/security_advisories_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v87/github"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -368,6 +369,132 @@ func Test_ListRepositorySecurityAdvisories(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_ListRepositorySecurityAdvisories_IFC_FeatureFlag verifies the IFC label
+// attached to list_repository_security_advisories. The label is only present
+// when the ifc_labels feature flag is enabled, and — critically — confidentiality
+// is public only when the repository is public AND every returned advisory is
+// published. Draft/triage/closed advisories are not world-readable even on a
+// public repo, so a result containing one must be labeled private. This guards
+// against the under-classification raised in PR review.
+func Test_ListRepositorySecurityAdvisories_IFC_FeatureFlag(t *testing.T) {
+	t.Parallel()
+
+	toolDef := ListRepositorySecurityAdvisories(translations.NullTranslationHelper)
+
+	publishedAdvisory := &github.SecurityAdvisory{
+		GHSAID:  github.Ptr("GHSA-1111-1111-1111"),
+		Summary: github.Ptr("Published advisory"),
+		State:   github.Ptr("published"),
+	}
+	draftAdvisory := &github.SecurityAdvisory{
+		GHSAID:  github.Ptr("GHSA-2222-2222-2222"),
+		Summary: github.Ptr("Draft advisory"),
+		State:   github.Ptr("draft"),
+	}
+
+	makeMockClient := func(isPrivate bool, advisories []*github.SecurityAdvisory) *http.Client {
+		return MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			GetReposSecurityAdvisoriesByOwnerByRepo: mockResponse(t, http.StatusOK, advisories),
+			GetReposByOwnerByRepo: mockResponse(t, http.StatusOK, map[string]any{
+				"name":    "repo",
+				"private": isPrivate,
+			}),
+		})
+	}
+
+	reqParams := map[string]any{
+		"owner": "owner",
+		"repo":  "repo",
+	}
+
+	readIFC := func(t *testing.T, result *mcp.CallToolResult) (map[string]any, bool) {
+		t.Helper()
+		if result.Meta == nil {
+			return nil, false
+		}
+		label, ok := result.Meta["ifc"]
+		if !ok {
+			return nil, false
+		}
+		labelJSON, err := json.Marshal(label)
+		require.NoError(t, err)
+		var labelMap map[string]any
+		require.NoError(t, json.Unmarshal(labelJSON, &labelMap))
+		return labelMap, true
+	}
+
+	t.Run("feature flag disabled omits ifc label", func(t *testing.T) {
+		t.Parallel()
+		deps := BaseDeps{Client: mustNewGHClient(t, makeMockClient(false, []*github.SecurityAdvisory{publishedAdvisory}))}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		assert.Nil(t, result.Meta, "result meta should be nil when IFC labels are disabled")
+	})
+
+	t.Run("public repo with only published advisories is public", func(t *testing.T) {
+		t.Parallel()
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeMockClient(false, []*github.SecurityAdvisory{publishedAdvisory})),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		label, ok := readIFC(t, result)
+		require.True(t, ok, "result meta should contain ifc key")
+		assert.Equal(t, "untrusted", label["integrity"])
+		assert.Equal(t, "public", label["confidentiality"])
+	})
+
+	t.Run("public repo with a draft advisory is private", func(t *testing.T) {
+		t.Parallel()
+		// Reviewer scenario: a draft advisory on a public repo is not
+		// world-readable, so the label must not be public.
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeMockClient(false, []*github.SecurityAdvisory{publishedAdvisory, draftAdvisory})),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		label, ok := readIFC(t, result)
+		require.True(t, ok, "result meta should contain ifc key")
+		assert.Equal(t, "untrusted", label["integrity"])
+		assert.Equal(t, "private", label["confidentiality"], "draft advisory on public repo must be private")
+	})
+
+	t.Run("private repo is private", func(t *testing.T) {
+		t.Parallel()
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeMockClient(true, []*github.SecurityAdvisory{publishedAdvisory})),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := toolDef.Handler(deps)
+
+		request := createMCPRequest(reqParams)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		label, ok := readIFC(t, result)
+		require.True(t, ok, "result meta should contain ifc key")
+		assert.Equal(t, "untrusted", label["integrity"])
+		assert.Equal(t, "private", label["confidentiality"])
+	})
 }
 
 func Test_ListOrgRepositorySecurityAdvisories(t *testing.T) {

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -94,10 +94,10 @@ func TestCreateHTTPFeatureChecker(t *testing.T) {
 			wantEnabled:    true,
 		},
 		{
-			name:         "insiders mode enables internal-only insiders flags",
+			name:         "insiders mode does not auto-enable ifc labels",
 			flagName:     github.FeatureFlagIFCLabels,
 			insidersMode: true,
-			wantEnabled:  true,
+			wantEnabled:  false,
 		},
 		{
 			name:         "insiders mode does not enable granular flags",

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -190,12 +190,17 @@ func LabelGlobalSecurityAdvisory() SecurityLabel {
 // LabelRepositorySecurityAdvisory returns the IFC label for repository- or
 // organization-scoped security advisories.
 //
-// Integrity is untrusted (externally authored advisory prose). Confidentiality
-// follows repository visibility: advisories on public repositories are
-// readable by anyone, while those on private repositories are restricted to
-// the repository's readers.
-func LabelRepositorySecurityAdvisory(isPrivate bool) SecurityLabel {
-	if isPrivate {
+// Integrity is untrusted (externally authored advisory prose).
+//
+// Confidentiality is public only when the repository is public AND every
+// advisory in the result is in the "published" state. Repository security
+// advisories also exist in draft, triage, and closed states; those are visible
+// only to maintainers and are NOT world-readable even on a public repository.
+// Treating any non-published advisory as private (allPublished == false)
+// prevents misclassifying an unpublished advisory from a public repo as
+// public-readable. Private repositories are always private regardless of state.
+func LabelRepositorySecurityAdvisory(isPrivate bool, allPublished bool) SecurityLabel {
+	if isPrivate || !allPublished {
 		return PrivateUntrusted()
 	}
 	return PublicUntrusted()

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -59,8 +59,18 @@ func PrivateUntrusted() SecurityLabel {
 	}
 }
 
+// LabelGetMe returns the IFC label for the authenticated user's own profile
+// (get_me).
+//
+// Integrity is trusted: this is GitHub-maintained data about the caller's own
+// account, not attacker-authored content.
+//
+// Confidentiality is private. The result includes fields that are NOT part of
+// the user's public profile — private_gists, total_private_repos, and
+// owned_private_repos — which are visible only to the authenticated user. The
+// result therefore must not be treated as world-readable.
 func LabelGetMe() SecurityLabel {
-	return PublicTrusted()
+	return PrivateTrusted()
 }
 
 // LabelListIssues returns the IFC label for a list_issues result.
@@ -126,6 +136,38 @@ func LabelRepoMetadata(isPrivate bool) SecurityLabel {
 		return PrivateTrusted()
 	}
 	return PublicTrusted()
+}
+
+// LabelRelease returns the IFC label for repository releases (list_releases,
+// get_latest_release, get_release_by_tag).
+//
+// Integrity is trusted: releases are published by collaborators with push
+// access, not by arbitrary outsiders.
+//
+// Confidentiality is public only when the repository is public AND no returned
+// release is a draft. Draft releases are visible only to users with push
+// access — they are NOT world-readable even on a public repository — so a
+// result containing one must be private. hasDraft reflects whether any release
+// in the result is a draft; private repositories are always private regardless.
+func LabelRelease(isPrivate bool, hasDraft bool) SecurityLabel {
+	if isPrivate || hasDraft {
+		return PrivateTrusted()
+	}
+	return PublicTrusted()
+}
+
+// LabelCollaboratorRoster returns the IFC label for a repository's collaborator
+// list (list_repository_collaborators).
+//
+// Integrity is trusted: the roster is GitHub-maintained membership data, not
+// attacker-authored content.
+//
+// Confidentiality is always private. Listing collaborators requires push
+// access to the repository, so the roster is never world-readable — not even
+// for public repositories. This mirrors LabelTeam: membership data is
+// restricted regardless of the repository's own visibility.
+func LabelCollaboratorRoster() SecurityLabel {
+	return PrivateTrusted()
 }
 
 // LabelCommitContents returns the IFC label for committed repository content

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -106,3 +106,166 @@ func LabelSearchIssues(repoVisibilities []bool) SecurityLabel {
 	}
 	return PublicUntrusted()
 }
+
+// LabelRepoMetadata returns the IFC label for structural repository metadata
+// that only collaborators with write access can define: labels, branches,
+// tags, releases, issue types, issue field definitions, discussion
+// categories, and the collaborator roster.
+//
+// Integrity is trusted because, unlike issue/PR/comment bodies, these
+// artifacts cannot be authored by arbitrary outsiders — creating a branch,
+// tag, release, or label requires push access, so the data reflects decisions
+// made by the repository's trusted writers rather than attacker-controllable
+// input.
+//
+// Confidentiality follows repository visibility: public repositories are
+// universally readable; private repositories restrict the reader set (the
+// opaque "private" marker, resolved client-side at egress time).
+func LabelRepoMetadata(isPrivate bool) SecurityLabel {
+	if isPrivate {
+		return PrivateTrusted()
+	}
+	return PublicTrusted()
+}
+
+// LabelCommitContents returns the IFC label for committed repository content
+// reachable from the default branch and its history: commits, commit diffs,
+// and the repository file tree.
+//
+// It shares the reasoning of LabelGetFileContents. In public repositories any
+// outsider can land content via a pull request, so the integrity of committed
+// content is untrusted. In private repositories only collaborators can push,
+// so committed content is trusted. Confidentiality follows repository
+// visibility.
+func LabelCommitContents(isPrivate bool) SecurityLabel {
+	if isPrivate {
+		return PrivateTrusted()
+	}
+	return PublicUntrusted()
+}
+
+// LabelActionsResult returns the IFC label for GitHub Actions resources:
+// workflow definitions, runs, jobs, artifacts, and job logs.
+//
+// Integrity is untrusted. Workflow logs echo arbitrary text produced during a
+// run — including output derived from pull-request branches, dependency
+// downloads, and other attacker-influenceable sources — so log and artifact
+// content must be treated as low integrity. Workflow definitions are
+// themselves editable through pull requests in public repositories.
+//
+// Confidentiality follows repository visibility.
+func LabelActionsResult(isPrivate bool) SecurityLabel {
+	if isPrivate {
+		return PrivateUntrusted()
+	}
+	return PublicUntrusted()
+}
+
+// LabelSecurityAlert returns the IFC label for security findings: code
+// scanning alerts, secret scanning alerts, and Dependabot alerts.
+//
+// Integrity is untrusted because alert payloads embed attacker-influenceable
+// material — the offending code snippet, the matched secret string, or a
+// vulnerable dependency's advisory text — none of which the agent should treat
+// as a trustworthy instruction source.
+//
+// Confidentiality is always private. Security alerts are access-restricted by
+// GitHub regardless of repository visibility (only users with a security role
+// can read them), so the reader set is narrow even for public repositories.
+// Secret scanning results additionally surface the secret material itself.
+func LabelSecurityAlert() SecurityLabel {
+	return PrivateUntrusted()
+}
+
+// LabelGlobalSecurityAdvisory returns the IFC label for advisories served from
+// the public GitHub Advisory Database (global advisories).
+//
+// The advisory database is world-readable, so confidentiality is public.
+// Integrity is untrusted: advisory descriptions are externally authored prose
+// and must not be treated as a trusted instruction source.
+func LabelGlobalSecurityAdvisory() SecurityLabel {
+	return PublicUntrusted()
+}
+
+// LabelRepositorySecurityAdvisory returns the IFC label for repository- or
+// organization-scoped security advisories.
+//
+// Integrity is untrusted (externally authored advisory prose). Confidentiality
+// follows repository visibility: advisories on public repositories are
+// readable by anyone, while those on private repositories are restricted to
+// the repository's readers.
+func LabelRepositorySecurityAdvisory(isPrivate bool) SecurityLabel {
+	if isPrivate {
+		return PrivateUntrusted()
+	}
+	return PublicUntrusted()
+}
+
+// LabelGist returns the IFC label for gist content.
+//
+// Integrity is untrusted: gist contents are arbitrary user-authored text.
+// Confidentiality derives from the gist's own visibility rather than any
+// repository — public gists are universally readable, while secret gists are
+// restricted to those who hold the gist URL (modeled with the opaque "private"
+// marker).
+func LabelGist(isPublic bool) SecurityLabel {
+	if isPublic {
+		return PublicUntrusted()
+	}
+	return PrivateUntrusted()
+}
+
+// LabelGistList returns the IFC label for a list of gists belonging to a user,
+// joining the per-gist confidentiality across the result set.
+//
+// Integrity is untrusted (user-authored content). Confidentiality follows the
+// IFC meet: if any gist in the result is secret the joined label is private;
+// otherwise public. An empty result is treated as public-untrusted.
+func LabelGistList(gistVisibilities []bool) SecurityLabel {
+	for _, isPublic := range gistVisibilities {
+		if !isPublic {
+			return PrivateUntrusted()
+		}
+	}
+	return PublicUntrusted()
+}
+
+// LabelProject returns the IFC label for a GitHub Project (Projects v2) and its
+// items, status updates, and field definitions.
+//
+// Integrity is untrusted: project titles, item content, and status update
+// bodies are user-authored free text. Confidentiality derives from the
+// project's own public flag — public projects are universally readable, while
+// private projects restrict the reader set.
+func LabelProject(isPublic bool) SecurityLabel {
+	if isPublic {
+		return PublicUntrusted()
+	}
+	return PrivateUntrusted()
+}
+
+// LabelTeam returns the IFC label for organization team membership data
+// (get_teams, get_team_members).
+//
+// Integrity is trusted: team membership is maintained by GitHub and cannot be
+// forged by outside contributors, so it is not an attacker-controllable
+// instruction source.
+//
+// Confidentiality is private. Organization team rosters and the teams a user
+// belongs to are visible only to members of the organization, not to the
+// public, so the reader set is restricted (the opaque "private" marker).
+func LabelTeam() SecurityLabel {
+	return PrivateTrusted()
+}
+
+// LabelNotificationDetails returns the IFC label for the subject of a single
+// notification.
+//
+// Integrity is untrusted: a notification subject points at an issue, pull
+// request, comment, or discussion whose content is user-authored and may carry
+// attacker-controlled text. Confidentiality is private because notifications
+// are delivered to a specific recipient and may reference private
+// repositories; the result cannot be assumed to be publicly readable.
+func LabelNotificationDetails() SecurityLabel {
+	return PrivateUntrusted()
+}

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -108,6 +108,16 @@ func LabelGetFileContents(isPrivate bool) SecurityLabel {
 //
 // An empty result set is treated as public-untrusted (no repository data is
 // leaked).
+//
+// Why a single joined label rather than one label per item: a tool result is
+// delivered as one opaque payload (a single content block) and the IFC engine
+// makes one allow/deny decision per flow at egress. Once the items share a
+// buffer in the agent's context they can be copied anywhere together, so the
+// only sound bound for the whole result is the meet of every item's label.
+// Per-item labels would only become load-bearing if the enforcement engine
+// could partition a result and route individual items to different sinks;
+// until then they would invite unsafe declassification of a "public" item that
+// actually arrived alongside private data.
 func LabelSearchIssues(repoVisibilities []bool) SecurityLabel {
 	for _, isPrivate := range repoVisibilities {
 		if isPrivate {
@@ -268,6 +278,9 @@ func LabelGist(isPublic bool) SecurityLabel {
 // Integrity is untrusted (user-authored content). Confidentiality follows the
 // IFC meet: if any gist in the result is secret the joined label is private;
 // otherwise public. An empty result is treated as public-untrusted.
+//
+// See LabelSearchIssues for why list results carry a single joined label
+// rather than one label per item.
 func LabelGistList(gistVisibilities []bool) SecurityLabel {
 	for _, isPublic := range gistVisibilities {
 		if !isPublic {

--- a/pkg/ifc/ifc_test.go
+++ b/pkg/ifc/ifc_test.go
@@ -68,6 +68,56 @@ func TestLabelRepoMetadata(t *testing.T) {
 	})
 }
 
+func TestLabelGetMe(t *testing.T) {
+	t.Parallel()
+
+	// get_me exposes private_gists/total_private_repos/owned_private_repos,
+	// which are not part of the public profile, so the result is trusted but
+	// private — never public.
+	label := LabelGetMe()
+	assert.Equal(t, IntegrityTrusted, label.Integrity)
+	assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+}
+
+func TestLabelRelease(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public repo with no draft is trusted and public", func(t *testing.T) {
+		t.Parallel()
+		label := LabelRelease(false, false)
+		assert.Equal(t, IntegrityTrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+	})
+
+	t.Run("public repo with a draft release is private", func(t *testing.T) {
+		t.Parallel()
+		// Draft releases are visible only to push-access users, so a draft on
+		// a public repo must not be labeled public.
+		label := LabelRelease(false, true)
+		assert.Equal(t, IntegrityTrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+
+	t.Run("private repo is private regardless of draft", func(t *testing.T) {
+		t.Parallel()
+		for _, hasDraft := range []bool{false, true} {
+			label := LabelRelease(true, hasDraft)
+			assert.Equal(t, IntegrityTrusted, label.Integrity)
+			assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+		}
+	})
+}
+
+func TestLabelCollaboratorRoster(t *testing.T) {
+	t.Parallel()
+
+	// A collaborator roster requires push access to list, so it is never
+	// world-readable — always trusted and private.
+	label := LabelCollaboratorRoster()
+	assert.Equal(t, IntegrityTrusted, label.Integrity)
+	assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+}
+
 func TestLabelCommitContents(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ifc/ifc_test.go
+++ b/pkg/ifc/ifc_test.go
@@ -49,3 +49,179 @@ func TestLabelSearchIssues(t *testing.T) {
 		})
 	}
 }
+
+func TestLabelRepoMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public repo metadata is trusted and public", func(t *testing.T) {
+		t.Parallel()
+		label := LabelRepoMetadata(false)
+		assert.Equal(t, IntegrityTrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+	})
+
+	t.Run("private repo metadata is trusted and private", func(t *testing.T) {
+		t.Parallel()
+		label := LabelRepoMetadata(true)
+		assert.Equal(t, IntegrityTrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+}
+
+func TestLabelCommitContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public repo commit content is untrusted and public", func(t *testing.T) {
+		t.Parallel()
+		label := LabelCommitContents(false)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+	})
+
+	t.Run("private repo commit content is trusted and private", func(t *testing.T) {
+		t.Parallel()
+		label := LabelCommitContents(true)
+		assert.Equal(t, IntegrityTrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+}
+
+func TestLabelActionsResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public repo actions result is untrusted and public", func(t *testing.T) {
+		t.Parallel()
+		label := LabelActionsResult(false)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+	})
+
+	t.Run("private repo actions result is untrusted and private", func(t *testing.T) {
+		t.Parallel()
+		label := LabelActionsResult(true)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+}
+
+func TestLabelSecurityAlert(t *testing.T) {
+	t.Parallel()
+	label := LabelSecurityAlert()
+	assert.Equal(t, IntegrityUntrusted, label.Integrity)
+	assert.Equal(t, ConfidentialityPrivate, label.Confidentiality,
+		"security alerts are access-restricted regardless of repo visibility")
+}
+
+func TestLabelGlobalSecurityAdvisory(t *testing.T) {
+	t.Parallel()
+	label := LabelGlobalSecurityAdvisory()
+	assert.Equal(t, IntegrityUntrusted, label.Integrity)
+	assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+}
+
+func TestLabelRepositorySecurityAdvisory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public repo advisory is untrusted and public", func(t *testing.T) {
+		t.Parallel()
+		label := LabelRepositorySecurityAdvisory(false)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+	})
+
+	t.Run("private repo advisory is untrusted and private", func(t *testing.T) {
+		t.Parallel()
+		label := LabelRepositorySecurityAdvisory(true)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+}
+
+func TestLabelGist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public gist is untrusted and public", func(t *testing.T) {
+		t.Parallel()
+		label := LabelGist(true)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+	})
+
+	t.Run("secret gist is untrusted and private", func(t *testing.T) {
+		t.Parallel()
+		label := LabelGist(false)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+}
+
+func TestLabelGistList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		visibilities     []bool // true == public
+		wantConfidential Confidentiality
+	}{
+		{
+			name:             "empty result is treated as public",
+			wantConfidential: ConfidentialityPublic,
+		},
+		{
+			name:             "all public gists stay public",
+			visibilities:     []bool{true, true},
+			wantConfidential: ConfidentialityPublic,
+		},
+		{
+			name:             "any secret gist flips to private",
+			visibilities:     []bool{true, false, true},
+			wantConfidential: ConfidentialityPrivate,
+		},
+		{
+			name:             "all secret gists stay private",
+			visibilities:     []bool{false, false},
+			wantConfidential: ConfidentialityPrivate,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			label := LabelGistList(tc.visibilities)
+			assert.Equal(t, IntegrityUntrusted, label.Integrity)
+			assert.Equal(t, tc.wantConfidential, label.Confidentiality)
+		})
+	}
+}
+
+func TestLabelProject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public project is untrusted and public", func(t *testing.T) {
+		t.Parallel()
+		label := LabelProject(true)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
+	})
+
+	t.Run("private project is untrusted and private", func(t *testing.T) {
+		t.Parallel()
+		label := LabelProject(false)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+}
+
+func TestLabelTeam(t *testing.T) {
+	t.Parallel()
+	label := LabelTeam()
+	assert.Equal(t, IntegrityTrusted, label.Integrity)
+	assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+}
+
+func TestLabelNotificationDetails(t *testing.T) {
+	t.Parallel()
+	label := LabelNotificationDetails()
+	assert.Equal(t, IntegrityUntrusted, label.Integrity)
+	assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+}

--- a/pkg/ifc/ifc_test.go
+++ b/pkg/ifc/ifc_test.go
@@ -122,16 +122,32 @@ func TestLabelGlobalSecurityAdvisory(t *testing.T) {
 func TestLabelRepositorySecurityAdvisory(t *testing.T) {
 	t.Parallel()
 
-	t.Run("public repo advisory is untrusted and public", func(t *testing.T) {
+	t.Run("public repo with all published advisories is untrusted and public", func(t *testing.T) {
 		t.Parallel()
-		label := LabelRepositorySecurityAdvisory(false)
+		label := LabelRepositorySecurityAdvisory(false, true)
 		assert.Equal(t, IntegrityUntrusted, label.Integrity)
 		assert.Equal(t, ConfidentialityPublic, label.Confidentiality)
 	})
 
+	t.Run("public repo with an unpublished advisory is untrusted and private", func(t *testing.T) {
+		t.Parallel()
+		// draft/triage/closed advisories are not world-readable even on a
+		// public repo, so confidentiality must be private.
+		label := LabelRepositorySecurityAdvisory(false, false)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+
 	t.Run("private repo advisory is untrusted and private", func(t *testing.T) {
 		t.Parallel()
-		label := LabelRepositorySecurityAdvisory(true)
+		label := LabelRepositorySecurityAdvisory(true, true)
+		assert.Equal(t, IntegrityUntrusted, label.Integrity)
+		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
+	})
+
+	t.Run("private repo with unpublished advisory is untrusted and private", func(t *testing.T) {
+		t.Parallel()
+		label := LabelRepositorySecurityAdvisory(true, false)
 		assert.Equal(t, IntegrityUntrusted, label.Integrity)
 		assert.Equal(t, ConfidentialityPrivate, label.Confidentiality)
 	})


### PR DESCRIPTION
## What changed
Added ifc annotations to additional read tools. Behind a `ifc_labels` insiders flag.

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
