### PR TITLE
fix(repos): default create_repository to private when visibility omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,7 +1204,7 @@ The following sets of tools are available:
   - `description`: Repository description (string, optional)
   - `name`: Repository name (string, required)
   - `organization`: Organization to create the repository in (omit to create in your personal account) (string, optional)
-  - `private`: Whether repo should be private (boolean, optional)
+  - `private`: Whether the repository should be private. Defaults to true (private) when omitted. (boolean, optional)
 
 - **delete_file** - Delete file
   - **Required OAuth Scopes**: `repo`

--- a/pkg/github/__toolsnaps__/create_repository.snap
+++ b/pkg/github/__toolsnaps__/create_repository.snap
@@ -22,7 +22,8 @@
         "type": "string"
       },
       "private": {
-        "description": "Whether repo should be private",
+        "default": true,
+        "description": "Whether the repository should be private. Defaults to true (private) when omitted.",
         "type": "boolean"
       }
     },

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -600,7 +600,8 @@ func CreateRepository(t translations.TranslationHelperFunc) inventory.ServerTool
 					},
 					"private": {
 						Type:        "boolean",
-						Description: "Whether repo should be private",
+						Description: "Whether the repository should be private. Defaults to true (private) when omitted.",
+						Default:     json.RawMessage("true"),
 					},
 					"autoInit": {
 						Type:        "boolean",
@@ -624,7 +625,7 @@ func CreateRepository(t translations.TranslationHelperFunc) inventory.ServerTool
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
-			private, err := OptionalParam[bool](args, "private")
+			private, err := OptionalBoolParamWithDefault(args, "private", true)
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -2020,7 +2020,28 @@ func Test_CreateRepository(t *testing.T) {
 			expectedRepo: mockRepo,
 		},
 		{
-			name: "successful repository creation with minimal parameters",
+			name: "successful repository creation with minimal parameters defaults to private",
+			mockedClient: NewMockedHTTPClient(
+				WithRequestMatchHandler(
+					EndpointPattern("POST /user/repos"),
+					expectRequestBody(t, map[string]any{
+						"name":        "test-repo",
+						"auto_init":   false,
+						"description": "",
+						"private":     true,
+					}).andThen(
+						mockResponse(t, http.StatusCreated, mockRepo),
+					),
+				),
+			),
+			requestArgs: map[string]any{
+				"name": "test-repo",
+			},
+			expectError:  false,
+			expectedRepo: mockRepo,
+		},
+		{
+			name: "successful public repository creation when private is explicitly false",
 			mockedClient: NewMockedHTTPClient(
 				WithRequestMatchHandler(
 					EndpointPattern("POST /user/repos"),
@@ -2035,7 +2056,8 @@ func Test_CreateRepository(t *testing.T) {
 				),
 			),
 			requestArgs: map[string]any{
-				"name": "test-repo",
+				"name":    "test-repo",
+				"private": false,
 			},
 			expectError:  false,
 			expectedRepo: mockRepo,


### PR DESCRIPTION
## Summary

`create_repository` previously created a **public** repository whenever the `private` parameter was omitted. Because the parameter is optional, agent-driven or automated workflows could unintentionally create public repos, exposing source code, configuration, workflow files, and commit history.

This change makes the secure choice the default: **omitting `private` now creates a private repository**. A public repository is only created when `private` is explicitly set to `false`.

## Changes

- `create_repository` now defaults `private` to `true` when the parameter is omitted (via `OptionalBoolParamWithDefault`).
- Updated the `private` field description and schema `default` so the behavior is explicit to callers.
- Updated the tool snapshot and regenerated docs (README).
- Tests:
  - Minimal-parameters case now asserts the repo is created private.
  - Added a case asserting `private: false` still creates a public repo.

## Behavior

| `private` value | Result |
| --- | --- |
| omitted | private (new default) |
| `true` | private |
| `false` | public |

## Verification

- `script/lint` — 0 issues
- `go test -race ./...` — all passing
- `script/generate-docs` — README updated