### PR TITLE
fix(tools): list supported methods in unknown-method dispatch errors

### DIFF
--- a/pkg/github/__toolsnaps__/sub_issue_write.snap
+++ b/pkg/github/__toolsnaps__/sub_issue_write.snap
@@ -21,6 +21,11 @@
       },
       "method": {
         "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\nWrites issue hierarchy. To move a sub-issue to a new parent, use `add` with `replace_parent=true`; there is no writable parent field.\n",
+        "enum": [
+          "add",
+          "remove",
+          "reprioritize"
+        ],
         "type": "string"
       },
       "owner": {

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -46,6 +46,15 @@ const (
 	actionsMethodDeleteWorkflowRunLogs    = "delete_workflow_run_logs"
 )
 
+// Method sets for the consolidated actions tools. Each slice is the single
+// source for its tool: it feeds both the schema enum (methodEnum) and the
+// unknown-method error (unknownMethodError). Order matches the advertised enum.
+var (
+	actionsWorkflowListMethods = []string{actionsMethodListWorkflows, actionsMethodListWorkflowRuns, actionsMethodListWorkflowJobs, actionsMethodListWorkflowArtifacts}
+	actionsWorkflowGetMethods  = []string{actionsMethodGetWorkflow, actionsMethodGetWorkflowRun, actionsMethodGetWorkflowJob, actionsMethodDownloadWorkflowArtifact, actionsMethodGetWorkflowRunUsage, actionsMethodGetWorkflowRunLogsURL}
+	actionsWorkflowRunMethods  = []string{actionsMethodRunWorkflow, actionsMethodRerunWorkflowRun, actionsMethodRerunFailedJobs, actionsMethodCancelWorkflowRun, actionsMethodDeleteWorkflowRunLogs}
+)
+
 // handleFailedJobLogs gets logs for all failed jobs in a workflow run
 func handleFailedJobLogs(ctx context.Context, client *github.Client, owner, repo string, runID int64, returnContent bool, tailLines int, contentWindowSize int) (*mcp.CallToolResult, any, error) {
 	// First, get all jobs for the workflow run
@@ -217,12 +226,7 @@ Use this tool to list workflows in a repository, or list workflow runs, jobs, an
 					"method": {
 						Type:        "string",
 						Description: "The action to perform",
-						Enum: []any{
-							actionsMethodListWorkflows,
-							actionsMethodListWorkflowRuns,
-							actionsMethodListWorkflowJobs,
-							actionsMethodListWorkflowArtifacts,
-						},
+						Enum: methodEnum(actionsWorkflowListMethods),
 					},
 					"owner": {
 						Type:        "string",
@@ -397,7 +401,7 @@ Use this tool to list workflows in a repository, or list workflow runs, jobs, an
 				result, payload, err := listWorkflowArtifacts(ctx, client, owner, repo, resourceIDInt, pagination)
 				return attachIFC(result), payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, actionsWorkflowListMethods), nil, nil
 			}
 		},
 	)
@@ -423,14 +427,7 @@ Use this tool to get details about individual workflows, workflow runs, jobs, an
 					"method": {
 						Type:        "string",
 						Description: "The method to execute",
-						Enum: []any{
-							actionsMethodGetWorkflow,
-							actionsMethodGetWorkflowRun,
-							actionsMethodGetWorkflowJob,
-							actionsMethodDownloadWorkflowArtifact,
-							actionsMethodGetWorkflowRunUsage,
-							actionsMethodGetWorkflowRunLogsURL,
-						},
+						Enum: methodEnum(actionsWorkflowGetMethods),
 					},
 					"owner": {
 						Type:        "string",
@@ -519,7 +516,7 @@ Use this tool to get details about individual workflows, workflow runs, jobs, an
 				result, payload, err := getWorkflowRunLogsURL(ctx, client, owner, repo, resourceIDInt)
 				return attachIFC(result), payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, actionsWorkflowGetMethods), nil, nil
 			}
 		},
 	)
