### PR TITLE
Mark pull_request_review_write and sub_issue_write as destructive

### DIFF
--- a/pkg/github/__toolsnaps__/pull_request_review_write.snap
+++ b/pkg/github/__toolsnaps__/pull_request_review_write.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": true,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Write operations (create, submit, delete) on pull request reviews"

--- a/pkg/github/__toolsnaps__/sub_issue_write.snap
+++ b/pkg/github/__toolsnaps__/sub_issue_write.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": true,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Change sub-issue"

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1384,8 +1384,9 @@ func SubIssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			Name:        "sub_issue_write",
 			Description: t("TOOL_SUB_ISSUE_WRITE_DESCRIPTION", "Add a sub-issue to a parent issue in a GitHub repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_SUB_ISSUE_WRITE_USER_TITLE", "Change sub-issue"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_SUB_ISSUE_WRITE_USER_TITLE", "Change sub-issue"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -3941,6 +3941,10 @@ func Test_AddSubIssue(t *testing.T) {
 
 	assert.Equal(t, "sub_issue_write", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	// remove deletes a sub-issue link, so clients must treat the tool as
+	// destructive and confirm before running it.
+	require.NotNil(t, tool.Annotations.DestructiveHint, "sub_issue_write should set DestructiveHint")
+	assert.True(t, *tool.Annotations.DestructiveHint, "sub_issue_write should be destructive")
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "method")
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "owner")
 	assert.Contains(t, tool.InputSchema.(*jsonschema.Schema).Properties, "repo")

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1784,8 +1784,9 @@ Available methods:
 - unresolve_thread: Unresolve a previously resolved review thread. Requires only "threadId" parameter. The owner, repo, and pullNumber parameters are not used for this method. Unresolving an already-unresolved thread is a no-op.
 `),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_PULL_REQUEST_REVIEW_WRITE_USER_TITLE", "Write operations (create, submit, delete) on pull request reviews"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_PULL_REQUEST_REVIEW_WRITE_USER_TITLE", "Write operations (create, submit, delete) on pull request reviews"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			InputSchema: schema,
 		},

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -2843,6 +2843,10 @@ func TestCreateAndSubmitPullRequestReview(t *testing.T) {
 
 	assert.Equal(t, "pull_request_review_write", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	// delete_pending discards a pending review's body, so clients must treat
+	// the tool as destructive and confirm before running it.
+	require.NotNil(t, tool.Annotations.DestructiveHint, "pull_request_review_write should set DestructiveHint")
+	assert.True(t, *tool.Annotations.DestructiveHint, "pull_request_review_write should be destructive")
 	schema := tool.InputSchema.(*jsonschema.Schema)
 	assert.Contains(t, schema.Properties, "method")
 	assert.Contains(t, schema.Properties, "owner")


### PR DESCRIPTION
## What

Sets `DestructiveHint: true` on the two remaining method-dispatched write tools whose `delete`/`remove` method discards data:

- **`pull_request_review_write`** — `method: "delete_pending"` deletes a pending review and discards its body.
- **`sub_issue_write`** — `method: "remove"` deletes a sub-issue link.

## Why

This completes the convention established by #2836 (issue #2723) for `label_write`, and already followed by `discussion_comment_write` and `projects_write`: a method-dispatched write tool capable of destruction sets `DestructiveHint: true` so MCP clients that gate on the hint surface a confirmation prompt before running it.

Before this PR, a client gating on `DestructiveHint` would warn before `label_write delete` but **not** before `pull_request_review_write method: "delete_pending"` or `sub_issue_write method: "remove"`, even though both discard data. The granular equivalents already flag these as destructive:

- `delete_pending_pull_request_review` (`pkg/github/pullrequests_granular.go`) sets `DestructiveHint: true`.
- `remove_sub_issue` (`pkg/github/issues_granular.go`) sets `DestructiveHint: true`.

So this brings the umbrella method-dispatched tools in line with both their granular equivalents and the sibling umbrella tools (`discussion_comment_write`, `projects_write`, `label_write`). No new judgment call — just consistency.

This was surfaced by a self-review of #2836/#2837: the #2836 rationale ("method-dispatched tools capable of destruction should set `DestructiveHint`") is satisfied by these two tools as well, so a maintainer would reasonably ask "why only `label_write`?" — this answers it.

## Changes

- `pkg/github/pullrequests.go` — add `DestructiveHint: jsonschema.Ptr(true)` to `pull_request_review_write` (gofmt re-aligned the struct fields).
- `pkg/github/issues.go` — add `DestructiveHint: jsonschema.Ptr(true)` to `sub_issue_write`.
- `pkg/github/pullrequests_test.go`, `pkg/github/issues_test.go` — add `require.NotNil` + `assert.True` assertions mirroring `labels_test.go`.
- Regenerated golden snapshots: `pull_request_review_write.snap`, `sub_issue_write.snap` (only delta is `+ "destructiveHint": true`).

No behavior, schema, or API change.

## Overlap with #2837 (heads-up)

#2837 also edits `pull_request_review_write`'s annotation block (its `Title` string) and regenerates the same `pull_request_review_write.snap`. This PR and #2837 touch **different fields** of the same `Annotations` struct, so the `.go` merge is clean. The `.snap` file will conflict if both merge, but it's a one-line regen — whichever merges second just re-runs `UPDATE_TOOLSNAPS=true go test ./pkg/github/ -run TestCreateAndSubmitPullRequestReview`. Happy to rebase onto whichever lands first if helpful.

## Verification

- `gofmt -l` clean on all touched files.
- `go vet ./pkg/github/`
- `go build ./...`
- `go test ./pkg/github/ -run 'TestCreateAndSubmitPullRequestReview|TestCreatePendingPullRequestReview|TestSubmitPendingPullRequestReview|TestDeletePendingPullRequestReview|Test_AddSubIssue|Test_RemoveSubIssue|Test_ReprioritizeSubIssue'` — green (snapshots regenerated with `UPDATE_TOOLSNAPS=true`, then re-run without the flag).