### PR TITLE
fix(pull_requests): validate required params in add_comment_to_pending_review

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -2277,38 +2277,74 @@ func AddCommentToPendingReview(t translations.TranslationHelperFunc) inventory.S
 		},
 		[]scopes.Scope{scopes.Repo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
-			var params struct {
-				Owner       string
-				Repo        string
-				PullNumber  int32
-				Path        string
-				Body        string
-				SubjectType string
-				Line        *int32
-				Side        *string
-				StartLine   *int32
-				StartSide   *string
-			}
-			if err := mapstructure.WeakDecode(args, &params); err != nil {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pullNumber, err := RequiredInt(args, "pullNumber")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			path, err := RequiredParam[string](args, "path")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			body, err := RequiredParam[string](args, "body")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			subjectType, err := RequiredParam[string](args, "subjectType")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			line, err := OptionalIntParam(args, "line")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			side, _ := OptionalParam[string](args, "side")
+			startLine, err := OptionalIntParam(args, "startLine")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			startSide, _ := OptionalParam[string](args, "startSide")
 
 			client, err := deps.GetGQLClient(ctx)
 			if err != nil {
 				return utils.NewToolResultErrorFromErr("failed to get GitHub GQL client", err), nil, nil
 			}
 
+			var linePtr, startLinePtr *int32
+			if line != 0 {
+				l := int32(line) // #nosec G115
+				linePtr = &l
+			}
+			if startLine != 0 {
+				sl := int32(startLine) // #nosec G115
+				startLinePtr = &sl
+			}
+			var sidePtr, startSidePtr *string
+			if side != "" {
+				sidePtr = &side
+			}
+			if startSide != "" {
+				startSidePtr = &startSide
+			}
+
 			result, err := AddCommentToPendingReviewCall(ctx, client, AddCommentToPendingReviewParams{
-				Owner:       params.Owner,
-				Repo:        params.Repo,
-				PullNumber:  params.PullNumber,
-				Path:        params.Path,
-				Body:        params.Body,
-				SubjectType: params.SubjectType,
-				Line:        params.Line,
-				Side:        params.Side,
-				StartLine:   params.StartLine,
-				StartSide:   params.StartSide,
+				Owner:       owner,
+				Repo:        repo,
+				PullNumber:  int32(pullNumber), // #nosec G115 - PR numbers are always small positive integers
+				Path:        path,
+				Body:        body,
+				SubjectType: subjectType,
+				Line:        linePtr,
+				Side:        sidePtr,
+				StartLine:   startLinePtr,
+				StartSide:   startSidePtr,
 			})
 			return result, nil, err
 		})

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -3517,6 +3517,30 @@ func TestAddPullRequestReviewCommentToPendingReview(t *testing.T) {
 			),
 		},
 		{
+			name: "missing required parameter owner",
+			requestArgs: map[string]any{
+				"repo":        "gated-probe",
+				"pullNumber":  float64(1),
+				"path":        "f.go",
+				"body":        "x",
+				"subjectType": "LINE",
+			},
+			expectToolError:    true,
+			expectedToolErrMsg: "missing required parameter: owner",
+		},
+		{
+			name: "missing required parameter path",
+			requestArgs: map[string]any{
+				"owner":       "owner",
+				"repo":        "repo",
+				"pullNumber":  float64(42),
+				"body":        "This is a test comment",
+				"subjectType": "LINE",
+			},
+			expectToolError:    true,
+			expectedToolErrMsg: "missing required parameter: path",
+		},
+		{
 			name: "thread ID is nil - invalid line number",
 			requestArgs: map[string]any{
 				"owner":       "owner",


### PR DESCRIPTION
## Summary

Validate required arguments in `add_comment_to_pending_review` before calling the GraphQL API, returning clear `missing required parameter` errors consistent with other pull request tools.

## Motivation

When a required argument such as `owner` was omitted, the handler used `mapstructure.WeakDecode` and proceeded with zero values. The downstream GraphQL call then failed with a confusing repository-resolution error instead of indicating which argument was missing.

Fixes #2718

## Changes

- Replace `mapstructure.WeakDecode` in `AddCommentToPendingReview` with `RequiredParam` / `RequiredInt` / `OptionalIntParam` / `OptionalParam`
- Align optional pointer handling with the granular pull request review comment tool
- Add regression tests for missing `owner` and `path`

## Tests

```bash
go test ./pkg/github/... -run TestAddPullRequestReviewCommentToPendingReview -count=1
./script/lint
```

All tests pass; lint reports 0 issues.

## Notes

The same `WeakDecode`-without-validation pattern also exists in `copilot.go` and `discussions.go`; those are out of scope for this focused fix as noted in the issue.