@@ -544,13 +541,7 @@ func ActionsRunTrigger(t translations.TranslationHelperFunc) inventory.ServerToo
 					"method": {
 						Type:        "string",
 						Description: "The method to execute",
-						Enum: []any{
-							actionsMethodRunWorkflow,
-							actionsMethodRerunWorkflowRun,
-							actionsMethodRerunFailedJobs,
-							actionsMethodCancelWorkflowRun,
-							actionsMethodDeleteWorkflowRunLogs,
-						},
+						Enum: methodEnum(actionsWorkflowRunMethods),
 					},
 					"owner": {
 						Type:        "string",
@@ -636,7 +627,7 @@ func ActionsRunTrigger(t translations.TranslationHelperFunc) inventory.ServerToo
 			case actionsMethodDeleteWorkflowRunLogs:
 				return deleteWorkflowRunLogs(ctx, client, owner, repo, int64(runID))
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, actionsWorkflowRunMethods), nil, nil
 			}
 		},
 	)

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -25,6 +25,13 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
+// Method sets for the consolidated issue tools (single source for the schema
+// enum via methodEnum and the unknown-method error via unknownMethodError).
+var (
+	issueReadMethods     = []string{"get", "get_comments", "get_sub_issues", "get_parent", "get_labels"}
+	subIssueWriteMethods = []string{"add", "remove", "reprioritize"}
+)
+
 // CloseIssueInput represents the input for closing an issue via the GraphQL API.
 // Used to extend the functionality of the githubv4 library to support closing issues as duplicates.
 type CloseIssueInput struct {
@@ -620,7 +627,7 @@ func IssueRead(t translations.TranslationHelperFunc) inventory.ServerTool {
 					"3. get_sub_issues - Get sub-issues (children) of the issue.\n" +
 					"4. get_parent - Get the parent issue, if this issue is a sub-issue of another.\n" +
 					"5. get_labels - Get labels assigned to the issue.\n",
-				Enum: []any{"get", "get_comments", "get_sub_issues", "get_parent", "get_labels"},
+				Enum: methodEnum(issueReadMethods),
 			},
 			"owner": {
 				Type:        "string",
@@ -707,7 +714,7 @@ func IssueRead(t translations.TranslationHelperFunc) inventory.ServerTool {
 				result, err := GetIssueLabels(ctx, gqlClient, owner, repo, issueNumber)
 				return attachIFC(result), nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, issueReadMethods), nil, nil
 			}
 		})
 }
@@ -1398,6 +1405,7 @@ func SubIssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 							"- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n" +
 							"- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n" +
 							"Writes issue hierarchy. To move a sub-issue to a new parent, use `add` with `replace_parent=true`; there is no writable parent field.\n",
+						Enum: methodEnum(subIssueWriteMethods),
 					},
 					"owner": {
 						Type:        "string",
@@ -1485,7 +1493,7 @@ func SubIssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 				result, err := ReprioritizeSubIssue(ctx, client, owner, repo, issueNumber, subIssueID, afterID, beforeID)
 				return result, nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, subIssueWriteMethods), nil, nil
 			}
 		})
 	st.FeatureFlagDisable = []string{FeatureFlagIssuesGranular}

--- a/pkg/github/params.go
+++ b/pkg/github/params.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
+	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/google/go-github/v89/github"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // OptionalParamOK is a helper function that can be used to fetch a requested parameter from the request.
@@ -487,4 +490,25 @@ func (p PaginationParams) ToGraphQLParams() (*GraphQLPaginationParams, error) {
 		After:   p.After,
 	}
 	return cursor.ToGraphQLParams()
+}
+
+
+// methodEnum renders a tool's supported method list as the []any value the
+// input-schema Enum field expects. Declaring the enum from the same []string
+// the handler validates against keeps the advertised methods and the runtime
+// check from drifting apart.
+func methodEnum(methods []string) []any {
+	out := make([]any, len(methods))
+	for i, m := range methods {
+		out[i] = m
+	}
+	return out
+}
+
+// unknownMethodError is the tool-result error returned when a method-dispatch
+// tool is called with a value outside its advertised method enum. Listing the
+// supported methods lets the caller (often an LLM) self-correct. supported must
+// be the same list advertised in the tool's input-schema enum.
+func unknownMethodError(method string, supported []string) *mcp.CallToolResult {
+	return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: %s", method, strings.Join(supported, ", ")))
 }

--- a/pkg/github/params_test.go
+++ b/pkg/github/params_test.go
@@ -642,3 +642,18 @@ func TestOptionalPaginationParams(t *testing.T) {
 		})
 	}
 }
