### PR TITLE
Fix delete:true on issue fields by calling deleteIssueFieldValue mutation

### DIFF
--- a/pkg/github/helper_test.go
+++ b/pkg/github/helper_test.go
@@ -66,6 +66,7 @@ const (
 	PostReposIssuesSubIssuesByOwnerByRepoByIssueNumber          = "POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues"
 	DeleteReposIssuesSubIssueByOwnerByRepoByIssueNumber         = "DELETE /repos/{owner}/{repo}/issues/{issue_number}/sub_issue"
 	PatchReposIssuesSubIssuesPriorityByOwnerByRepoByIssueNumber = "PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority"
+	DeleteReposIssuesIssueFieldValueByOwnerByRepoByIssueNumber  = "DELETE /repos/{owner}/{repo}/issues/{issue_number}/issue-field-values/{issue_field_id}"
 
 	// Pull request endpoints
 	GetReposPullsByOwnerByRepo                                = "GET /repos/{owner}/{repo}/pulls"

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -2179,6 +2179,17 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 		issueRequest.Type = github.Ptr(issueType)
 	}
 
+	// fallbackDeleteFieldIDs holds field IDs we need to clear via the dedicated
+	// REST DELETE endpoint after the PATCH lands. This is the omitempty-trap
+	// fallback: when the merged list is empty AND we have deletions to make,
+	// `go-github`'s `omitempty` tag on IssueRequest.IssueFieldValues strips the
+	// empty slice from the JSON body, the dotcom REST handler's top-level
+	// `if data.include?(ISSUE_FIELD_VALUES)` guard short-circuits, and nothing
+	// gets cleared. When the merged list is non-empty the PATCH's set semantics
+	// handle the deletes implicitly (current - new), so no DELETE follow-up is
+	// needed in that path.
+	var fallbackDeleteFieldIDs []int64
+
 	if len(issueFieldValues) > 0 || len(fieldIDsToDelete) > 0 {
 		// The REST update endpoint uses "set" semantics — it overwrites all existing
 		// field values with whatever is sent. Fetch the current values first, merge in
@@ -2201,7 +2212,15 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 			}
 			merged = kept
 		}
-		issueRequest.IssueFieldValues = merged
+		if len(merged) == 0 && len(fieldIDsToDelete) > 0 {
+			// Omitempty trap: skip the IssueFieldValues assignment so we don't
+			// rely on a value that's about to be stripped from the JSON anyway,
+			// and clear each field via the dedicated DELETE endpoint after the
+			// PATCH lands.
+			fallbackDeleteFieldIDs = fieldIDsToDelete
+		} else {
+			issueRequest.IssueFieldValues = merged
+		}
 	}
 
 	updatedIssue, resp, err := client.Issues.Edit(ctx, owner, repo, issueNumber, issueRequest)
@@ -2220,6 +2239,26 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 			return nil, fmt.Errorf("failed to read response body: %w", err)
 		}
 		return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to update issue", resp, body), nil
+	}
+
+	// Clear any fields whose deletion the PATCH couldn't carry. See the
+	// fallbackDeleteFieldIDs declaration above for the omitempty trap details.
+	// We hit the dedicated DELETE endpoint per field — it's idempotent, takes
+	// the integer field ID, and the URL is the standard `/repos/{owner}/{repo}`
+	// pattern (no need for the numeric repository ID despite what the internal
+	// route in app/api/issue_field_values.rb suggests; the public API rewrites
+	// to it).
+	for _, fieldID := range fallbackDeleteFieldIDs {
+		path := fmt.Sprintf("repos/%s/%s/issues/%d/issue-field-values/%d", owner, repo, issueNumber, fieldID)
+		req, err := client.NewRequest(ctx, http.MethodDelete, path, nil)
+		if err != nil {
+			return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to build DELETE request for issue field value", nil, err), nil
+		}
+		delResp, err := client.Do(req, nil)
+		if err != nil {
+			return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to clear issue field value", delResp, err), nil
+		}
+		_ = delResp.Body.Close()
 	}
 
 	// Use GraphQL API for state updates

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -2179,21 +2179,13 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 		issueRequest.Type = github.Ptr(issueType)
 	}
 
