### PR TITLE
fix: add DestructiveHint and OpenWorldHint to label_write annotations

### DIFF
--- a/pkg/github/__toolsnaps__/label_write.snap
+++ b/pkg/github/__toolsnaps__/label_write.snap
@@ -1,6 +1,8 @@
 {
   "annotations": {
+    "destructiveHint": true,
     "idempotentHint": false,
+    "openWorldHint": true,
     "readOnlyHint": false,
     "title": "Write operations on repository labels"
   },

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -226,8 +226,10 @@ func LabelWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "label_write",
 			Description: t("TOOL_LABEL_WRITE_DESCRIPTION", "Perform write operations on repository labels. To set labels on issues, use the 'update_issue' tool."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_LABEL_WRITE_TITLE", "Write operations on repository labels"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_LABEL_WRITE_TITLE", "Write operations on repository labels"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
+				OpenWorldHint:   jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -247,6 +247,8 @@ func TestWriteLabel(t *testing.T) {
 	assert.Equal(t, "label_write", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.False(t, tool.Annotations.ReadOnlyHint, "label_write tool should not be read-only")
+	require.NotNil(t, tool.Annotations.DestructiveHint, "label_write tool should have DestructiveHint set")
+	assert.True(t, *tool.Annotations.DestructiveHint, "label_write tool should be marked as destructive")
 
 	tests := []struct {
 		name               string


### PR DESCRIPTION
Fixes #2723

## Problem

The `label_write` tool supports a `delete` method that permanently removes a label and all its associations from every issue/PR in the repository. However, its annotations only set `ReadOnlyHint: false` -- it does not set `DestructiveHint: true` or `OpenWorldHint: true`. MCP clients receive no destructive-operation signal for what is arguably the most destructive label operation available.

## Fix

Add `DestructiveHint: jsonschema.Ptr(true)` and `OpenWorldHint: jsonschema.Ptr(true)` to the `LabelWrite` tool annotations, matching the pattern used by other destructive tools in the codebase:

- `actions_run_trigger` (actions.go)
- `projects_write` (projects.go)
- `discussion_comment_write` (discussions.go)
- `remove_sub_issue` (issues_granular.go)

## Changes

- `pkg/github/labels.go`: Add annotation fields to LabelWrite tool definition
- `pkg/github/labels_test.go`: Add DestructiveHint assertion in TestWriteLabel
- `pkg/github/__toolsnaps__/label_write.snap`: Update snapshot to match