+
+
+func TestMethodEnum(t *testing.T) {
+	assert.Equal(t, []any{"create", "submit_pending"}, methodEnum([]string{"create", "submit_pending"}))
+	assert.Empty(t, methodEnum(nil))
+}
+
+func TestUnknownMethodError(t *testing.T) {
+	res := unknownMethodError("bogus", []string{"create", "submit_pending", "delete_pending"})
+	assert.NotNil(t, res)
+	assert.True(t, res.IsError)
+	txt := getErrorResult(t, res).Text
+	assert.Contains(t, txt, "unknown method: bogus")
+	assert.Contains(t, txt, "Supported methods are: create, submit_pending, delete_pending")
+}

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -51,6 +51,15 @@ const (
 	projectsMethodCreateIterationField      = "create_iteration_field"
 )
 
+// Method sets for the consolidated project tools. Single source per tool: feeds
+// both the schema enum (methodEnum) and the unknown-method error
+// (unknownMethodError). Order matches the advertised enum.
+var (
+	projectsListMethods  = []string{projectsMethodListProjects, projectsMethodListProjectFields, projectsMethodListProjectItems, projectsMethodListProjectStatusUpdates}
+	projectsGetMethods   = []string{projectsMethodGetProject, projectsMethodGetProjectField, projectsMethodGetProjectItem, projectsMethodGetProjectStatusUpdate}
+	projectsWriteMethods = []string{projectsMethodAddProjectItem, projectsMethodUpdateProjectItem, projectsMethodDeleteProjectItem, projectsMethodCreateProjectStatusUpdate, projectsMethodCreateProject, projectsMethodCreateIterationField}
+)
+
 // GraphQL types for ProjectV2 status updates
 
 type statusUpdateNode struct {
@@ -169,12 +178,7 @@ Use this tool to list projects for a user or organization, or list project field
 					"method": {
 						Type:        "string",
 						Description: "The action to perform",
-						Enum: []any{
-							projectsMethodListProjects,
-							projectsMethodListProjectFields,
-							projectsMethodListProjectItems,
-							projectsMethodListProjectStatusUpdates,
-						},
+						Enum: methodEnum(projectsListMethods),
 					},
 					"owner_type": {
 						Type:        "string",
@@ -284,10 +288,10 @@ Use this tool to list projects for a user or organization, or list project field
 					result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelProjectContent(isPrivate))
 					return result, payload, err
 				default:
-					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+					return unknownMethodError(method, projectsListMethods), nil, nil
 				}
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, projectsListMethods), nil, nil
 			}
 		},
 	)
@@ -313,12 +317,7 @@ Use this tool to get details about individual projects, project fields, and proj
 					"method": {
 						Type:        "string",
 						Description: "The method to execute",
-						Enum: []any{
-							projectsMethodGetProject,
-							projectsMethodGetProjectField,
-							projectsMethodGetProjectItem,
-							projectsMethodGetProjectStatusUpdate,
-						},
+						Enum: methodEnum(projectsGetMethods),
 					},
 					"owner_type": {
 						Type:        "string",
@@ -442,7 +441,7 @@ Use this tool to get details about individual projects, project fields, and proj
 				}
 				return result, payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, projectsGetMethods), nil, nil
 			}
 		},
 	)
@@ -467,14 +466,7 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 					"method": {
 						Type:        "string",
 						Description: "The method to execute",
-						Enum: []any{
-							projectsMethodAddProjectItem,
-							projectsMethodUpdateProjectItem,
-							projectsMethodDeleteProjectItem,
-							projectsMethodCreateProjectStatusUpdate,
-							projectsMethodCreateProject,
-							projectsMethodCreateIterationField,
-						},
+						Enum: methodEnum(projectsWriteMethods),
 					},
 					"owner_type": {
 						Type:        "string",
@@ -692,7 +684,7 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			case projectsMethodCreateIterationField:
 				return createIterationField(ctx, gqlClient, owner, ownerType, projectNumber, args)
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, projectsWriteMethods), nil, nil
 			}
 		},
 	)

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -93,7 +93,7 @@ func Test_ProjectsList_ListProjects(t *testing.T) {
 				"owner_type": "org",
 			},
 			expectError:    true,
