### PR TITLE
fix(labels): mark label_write as destructive

### DIFF
--- a/pkg/github/__toolsnaps__/label_write.snap
+++ b/pkg/github/__toolsnaps__/label_write.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": true,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Write operations on repository labels"

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -226,8 +226,9 @@ func LabelWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "label_write",
 			Description: t("TOOL_LABEL_WRITE_DESCRIPTION", "Perform write operations on repository labels. To set labels on issues, use the 'update_issue' tool."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_LABEL_WRITE_TITLE", "Write operations on repository labels"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_LABEL_WRITE_TITLE", "Write operations on repository labels"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/github/labels_test.go
+++ b/pkg/github/labels_test.go
@@ -247,6 +247,10 @@ func TestWriteLabel(t *testing.T) {
 	assert.Equal(t, "label_write", tool.Name)
 	assert.NotEmpty(t, tool.Description)
 	assert.False(t, tool.Annotations.ReadOnlyHint, "label_write tool should not be read-only")
+	// label_write can delete a label repo-wide (removing it from every issue/PR),
+	// so clients must treat the tool as destructive and confirm before running it.
+	require.NotNil(t, tool.Annotations.DestructiveHint, "label_write should set DestructiveHint")
+	assert.True(t, *tool.Annotations.DestructiveHint, "label_write should be destructive")
 
 	tests := []struct {
 		name               string


### PR DESCRIPTION
## What & why

`label_write`'s `delete` method removes a label at the repository level, detaching it from every issue and PR in the repo — an operation whose effects cannot be automatically restored even if the label is recreated with the same name. The tool set `ReadOnlyHint: false` but **omitted `DestructiveHint`**, so MCP clients received no destructive-operation signal and could execute the deletion without confirming with the user.

This addresses the concern raised in #2723.

## Change

Set `DestructiveHint: true` on `label_write` (`pkg/github/labels.go`).

`label_write` is a method-dispatched tool (create/update/delete), so the static hint cannot vary per method. I set it `true` on the whole tool, matching the convention already established by the other method-dispatched tools capable of destruction:

- `projects_write` — `pkg/github/projects.go:462` (asserted in `projects_test.go`)
- `actions_run_trigger` — `pkg/github/actions.go:539`

The hint communicates "this tool is capable of destruction" (so clients should confirm), which is accurate for `label_write` regardless of method.

## Tests

- Added assertions in `TestWriteLabel` that `DestructiveHint` is non-nil and `true` (mirrors `projects_test.go`).
- Regenerated the `toolsnaps` golden snapshot for `label_write` via the documented `UPDATE_TOOLSNAPS=true` workflow; the only diff is `+ "destructiveHint": true`.
- `go build ./...` clean.
- `go vet ./pkg/github/` clean.
- `go test ./pkg/github/` passes (full package suite).

Closes #2723