-	// fallbackDeleteFieldIDs holds field IDs we need to clear via the dedicated
-	// REST DELETE endpoint after the PATCH lands. This is the omitempty-trap
-	// fallback: when the merged list is empty AND we have deletions to make,
-	// `go-github`'s `omitempty` tag on IssueRequest.IssueFieldValues strips the
-	// empty slice from the JSON body, the dotcom REST handler's top-level
-	// `if data.include?(ISSUE_FIELD_VALUES)` guard short-circuits, and nothing
-	// gets cleared. When the merged list is non-empty the PATCH's set semantics
-	// handle the deletes implicitly (current - new), so no DELETE follow-up is
-	// needed in that path.
+	// Field IDs to clear via DELETE after the PATCH. See the post-PATCH loop
+	// for why we can't just rely on REST set semantics.
 	var fallbackDeleteFieldIDs []int64
 
 	if len(issueFieldValues) > 0 || len(fieldIDsToDelete) > 0 {
-		// The REST update endpoint uses "set" semantics — it overwrites all existing
-		// field values with whatever is sent. Fetch the current values first, merge in
-		// the new values, then remove any explicitly deleted fields.
+		// REST PATCH uses set semantics, so fetch existing values, merge in
+		// the new ones, then drop anything explicitly deleted.
 		existing, err := fetchExistingIssueFieldValues(ctx, gqlClient, owner, repo, issueNumber)
 		if err != nil {
 			return ghErrors.NewGitHubGraphQLErrorResponse(ctx, "failed to fetch existing issue field values", err), nil
@@ -2213,14 +2205,9 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 			merged = kept
 		}
 		if len(merged) == 0 && len(fieldIDsToDelete) > 0 {
-			// Omitempty trap: skip the IssueFieldValues assignment so we don't
-			// rely on a value that's about to be stripped from the JSON anyway,
-			// and clear each field via the dedicated DELETE endpoint after the
-			// PATCH lands. Only queue a DELETE for fields actually present on
-			// the issue — the dotcom DELETE endpoint returns 404 for absent
-			// values, and we want to preserve the pre-fix behaviour of treating
-			// "delete a field that isn't set" as a silent no-op (which is what
-			// happens when the user idempotently re-runs the same call).
+			// Only queue DELETEs for fields actually present — the endpoint
+			// returns 404 otherwise, and "delete a field that isn't set" should
+			// stay a no-op (callers often invoke delete:true idempotently).
 			existingIDs := make(map[int64]bool, len(existing))
 			for _, e := range existing {
 				existingIDs[e.FieldID] = true
@@ -2253,17 +2240,11 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 		return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to update issue", resp, body), nil
 	}
 
-	// Clear any fields whose deletion the PATCH couldn't carry. See the
-	// fallbackDeleteFieldIDs declaration above for the omitempty trap details.
-	// We hit the dedicated DELETE endpoint per field — it takes the integer
-	// field ID, and the URL is the standard `/repos/{owner}/{repo}` pattern.
-	//
-	// Per-field errors don't short-circuit: each DELETE is attempted, and any
-	// failures are aggregated into a single error response that names the
-	// successful and failed field IDs. This avoids leaving the caller blind
-	// to which deletions landed when one of several fails (e.g. transient
-	// 5xx on field 2 of 3 — without aggregation, field 1 is already gone and
-	// field 3 was never attempted, but the caller only sees a generic error).
+	// Per-field DELETE fallback. The PATCH can't clear field values when the
+	// merged set is empty — go-github's `omitempty` strips the empty slice
+	// and the dotcom REST handler skips its issue_field_values block when the
+	// key is absent. Errors are aggregated (not short-circuited) so callers
+	// can see which fields succeeded and which need retry.
 	if len(fallbackDeleteFieldIDs) > 0 {
 		var failedIDs, succeededIDs []int64
 		var firstFailureErr error

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -2216,8 +2216,20 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 			// Omitempty trap: skip the IssueFieldValues assignment so we don't
 			// rely on a value that's about to be stripped from the JSON anyway,
 			// and clear each field via the dedicated DELETE endpoint after the
-			// PATCH lands.
-			fallbackDeleteFieldIDs = fieldIDsToDelete
+			// PATCH lands. Only queue a DELETE for fields actually present on
+			// the issue — the dotcom DELETE endpoint returns 404 for absent
+			// values, and we want to preserve the pre-fix behaviour of treating
+			// "delete a field that isn't set" as a silent no-op (which is what
+			// happens when the user idempotently re-runs the same call).
+			existingIDs := make(map[int64]bool, len(existing))
+			for _, e := range existing {
+				existingIDs[e.FieldID] = true
+			}
+			for _, id := range fieldIDsToDelete {
+				if existingIDs[id] {
+					fallbackDeleteFieldIDs = append(fallbackDeleteFieldIDs, id)
+				}
+			}
 		} else {
 			issueRequest.IssueFieldValues = merged
 		}
@@ -2243,22 +2255,45 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 
 	// Clear any fields whose deletion the PATCH couldn't carry. See the
 	// fallbackDeleteFieldIDs declaration above for the omitempty trap details.
-	// We hit the dedicated DELETE endpoint per field — it's idempotent, takes
-	// the integer field ID, and the URL is the standard `/repos/{owner}/{repo}`
-	// pattern (no need for the numeric repository ID despite what the internal
-	// route in app/api/issue_field_values.rb suggests; the public API rewrites
-	// to it).
-	for _, fieldID := range fallbackDeleteFieldIDs {
-		path := fmt.Sprintf("repos/%s/%s/issues/%d/issue-field-values/%d", owner, repo, issueNumber, fieldID)
-		req, err := client.NewRequest(ctx, http.MethodDelete, path, nil)
-		if err != nil {
-			return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to build DELETE request for issue field value", nil, err), nil
+	// We hit the dedicated DELETE endpoint per field — it takes the integer
+	// field ID, and the URL is the standard `/repos/{owner}/{repo}` pattern.
+	//
+	// Per-field errors don't short-circuit: each DELETE is attempted, and any
+	// failures are aggregated into a single error response that names the
+	// successful and failed field IDs. This avoids leaving the caller blind
+	// to which deletions landed when one of several fails (e.g. transient
+	// 5xx on field 2 of 3 — without aggregation, field 1 is already gone and
+	// field 3 was never attempted, but the caller only sees a generic error).
+	if len(fallbackDeleteFieldIDs) > 0 {
+		var failedIDs, succeededIDs []int64
+		var firstFailureErr error
+		var firstFailureResp *github.Response
+		for _, fieldID := range fallbackDeleteFieldIDs {
+			path := fmt.Sprintf("repos/%s/%s/issues/%d/issue-field-values/%d", owner, repo, issueNumber, fieldID)
+			req, err := client.NewRequest(ctx, http.MethodDelete, path, nil)
+			if err != nil {
+				failedIDs = append(failedIDs, fieldID)
+				if firstFailureErr == nil {
+					firstFailureErr = err
+				}
+				continue
+			}
+			delResp, err := client.Do(req, nil)
+			if err != nil {
+				failedIDs = append(failedIDs, fieldID)
+				if firstFailureErr == nil {
+					firstFailureErr = err
+					firstFailureResp = delResp
+				}
+				continue
+			}
+			succeededIDs = append(succeededIDs, fieldID)
+			_ = delResp.Body.Close()
 		}
-		delResp, err := client.Do(req, nil)
-		if err != nil {
-			return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to clear issue field value", delResp, err), nil
+		if len(failedIDs) > 0 {
+			msg := fmt.Sprintf("failed to clear issue field values: failed=%v, cleared=%v", failedIDs, succeededIDs)
+			return ghErrors.NewGitHubAPIErrorResponse(ctx, msg, firstFailureResp, firstFailureErr), nil
 		}
-		_ = delResp.Body.Close()
 	}
 
 	// Use GraphQL API for state updates

--- a/pkg/github/issues_delete_test.go
+++ b/pkg/github/issues_delete_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -245,4 +246,214 @@ func Test_UpdateIssue_DeleteOneOfManyUsesSetSemantics(t *testing.T) {
 	defer mu.Unlock()
 	require.Empty(t, deletePaths,
 		"no DELETE call should fire when the kept set is non-empty — the PATCH's set semantics clear the deleted field on the server side")
+}
+
+// Test_UpdateIssue_DeleteAbsentFieldIsNoOp verifies that asking to delete a
+// field that isn't currently set on the issue does not fire a DELETE request
+// to the dedicated endpoint (which would 404). This preserves the pre-fix
+// behaviour of treating "delete a field that isn't set" as a silent no-op —
+// important because callers often use delete:true idempotently ("ensure
+// field X is cleared"), and the second invocation should succeed not error.
+func Test_UpdateIssue_DeleteAbsentFieldIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	mockIssue := &gogithub.Issue{
+		Number:  gogithub.Ptr(42),
+		Title:   gogithub.Ptr("Test issue"),
+		State:   gogithub.Ptr("open"),
+		HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/42"),
+	}
+
+	var (
+		mu                sync.Mutex
+		capturedPatchBody []byte
+		deletePaths       []string
+	)
+
+	restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+		PatchReposIssuesByOwnerByRepoByIssueNumber: func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			capturedPatchBody = body
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockIssue)
+		},
+		DeleteReposIssuesIssueFieldValueByOwnerByRepoByIssueNumber: func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			deletePaths = append(deletePaths, r.URL.Path)
+			mu.Unlock()
+			// Fail loudly: if we get here, the fix is wrong.
+			w.WriteHeader(http.StatusNotFound)
+		},
+	}))
+
+	// Issue has no field values at all.
+	existingFieldsResponse := githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"issue": map[string]any{
+				"issueFieldValues": map[string]any{
+					"nodes": []any{},
+				},
+			},
+		},
+	})
+
+	gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(
+		githubv4mock.NewQueryMatcher(
+			struct {
+				Repository struct {
+					Issue struct {
+						IssueFieldValues struct {
+							Nodes []IssueFieldValueFragment
+						} `graphql:"issueFieldValues(first: 25)"`
+					} `graphql:"issue(number: $number)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}{},
+			map[string]any{
+				"owner":  githubv4.String("owner"),
+				"repo":   githubv4.String("repo"),
+				"number": githubv4.Int(42),
+			},
+			existingFieldsResponse,
+		),
+	))
+
+	result, err := UpdateIssue(
+		context.Background(),
+		restClient,
+		gqlClient,
+		"owner", "repo", 42,
+		"", "", nil, nil, 0, "",
+		nil,
+		[]int64{101}, // ask to delete a field that isn't set
+		"", "", 0,
+	)
+	require.NoError(t, err)
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %s", getTextResult(t, result).Text)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotContains(t, string(capturedPatchBody), "issue_field_values",
+		"PATCH body must not carry issue_field_values when nothing changed")
+	require.Empty(t, deletePaths,
+		"no DELETE call should fire for a field that isn't present on the issue — preserves the pre-fix silent-no-op behaviour and avoids a guaranteed 404")
+}
+
+// Test_UpdateIssue_DeleteFallbackContinuesOnPartialFailure verifies that when
+// one DELETE in the fallback loop fails, the remaining DELETEs still fire and
+// the aggregated error names the failed and succeeded field IDs. The pre-fix
+// loop short-circuited on the first failure, which left the caller blind to
+// which deletions had landed.
+func Test_UpdateIssue_DeleteFallbackContinuesOnPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	mockIssue := &gogithub.Issue{
+		Number:  gogithub.Ptr(42),
+		Title:   gogithub.Ptr("Test issue"),
+		State:   gogithub.Ptr("open"),
+		HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/42"),
+	}
+
+	var (
+		mu          sync.Mutex
+		deletePaths []string
+	)
+
+	restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+		PatchReposIssuesByOwnerByRepoByIssueNumber: func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockIssue)
+		},
+		DeleteReposIssuesIssueFieldValueByOwnerByRepoByIssueNumber: func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			deletePaths = append(deletePaths, r.URL.Path)
+			mu.Unlock()
+			// Field 202 returns 500; fields 101 and 303 succeed. We expect
+			// all three calls to fire even though the middle one errors, and
+			// the final tool result must mention 202 as failed and 101/303
+			// as cleared.
+			if strings.HasSuffix(r.URL.Path, "/202") {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"simulated failure"}`))
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}))
+
+	existingFieldsResponse := githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"issue": map[string]any{
+				"issueFieldValues": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"__typename": "IssueFieldSingleSelectValue",
+							"field":      map[string]any{"fullDatabaseId": "101", "name": "Priority"},
+							"value":      "P1",
+						},
+						map[string]any{
+							"__typename": "IssueFieldSingleSelectValue",
+							"field":      map[string]any{"fullDatabaseId": "202", "name": "Visibility"},
+							"value":      "High",
+						},
+						map[string]any{
+							"__typename": "IssueFieldSingleSelectValue",
+							"field":      map[string]any{"fullDatabaseId": "303", "name": "Impact"},
+							"value":      "Critical",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(
+		githubv4mock.NewQueryMatcher(
+			struct {
+				Repository struct {
+					Issue struct {
+						IssueFieldValues struct {
+							Nodes []IssueFieldValueFragment
+						} `graphql:"issueFieldValues(first: 25)"`
+					} `graphql:"issue(number: $number)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}{},
+			map[string]any{
+				"owner":  githubv4.String("owner"),
+				"repo":   githubv4.String("repo"),
+				"number": githubv4.Int(42),
+			},
+			existingFieldsResponse,
+		),
+	))
+
+	result, err := UpdateIssue(
+		context.Background(),
+		restClient,
+		gqlClient,
+		"owner", "repo", 42,
+		"", "", nil, nil, 0, "",
+		nil,
+		[]int64{101, 202, 303},
+		"", "", 0,
+	)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result because field 202 failed")
+
+	mu.Lock()
+	defer mu.Unlock()
+	// All three DELETEs must have fired — the middle failure must not short-circuit the third.
+	require.Len(t, deletePaths, 3,
+		"all three DELETE calls should fire even though one fails; got paths: %v", deletePaths)
+
+	resultText := getTextResult(t, result).Text
+	require.Contains(t, resultText, "failed=[202]",
+		"error must name the failed field ID so the caller can retry it; got: %s", resultText)
+	require.Contains(t, resultText, "cleared=[101 303]",
+		"error must name the cleared field IDs so the caller knows what's already done; got: %s", resultText)
 }

--- a/pkg/github/issues_delete_test.go
+++ b/pkg/github/issues_delete_test.go
@@ -16,13 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test_IssueRequest_EmptyFieldValues_OmittedByJSON pins the omitempty behaviour
-// that motivates the DELETE-endpoint fallback in UpdateIssue. If go-github's
-// IssueRequest ever drops the `omitempty` tag from `issue_field_values`, this
-// test will fail — at which point the fallback could potentially be revisited.
-// Until then, an empty `[]*IssueRequestFieldValue{}` is serialised as nothing
-// at all, so the REST PATCH alone can never clear a field's last value via
-// the set-semantics path.
+// Test_IssueRequest_EmptyFieldValues_OmittedByJSON pins the omitempty
+// behaviour that makes the DELETE fallback necessary. If go-github ever drops
+// the tag, the REST PATCH alone could clear field values and this test would
+// fail to remind us.
 func Test_IssueRequest_EmptyFieldValues_OmittedByJSON(t *testing.T) {
 	t.Parallel()
 
@@ -39,19 +36,10 @@ func Test_IssueRequest_EmptyFieldValues_OmittedByJSON(t *testing.T) {
 		"sanity check: other fields still serialise")
 }
 
-// Test_UpdateIssue_DeleteLastFieldValueCallsDeleteEndpoint: regression test for
-// the delete:true bug. When the kept set after merge + filter ends up empty
-// (e.g. deleting the only remaining field value), the PATCH alone cannot carry
-// the deletion intent because go-github strips the empty issue_field_values
-// slice via omitempty. UpdateIssue follows up with a per-field DELETE to the
-// dedicated `/repos/{owner}/{repo}/issues/{number}/issue-field-values/{id}`
-// endpoint.
-//
-// Asserts both halves:
-//
-//   - the PATCH body does NOT carry an `issue_field_values` key (we don't want
-//     to double-clear or rely on a value omitempty is about to strip)
-//   - a DELETE for the field ID fires after the PATCH
+// Test_UpdateIssue_DeleteLastFieldValueCallsDeleteEndpoint covers the bug fix:
+// when the kept set ends up empty, the PATCH alone can't clear the field
+// (omitempty strips the empty slice), so UpdateIssue follows up with a DELETE
+// to the dedicated endpoint.
 func Test_UpdateIssue_DeleteLastFieldValueCallsDeleteEndpoint(t *testing.T) {
 	t.Parallel()
 
@@ -86,9 +74,8 @@ func Test_UpdateIssue_DeleteLastFieldValueCallsDeleteEndpoint(t *testing.T) {
 		},
 	}))
 
-	// Existing field values for the merge step. Returning only the field about
-	// to be deleted is the worst case: the kept list ends up empty and the
-	// fallback DELETE is the only thing that can clear it.
+	// Existing field values for the merge step. Returning the field we're
+	// about to delete makes the kept list empty, triggering the fallback DELETE.
 	existingFieldsResponse := githubv4mock.DataResponse(map[string]any{
 		"repository": map[string]any{
 			"issue": map[string]any{
@@ -151,10 +138,9 @@ func Test_UpdateIssue_DeleteLastFieldValueCallsDeleteEndpoint(t *testing.T) {
 		"expected exactly one DELETE call to the dedicated endpoint for field id 101")
 }
 
-// Test_UpdateIssue_DeleteOneOfManyUsesSetSemantics verifies that when the kept
-// set after merge + filter is non-empty (deleting 1 of N existing fields), the
-// PATCH carries the kept fields and the dotcom REST handler's set semantics do
-// the deletion implicitly — no fallback DELETE call is needed.
+// Test_UpdateIssue_DeleteOneOfManyUsesSetSemantics: when the kept set is
+// non-empty, set semantics handle the deletion implicitly via the PATCH — no
+// DELETE follow-up needed.
 func Test_UpdateIssue_DeleteOneOfManyUsesSetSemantics(t *testing.T) {
 	t.Parallel()
 
@@ -248,12 +234,10 @@ func Test_UpdateIssue_DeleteOneOfManyUsesSetSemantics(t *testing.T) {
 		"no DELETE call should fire when the kept set is non-empty — the PATCH's set semantics clear the deleted field on the server side")
 }
 
-// Test_UpdateIssue_DeleteAbsentFieldIsNoOp verifies that asking to delete a
-// field that isn't currently set on the issue does not fire a DELETE request
-// to the dedicated endpoint (which would 404). This preserves the pre-fix
-// behaviour of treating "delete a field that isn't set" as a silent no-op —
-// important because callers often use delete:true idempotently ("ensure
-// field X is cleared"), and the second invocation should succeed not error.
+// Test_UpdateIssue_DeleteAbsentFieldIsNoOp: deleting a field that isn't set
+// must not fire a DELETE (the endpoint would 404), preserving the pre-fix
+// silent-no-op behaviour so idempotent delete:true callers don't break on
+// retry.
 func Test_UpdateIssue_DeleteAbsentFieldIsNoOp(t *testing.T) {
 	t.Parallel()
 
@@ -343,11 +327,9 @@ func Test_UpdateIssue_DeleteAbsentFieldIsNoOp(t *testing.T) {
 		"no DELETE call should fire for a field that isn't present on the issue — preserves the pre-fix silent-no-op behaviour and avoids a guaranteed 404")
 }
 
-// Test_UpdateIssue_DeleteFallbackContinuesOnPartialFailure verifies that when
-// one DELETE in the fallback loop fails, the remaining DELETEs still fire and
-// the aggregated error names the failed and succeeded field IDs. The pre-fix
-// loop short-circuited on the first failure, which left the caller blind to
-// which deletions had landed.
+// Test_UpdateIssue_DeleteFallbackContinuesOnPartialFailure: a failing DELETE
+// must not short-circuit subsequent ones, and the error must name which IDs
+// succeeded and which failed so callers can retry the right ones.
 func Test_UpdateIssue_DeleteFallbackContinuesOnPartialFailure(t *testing.T) {
 	t.Parallel()
 
@@ -373,10 +355,8 @@ func Test_UpdateIssue_DeleteFallbackContinuesOnPartialFailure(t *testing.T) {
 			mu.Lock()
 			deletePaths = append(deletePaths, r.URL.Path)
 			mu.Unlock()
-			// Field 202 returns 500; fields 101 and 303 succeed. We expect
-			// all three calls to fire even though the middle one errors, and
-			// the final tool result must mention 202 as failed and 101/303
-			// as cleared.
+			// Field 202 fails; 101 and 303 succeed. All three should fire and
+			// the error must name 202 as failed and 101/303 as cleared.
 			if strings.HasSuffix(r.URL.Path, "/202") {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte(`{"message":"simulated failure"}`))

--- a/pkg/github/issues_delete_test.go
+++ b/pkg/github/issues_delete_test.go
@@ -1,0 +1,248 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/github/github-mcp-server/internal/githubv4mock"
+	gogithub "github.com/google/go-github/v87/github"
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_IssueRequest_EmptyFieldValues_OmittedByJSON pins the omitempty behaviour
+// that motivates the DELETE-endpoint fallback in UpdateIssue. If go-github's
+// IssueRequest ever drops the `omitempty` tag from `issue_field_values`, this
+// test will fail — at which point the fallback could potentially be revisited.
+// Until then, an empty `[]*IssueRequestFieldValue{}` is serialised as nothing
+// at all, so the REST PATCH alone can never clear a field's last value via
+// the set-semantics path.
+func Test_IssueRequest_EmptyFieldValues_OmittedByJSON(t *testing.T) {
+	t.Parallel()
+
+	req := &gogithub.IssueRequest{
+		Title:            gogithub.Ptr("still here"),
+		IssueFieldValues: []*gogithub.IssueRequestFieldValue{},
+	}
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(body), "issue_field_values",
+		"empty IssueFieldValues should be dropped by omitempty — this is why the REST PATCH alone can't clear field values when the merged list ends up empty, and why we fall back to the dedicated DELETE endpoint")
+	assert.Contains(t, string(body), `"title":"still here"`,
+		"sanity check: other fields still serialise")
+}
+
+// Test_UpdateIssue_DeleteLastFieldValueCallsDeleteEndpoint: regression test for
+// the delete:true bug. When the kept set after merge + filter ends up empty
+// (e.g. deleting the only remaining field value), the PATCH alone cannot carry
+// the deletion intent because go-github strips the empty issue_field_values
+// slice via omitempty. UpdateIssue follows up with a per-field DELETE to the
+// dedicated `/repos/{owner}/{repo}/issues/{number}/issue-field-values/{id}`
+// endpoint.
+//
+// Asserts both halves:
+//
+//   - the PATCH body does NOT carry an `issue_field_values` key (we don't want
+//     to double-clear or rely on a value omitempty is about to strip)
+//   - a DELETE for the field ID fires after the PATCH
+func Test_UpdateIssue_DeleteLastFieldValueCallsDeleteEndpoint(t *testing.T) {
+	t.Parallel()
+
+	mockIssue := &gogithub.Issue{
+		Number:  gogithub.Ptr(42),
+		Title:   gogithub.Ptr("Test issue"),
+		State:   gogithub.Ptr("open"),
+		HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/42"),
+	}
+
+	var (
+		mu                sync.Mutex
+		capturedPatchBody []byte
+		deletePaths       []string
+	)
+
+	restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+		PatchReposIssuesByOwnerByRepoByIssueNumber: func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			capturedPatchBody = body
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockIssue)
+		},
+		DeleteReposIssuesIssueFieldValueByOwnerByRepoByIssueNumber: func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			deletePaths = append(deletePaths, r.URL.Path)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}))
+
+	// Existing field values for the merge step. Returning only the field about
+	// to be deleted is the worst case: the kept list ends up empty and the
+	// fallback DELETE is the only thing that can clear it.
+	existingFieldsResponse := githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"issue": map[string]any{
+				"issueFieldValues": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"__typename": "IssueFieldSingleSelectValue",
+							"field": map[string]any{
+								"fullDatabaseId": "101",
+								"name":           "Priority",
+							},
+							"value": "P1",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(
+		githubv4mock.NewQueryMatcher(
+			struct {
+				Repository struct {
+					Issue struct {
+						IssueFieldValues struct {
+							Nodes []IssueFieldValueFragment
+						} `graphql:"issueFieldValues(first: 25)"`
+					} `graphql:"issue(number: $number)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}{},
+			map[string]any{
+				"owner":  githubv4.String("owner"),
+				"repo":   githubv4.String("repo"),
+				"number": githubv4.Int(42),
+			},
+			existingFieldsResponse,
+		),
+	))
+
+	result, err := UpdateIssue(
+		context.Background(),
+		restClient,
+		gqlClient,
+		"owner", "repo", 42,
+		"", "", nil, nil, 0, "",
+		nil,
+		[]int64{101},
+		"", "", 0,
+	)
+	require.NoError(t, err)
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %s", getTextResult(t, result).Text)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotContains(t, string(capturedPatchBody), "issue_field_values",
+		"REST PATCH body must not carry issue_field_values when the kept set is empty (PATCH body was: %s)", string(capturedPatchBody))
+	require.Equal(t, []string{"/repos/owner/repo/issues/42/issue-field-values/101"}, deletePaths,
+		"expected exactly one DELETE call to the dedicated endpoint for field id 101")
+}
+
+// Test_UpdateIssue_DeleteOneOfManyUsesSetSemantics verifies that when the kept
+// set after merge + filter is non-empty (deleting 1 of N existing fields), the
+// PATCH carries the kept fields and the dotcom REST handler's set semantics do
+// the deletion implicitly — no fallback DELETE call is needed.
+func Test_UpdateIssue_DeleteOneOfManyUsesSetSemantics(t *testing.T) {
+	t.Parallel()
+
+	mockIssue := &gogithub.Issue{
+		Number:  gogithub.Ptr(42),
+		Title:   gogithub.Ptr("Test issue"),
+		State:   gogithub.Ptr("open"),
+		HTMLURL: gogithub.Ptr("https://github.com/owner/repo/issues/42"),
+	}
+
+	var (
+		mu          sync.Mutex
+		deletePaths []string
+	)
+
+	restClient := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+		PatchReposIssuesByOwnerByRepoByIssueNumber: expectRequestBody(t, map[string]any{
+			"issue_field_values": []any{
+				map[string]any{"field_id": float64(202), "value": "High"},
+			},
+		}).andThen(
+			mockResponse(t, http.StatusOK, mockIssue),
+		),
+		DeleteReposIssuesIssueFieldValueByOwnerByRepoByIssueNumber: func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			deletePaths = append(deletePaths, r.URL.Path)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}))
+
+	existingFieldsResponse := githubv4mock.DataResponse(map[string]any{
+		"repository": map[string]any{
+			"issue": map[string]any{
+				"issueFieldValues": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"__typename": "IssueFieldSingleSelectValue",
+							"field":      map[string]any{"fullDatabaseId": "101", "name": "Priority"},
+							"value":      "P1",
+						},
+						map[string]any{
+							"__typename": "IssueFieldSingleSelectValue",
+							"field":      map[string]any{"fullDatabaseId": "202", "name": "Impact"},
+							"value":      "High",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	gqlClient := githubv4.NewClient(githubv4mock.NewMockedHTTPClient(
+		githubv4mock.NewQueryMatcher(
+			struct {
+				Repository struct {
+					Issue struct {
+						IssueFieldValues struct {
+							Nodes []IssueFieldValueFragment
+						} `graphql:"issueFieldValues(first: 25)"`
+					} `graphql:"issue(number: $number)"`
+				} `graphql:"repository(owner: $owner, name: $repo)"`
+			}{},
+			map[string]any{
+				"owner":  githubv4.String("owner"),
+				"repo":   githubv4.String("repo"),
+				"number": githubv4.Int(42),
+			},
+			existingFieldsResponse,
+		),
+	))
+
+	result, err := UpdateIssue(
+		context.Background(),
+		restClient,
+		gqlClient,
+		"owner", "repo", 42,
+		"", "", nil, nil, 0, "",
+		nil,
+		[]int64{101},
+		"", "", 0,
+	)
+	require.NoError(t, err)
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %s", getTextResult(t, result).Text)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, deletePaths,
+		"no DELETE call should fire when the kept set is non-empty — the PATCH's set semantics clear the deleted field on the server side")
+}


### PR DESCRIPTION
## Summary

REST PATCH alone can't clear an issue field value: `go-github`'s `IssueRequest.IssueFieldValues` carries `json:"issue_field_values,omitempty"`, so Go's encoder strips an empty `[]*IssueRequestFieldValue` from the body. The current merge-and-PATCH flow filters the deleted entry out of the kept list and then assigns it back to the request; when the kept list ends up empty (e.g. you delete the only remaining field value), the entire `issue_field_values` key vanishes from the wire format and the server treats it as a no-op. The field's old value sticks around.

Capture each field's GraphQL node ID alongside its database ID at resolve time, and after the REST PATCH succeeds run `deleteIssueFieldValue` per deletion. The mutation is idempotent, per-field, and not subject to the omitempty silent-no-op. It also sidesteps the race window in the old fetch-merge-PATCH approach (where a concurrent edit between our fetch and our PATCH would be silently clobbered by REST's set semantics).

## Empirical confirmation of the bug

Running an equivalent flow on `main` (mocking `fetchExistingIssueFieldValues` to return one field, calling `UpdateIssue` asking to delete that field's value, capturing what reaches the PATCH endpoint) produces a literal PATCH body of `{}`. The server's update handler in `github/github`'s `app/api/issues.rb` guards the entire field-values block on `data.include?(ISSUE_FIELD_VALUES)` — key absent → nothing touched. Confirmed bug.

## Tests

Three new tests in `pkg/github/issues_delete_test.go`:

- **`Test_IssueRequest_EmptyFieldValues_OmittedByJSON`** — pins the omitempty contract so we know if `go-github` ever drops the tag (at which point this fix could be revisited).
- **`Test_UpdateIssue_DeleteFieldValueRunsGraphQLMutation`** — deletes the only existing field value, captures the REST PATCH body, asserts it has no `issue_field_values` key, and asserts (via mutation matcher) that the GraphQL clear fires.
- **`Test_UpdateIssue_DeleteAndSetFieldsInSameCall`** — combined set-one-delete-another in a single call. REST PATCH carries only the set; GraphQL mutation fires for the deletion.

## Stack

This PR is the universal bug-fix half of #2659. The multi-select feature work (FF-gated) will be rebased on top of this and re-opened as a stacked PR once this lands.