-			expectedErrMsg: "unknown method: unknown_method",
+			expectedErrMsg: "unknown method: unknown_method. Supported methods are:",
 		},
 	}
 
@@ -625,8 +625,10 @@ func Test_ProjectsGet_GetProject(t *testing.T) {
 		require.True(t, result.IsError)
 		textContent := getTextResult(t, result)
 		assert.Contains(t, textContent.Text, "unknown method: unknown_method")
+		assert.Contains(t, textContent.Text, "Supported methods are:")
 	})
 }
+
 
 func Test_ProjectsGet_IFC_InsidersMode(t *testing.T) {
 	toolDef := ProjectsGet(translations.NullTranslationHelper)
@@ -1113,8 +1115,10 @@ func Test_ProjectsWrite_AddProjectItem(t *testing.T) {
 		require.True(t, result.IsError)
 		textContent := getTextResult(t, result)
 		assert.Contains(t, textContent.Text, "unknown method: unknown_method")
+		assert.Contains(t, textContent.Text, "Supported methods are:")
 	})
 }
+
 
 func Test_ProjectsWrite_UpdateProjectItem(t *testing.T) {
 	toolDef := ProjectsWrite(translations.NullTranslationHelper)

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -23,6 +23,13 @@ import (
 	"github.com/github/github-mcp-server/pkg/utils"
 )
 
+// Method sets for the consolidated pull request tools (single source for the
+// schema enum via methodEnum and the unknown-method error via unknownMethodError).
+var (
+	pullRequestReadMethods        = []string{"get", "get_diff", "get_status", "get_files", "get_commits", "get_review_comments", "get_reviews", "get_comments", "get_check_runs"}
+	pullRequestReviewWriteMethods = []string{"create", "submit_pending", "delete_pending", "resolve_thread", "unresolve_thread"}
+)
+
 // PullRequestRead creates a tool to get details of a specific pull request.
 func PullRequestRead(t translations.TranslationHelperFunc) inventory.ServerTool {
 	schema := &jsonschema.Schema{
@@ -42,7 +49,7 @@ Possible options:
  8. get_comments - Get comments on a pull request. Use this if user doesn't specifically want review comments. Use with pagination parameters to control the number of results returned.
  9. get_check_runs - Get check runs for the head commit of a pull request. Check runs are the individual CI/CD jobs and checks that run on the PR.
 `,
-				Enum: []any{"get", "get_diff", "get_status", "get_files", "get_commits", "get_review_comments", "get_reviews", "get_comments", "get_check_runs"},
+				Enum: methodEnum(pullRequestReadMethods),
 			},
 			"owner": {
 				Type:        "string",
@@ -155,7 +162,7 @@ Possible options:
 				result, err := GetPullRequestCheckRuns(ctx, client, owner, repo, pullNumber, pagination)
 				return attachIFC(result), nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, pullRequestReadMethods), nil, nil
 			}
 		})
 }
@@ -1735,7 +1742,7 @@ func PullRequestReviewWrite(t translations.TranslationHelperFunc) inventory.Serv
 			"method": {
 				Type:        "string",
 				Description: `The write operation to perform on pull request review.`,
-				Enum:        []any{"create", "submit_pending", "delete_pending", "resolve_thread", "unresolve_thread"},
+				Enum:        methodEnum(pullRequestReviewWriteMethods),
 			},
 			"owner": {
 				Type:        "string",
@@ -1796,6 +1803,15 @@ Available methods:
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
+			// Unlike the other method-dispatch tools, this handler decodes args
+			// with WeakDecode rather than RequiredParam, so an omitted method
+			// would otherwise reach the switch default as an empty value. Enforce
+			// it explicitly so a missing method is reported the same way as every
+			// other missing required parameter.
+			if _, err := RequiredParam[string](args, "method"); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
 			// Given our owner, repo and PR number, lookup the GQL ID of the PR.
 			client, err := deps.GetGQLClient(ctx)
 			if err != nil {
@@ -1819,7 +1835,7 @@ Available methods:
 				result, err := ResolveReviewThread(ctx, client, params.ThreadID, false)
 				return result, nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", params.Method)), nil, nil
+				return unknownMethodError(params.Method, pullRequestReviewWriteMethods), nil, nil
 			}
 		})
 	st.FeatureFlagDisable = []string{FeatureFlagPullRequestsGranular}

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -3249,6 +3249,20 @@ func TestCreatePendingPullRequestReview(t *testing.T) {
 			expectToolError:    true,
 			expectedToolErrMsg: "expected test failure",
 		},
+		{
+			name:               "missing method is reported as a required parameter",
+			mockedClient:       githubv4mock.NewMockedHTTPClient(),
+			requestArgs:        map[string]any{"owner": "owner", "repo": "repo", "pullNumber": float64(42)},
+			expectToolError:    true,
+			expectedToolErrMsg: "missing required parameter: method",
+		},
+		{
+			name:               "unknown method lists the supported methods",
+			mockedClient:       githubv4mock.NewMockedHTTPClient(),
+			requestArgs:        map[string]any{"method": "bogus", "owner": "owner", "repo": "repo", "pullNumber": float64(42)},
+			expectToolError:    true,
+			expectedToolErrMsg: "unknown method: bogus. Supported methods are: create, submit_pending, delete_pending, resolve_thread, unresolve_thread",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/github/ui_tools.go
+++ b/pkg/github/ui_tools.go
@@ -29,6 +29,10 @@ import (
 // flag, which is acceptable because the picker pairs truncation with typeahead.
 const uiGetMaxPages = 10
 
+// uiGetMethods is the single source for ui_get's schema enum (methodEnum) and its
+// unknown-method error (unknownMethodError).
+var uiGetMethods = []string{"labels", "assignees", "milestones", "issue_types", "branches", "issue_fields", "reviewers"}
+
 // UIGet creates a tool to fetch UI data for MCP Apps.
 func UIGet(t translations.TranslationHelperFunc) inventory.ServerTool {
 	st := NewTool(
@@ -53,7 +57,7 @@ func UIGet(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Properties: map[string]*jsonschema.Schema{
 					"method": {
 						Type:        "string",
-						Enum:        []any{"labels", "assignees", "milestones", "issue_types", "branches", "issue_fields", "reviewers"},
+						Enum:        methodEnum(uiGetMethods),
 						Description: "The type of data to fetch",
 					},
 					"owner": {
@@ -96,7 +100,7 @@ func UIGet(t translations.TranslationHelperFunc) inventory.ServerTool {
 			case "reviewers":
 				return uiGetReviewers(ctx, deps, args, owner)
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, uiGetMethods), nil, nil
 			}
 		})
 	st.FeatureFlagEnable = MCPAppsFeatureFlag

--- a/pkg/github/ui_tools_test.go
+++ b/pkg/github/ui_tools_test.go
@@ -483,7 +483,7 @@ func Test_UIGet(t *testing.T) {
 				"repo":   "repo",
 			},
 			expectError:    true,
-			expectedErrMsg: "unknown method: unknown",
+			expectedErrMsg: "unknown method: unknown. Supported methods are:",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Improve consolidated method-dispatch MCP tools to return actionable errors when an unrecognized `method` is provided, matching the existing `label_write` behavior.

## Motivation

Fixes #2712. Tools such as `pull_request_read`, `pull_request_review_write`, `issue_read`, `sub_issue_write`, `actions_*`, `projects_*`, and `ui_get` previously returned bare `unknown method: <value>` errors. When `method` was omitted from `pull_request_review_write`, callers saw `unknown method: ` with an empty value instead of a required-parameter error.

## Changes

- Add shared `methodEnum()` and `unknownMethodError()` helpers in `pkg/github/params.go`
- Declare per-tool method slices as the single source for schema enums and runtime validation
- Update consolidated tools to use the helpers in their `default` branches
- Validate required `method` in `pull_request_review_write` before `WeakDecode` routing
- Add regression tests for helpers and `pull_request_review_write` error paths
- Update `sub_issue_write` toolsnap enum

## Tests

```bash
go test ./pkg/github/... -count=1
```

Result: **PASS** (0.161s)

## Notes

- Rebased on current `main`; `issue_read` retains `get_parent` support.
- `label_write` already had inline supported-method messaging and was left unchanged to keep scope minimal.
- Related open PR #2713 appears conflicted/stale; this branch is a fresh implementation on current `main`.