### PR TITLE
Treat omitted MCP tool arguments as empty object

### DIFF
--- a/pkg/inventory/server_tool.go
+++ b/pkg/inventory/server_tool.go
@@ -133,7 +133,11 @@ func NewServerToolWithContextHandler[In any, Out any](tool mcp.Tool, toolset Too
 		HandlerFunc: func(_ any) mcp.ToolHandler {
 			return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				var arguments In
-				if err := json.Unmarshal(req.Params.Arguments, &arguments); err != nil {
+				args := req.Params.Arguments
+				if len(args) == 0 {
+					args = json.RawMessage(`{}`)
+				}
+				if err := json.Unmarshal(args, &arguments); err != nil {
 					return &mcp.CallToolResult{
 						Content: []mcp.Content{
 							&mcp.TextContent{Text: fmt.Sprintf("invalid arguments: %s", err)},

--- a/pkg/inventory/server_tool_test.go
+++ b/pkg/inventory/server_tool_test.go
@@ -78,3 +78,36 @@ func TestNewServerToolWithContextHandler_ValidArguments_Succeeds(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "success: octocat/hello-world", textContent.Text)
 }
+
+func TestNewServerToolWithContextHandler_EmptyArguments_TreatedAsEmptyObject(t *testing.T) {
+	type expectedArgs struct {
+		Owner string `json:"owner"`
+	}
+
+	tool := NewServerToolWithContextHandler(
+		mcp.Tool{Name: "test_tool"},
+		testToolsetMetadata("test"),
+		func(_ context.Context, _ *mcp.CallToolRequest, args expectedArgs) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: "success: " + args.Owner},
+				},
+			}, nil, nil
+		},
+	)
+
+	handler := tool.HandlerFunc(nil)
+
+	for _, args := range []json.RawMessage{nil, json.RawMessage{}, json.RawMessage(`{}`)} {
+		result, err := handler(context.Background(), &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{
+				Name:      "test_tool",
+				Arguments: args,
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError, "arguments payload %q should be treated as empty object", args)
+	}
+}


### PR DESCRIPTION
## Problem

Zero-parameter MCP tools such as `get_me` fail when a client omits the `arguments` field entirely. Some MCP clients send no `arguments` payload for tools with an empty input schema, which is valid JSON-RPC but breaks server-side unmarshaling.

## Root cause

`NewServerToolWithContextHandler` unmarshals `req.Params.Arguments` directly into the handler argument struct. When the field is missing or empty, `json.Unmarshal` receives nil/empty bytes and returns an error before the tool handler runs.

## Fix

Default nil or empty `Arguments` payloads to `{}` before unmarshaling. This matches the MCP expectation that tools with no required parameters can be invoked without an explicit arguments object.

## Testing

- `go test ./pkg/inventory/...`

Fixes #2587