### PR TITLE
Bump Go toolchain to 1.26.4

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ go test ./pkg/github -run TestGetMe
 
 - **go.mod / go.sum:** Go module dependencies (Go 1.24.0+)
 - **.golangci.yml:** Linter configuration (v2 format, ~15 linters enabled)
-- **Dockerfile:** Multi-stage build (golang:1.25.8-alpine → distroless)
+- **Dockerfile:** Multi-stage build (golang:1.26.4-alpine → distroless)
 - **server.json:** MCP server metadata for registry
 - **.goreleaser.yaml:** Release automation config
 - **.gitignore:** Excludes bin/, dist/, vendor/, *.DS_Store, github-mcp-server binary

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: ./.github/actions/build-ui
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,14 @@ linters:
           - revive
         text: "var-naming: avoid package names that conflict with Go standard library package names"
   settings:
+    modernize:
+      # The newexpr modernizer rewrites pointer-helpers such as github.Ptr(x)
+      # into the Go 1.26 new(expr) builtin. Adopting it touches ~1.2k call sites
+      # across the codebase, which is out of scope for a toolchain bump. Disable
+      # it here so the rest of the modernize suite stays active; adopting
+      # new(expr) can be done as a separate, focused change.
+      disable:
+        - newexpr
     staticcheck:
       checks:
         - "all"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ui/ ./ui/
 RUN mkdir -p ./pkg/github/ui_dist && \
     cd ui && npm run build
 
-FROM golang:1.25.11-alpine@sha256:8d95af53d0d58e1759ddb4028285d9b1239067e4fbf4f544618cad0f60fbc354 AS build
+FROM golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS build
 ARG VERSION="dev"
 
 # Set the working directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/github-mcp-server
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-chi/chi/v5 v5.3.0


### PR DESCRIPTION
## Summary

Moves the project from the Go 1.25 line to the latest stable **Go 1.26.4**. This is a deliberate minor-version bump, so it gets its own PR with full CI rather than an admin/digest-only update.

## Pins changed

| File | Before | After |
|------|--------|-------|
| `go.mod` | `go 1.25.0` | `go 1.26.0` (language floor) |
| `Dockerfile` | `golang:1.25.11-alpine@sha256:8d95af53…` | `golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14` |
| `.github/workflows/lint.yml` | `go-version: '1.25'` | `go-version: '1.26'` |
| `.github/copilot-instructions.md` | `golang:1.25.8-alpine` reference | `golang:1.26.4-alpine` |
| `.golangci.yml` | — | disable only the `modernize` `newexpr` analyzer (see below) |

Notes:
- **No `toolchain` directive** was added — `go mod tidy` did not introduce one.
- The Docker digest is the real **index digest** (resolved via `docker buildx imagetools inspect golang:1.26.4-alpine`), verified by pulling it and running `go version` → `go1.26.4`.
- **Most CI workflows follow `go-version-file: go.mod`** (`go.yml`, `docs-check.yml`, `goreleaser.yml`, `license-check.yml`, `mcp-diff.yml`), so they pick up 1.26 automatically. Only `lint.yml` pinned a literal version, now updated. `registry-releaser.yml` uses `go-version: "stable"` and `code-scanning.yml` resolves from CodeQL config — both unaffected.

## New Go 1.26 lint finding — and why it's scoped out

Bumping `go.mod` to 1.26 enables the `modernize` `newexpr` modernizer (the new `new(expr)` builtin). golangci-lint's `max-same-issues: 3` made it *look* like only 11 findings, but it actually flags **~1,176 `github.Ptr(...)` → `new(...)` rewrites across 33 files**. That's a sweeping, unrelated refactor — out of scope for a toolchain bump.

Rather than churn the whole codebase or blanket-disable a linter, I disabled **only** the `newexpr` analyzer in `.golangci.yml` (all other `modernize` checks stay active). Adopting `new(expr)` can be done later as a separate, focused change. **Flagging for maintainer review** in case you'd prefer the wholesale adoption instead.

No other new `go vet` / staticcheck / golangci-lint findings appeared.

## Validation

- `go mod tidy` — clean, no toolchain directive added
- `go build ./...` — ✅
- `script/lint` (gofmt + golangci-lint v2.9) — ✅ `0 issues`
- `script/test` (`go test -race ./...`) — ✅ all packages pass
- `script/generate-docs` — README.md already current (no change). Two unrelated docs files (`docs/feature-flags.md`, `docs/insiders-features.md`) showed pre-existing drift unrelated to this bump and were intentionally left untouched to keep the PR focused.
- Docker base image digest pulled and verified as `go1.26.4`.

Please let full CI validate — **do not force-merge**.