### PR TITLE
Route github.localhost to split-host URLs for local dotcom dev

### DIFF
--- a/pkg/utils/api.go
+++ b/pkg/utils/api.go
@@ -239,9 +239,55 @@ func parseAPIHost(s string) (APIHost, error) {
 		return newDotcomHost()
 	}
 
+	if u.Hostname() == "github.localhost" || strings.HasSuffix(u.Hostname(), ".github.localhost") {
+		return newLocalDevHost(u.Scheme)
+	}
+
 	if u.Hostname() == "ghe.com" || strings.HasSuffix(u.Hostname(), ".ghe.com") {
 		return newGHECHost(s)
 	}
 
 	return newGHESHost(s)
+}
+
+// newLocalDevHost handles a local dotcom checkout served from github.localhost.
+// Local dev mirrors production's split-host layout (api., uploads., raw.) but
+// uses a plain hostname that doesn't match the github.com / ghe.com branches,
+// so without this it falls through to newGHESHost and tries /api/v3 paths that
+// the local stack doesn't serve.
+func newLocalDevHost(scheme string) (APIHost, error) {
+	const root = "github.localhost"
+
+	restURL, err := url.Parse(fmt.Sprintf("%s://api.%s/", scheme, root))
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse local dev REST URL: %w", err)
+	}
+
+	gqlURL, err := url.Parse(fmt.Sprintf("%s://api.%s/graphql", scheme, root))
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse local dev GraphQL URL: %w", err)
+	}
+
+	uploadURL, err := url.Parse(fmt.Sprintf("%s://uploads.%s/", scheme, root))
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse local dev Upload URL: %w", err)
+	}
+
+	rawURL, err := url.Parse(fmt.Sprintf("%s://raw.%s/", scheme, root))
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse local dev Raw URL: %w", err)
+	}
+
+	authorizationServerURL, err := url.Parse(fmt.Sprintf("%s://%s/login/oauth", scheme, root))
+	if err != nil {
+		return APIHost{}, fmt.Errorf("failed to parse local dev Authorization Server URL: %w", err)
+	}
+
+	return APIHost{
+		restURL:                restURL,
+		gqlURL:                 gqlURL,
+		uploadURL:              uploadURL,
+		rawURL:                 rawURL,
+		authorizationServerURL: authorizationServerURL,
+	}, nil
 }

--- a/pkg/utils/api_test.go
+++ b/pkg/utils/api_test.go
@@ -55,6 +55,21 @@ func TestParseAPIHost(t *testing.T) {
 			wantRestURL: "https://myghe.com/api/v3/",
 		},
 		{
+			name:        "github.localhost (local dotcom dev) routes to api.github.localhost",
+			input:       "http://github.localhost",
+			wantRestURL: "http://api.github.localhost/",
+		},
+		{
+			name:        "subdomain of github.localhost also routes to api.github.localhost",
+			input:       "http://www.github.localhost",
+			wantRestURL: "http://api.github.localhost/",
+		},
+		{
+			name:        "hostname ending in github.localhost but not a subdomain",
+			input:       "http://notgithub.localhost",
+			wantRestURL: "http://notgithub.localhost/api/v3/",
+		},
+		{
 			name:    "missing scheme",
 			input:   "github.com",
 			wantErr: true,


### PR DESCRIPTION
## What

Adds a fourth branch to `parseAPIHost` in `pkg/utils/api.go` for hostnames matching `github.localhost` (or any subdomain of it). It mirrors the dotcom split-host layout — REST at `api.github.localhost`, GraphQL at `api.github.localhost/graphql`, uploads/raw on their own subdomains, oauth at the apex.

## Why

A local dotcom checkout serves its APIs from the same split-host shape as production. But `github.localhost` doesn't match the `github.com` or `*.ghe.com` branches in `parseAPIHost`, so today it falls through to `newGHESHost`, which tries `/api/v3` and `/api/graphql` against the apex and gets 404/422 back.

Hit this while testing the multi_select issue field PR (#2659) against local dotcom — without this patch the MCP server can't talk to the local stack at all without modifying `parseAPIHost` by hand.

## Notes

- Tests cover the new branch and the not-a-subdomain edge case (e.g. `notgithub.localhost` still routes through GHES).
- Only handles `github.localhost` — not bare `localhost:port` style dev setups. Happy to broaden if anyone is using something different.
- Draft because I'd like a sanity check from someone closer to local dev tooling before marking ready.