### PR TITLE
Clarify pull_request_review_write title notes pending review creation

### DIFF
--- a/pkg/github/__toolsnaps__/pull_request_review_write.snap
+++ b/pkg/github/__toolsnaps__/pull_request_review_write.snap
@@ -2,7 +2,7 @@
   "annotations": {
     "idempotentHint": false,
     "readOnlyHint": false,
-    "title": "Write operations (create, submit, delete) on pull request reviews"
+    "title": "Create (pending), submit, or delete pull request reviews"
   },
   "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n- resolve_thread: Resolve a review thread. Requires only \"threadId\" parameter with the thread's node ID (e.g., PRRT_kwDOxxx). The owner, repo, and pullNumber parameters are not used for this method. Resolving an already-resolved thread is a no-op.\n- unresolve_thread: Unresolve a previously resolved review thread. Requires only \"threadId\" parameter. The owner, repo, and pullNumber parameters are not used for this method. Unresolving an already-unresolved thread is a no-op.\n",
   "inputSchema": {

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1784,7 +1784,7 @@ Available methods:
 - unresolve_thread: Unresolve a previously resolved review thread. Requires only "threadId" parameter. The owner, repo, and pullNumber parameters are not used for this method. Unresolving an already-unresolved thread is a no-op.
 `),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_PULL_REQUEST_REVIEW_WRITE_USER_TITLE", "Write operations (create, submit, delete) on pull request reviews"),
+				Title:        t("TOOL_PULL_REQUEST_REVIEW_WRITE_USER_TITLE", "Create (pending), submit, or delete pull request reviews"),
 				ReadOnlyHint: false,
 			},
 			InputSchema: schema,


### PR DESCRIPTION
## What

Updates the `Title` annotation of the `pull_request_review_write` tool from:

> Write operations (create, submit, delete) on pull request reviews

to:

> Create (pending), submit, or delete pull request reviews

## Why

When an MCP client (e.g. Claude Code) surfaces only a tool's short title, `method: "create"` reads as "create a review" — implying the review is created and submitted. In reality, when the `event` parameter is omitted, `create` opens a **pending** review that is *not* submitted; it must later be submitted via `method: "submit_pending"`. The description body already documents this correctly, but the short title — the part many clients actually show — was misleading.

The parenthetical scopes "pending" to the `create` action: `create` opens a pending review when `event` is omitted, and submits immediately when `event` is supplied. This surfaces the pending-by-default behavior at a glance without overclaiming that `create` is always pending. No behavior, schema, or API change.

Closes #2524.

## Wording

This follows the wording suggested in the issue, tightened to a parenthetical so "pending" reads as an attribute of `create` rather than a synonym for it (since `create` with `event` does submit). If a maintainer prefers different phrasing — e.g. the issue's alternate `"Pending review create / submit / delete for pull requests"` — it's a one-line change.

## Verification

- `gofmt -l` clean.
- `go vet ./pkg/github/`
- `go build ./...`
- `go test ./pkg/github/ -run 'TestCreateAndSubmitPullRequestReview|TestCreatePendingPullRequestReview|TestSubmitPendingPullRequestReview|TestDeletePendingPullRequestReview'` — green.
- Regenerated `pull_request_review_write` golden snapshot (`pkg/github/__toolsnaps__/pull_request_review_write.snap`) via `UPDATE_TOOLSNAPS=true`; the only delta is the `title` field, matching the code change.