### PR TITLE
fix(notifications): set destructiveHint false on subscription tools

### DIFF
--- a/pkg/github/__toolsnaps__/manage_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_notification_subscription.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": false,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Manage notification subscription"

--- a/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": false,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Manage repository notification subscription"

--- a/pkg/github/notifications.go
+++ b/pkg/github/notifications.go
@@ -413,8 +413,9 @@ func ManageNotificationSubscription(t translations.TranslationHelperFunc) invent
 			Name:        "manage_notification_subscription",
 			Description: t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a notification subscription: ignore, watch, or delete a notification thread subscription."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(false),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
@@ -509,8 +510,9 @@ func ManageRepositoryNotificationSubscription(t translations.TranslationHelperFu
 			Name:        "manage_repository_notification_subscription",
 			Description: t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a repository notification subscription: ignore, watch, or delete repository notifications subscription for the provided repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(false),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/github/notifications_test.go
+++ b/pkg/github/notifications_test.go
@@ -146,6 +146,9 @@ func Test_ManageNotificationSubscription(t *testing.T) {
 
 	assert.Equal(t, "manage_notification_subscription", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations)
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	assert.False(t, *tool.Annotations.DestructiveHint)
 
 	schema, ok := tool.InputSchema.(*jsonschema.Schema)
 	require.True(t, ok, "InputSchema should be *jsonschema.Schema")
@@ -282,6 +285,9 @@ func Test_ManageRepositoryNotificationSubscription(t *testing.T) {
 
 	assert.Equal(t, "manage_repository_notification_subscription", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations)
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	assert.False(t, *tool.Annotations.DestructiveHint)
 
 	schema, ok := tool.InputSchema.(*jsonschema.Schema)
 	require.True(t, ok, "InputSchema should be *jsonschema.Schema")


### PR DESCRIPTION
## Summary
Explicitly mark `manage_notification_subscription` and `manage_repository_notification_subscription` as non-destructive MCP tools.

## Why
Fixes #2841

Under MCP schema 2025-06-18, an omitted `destructiveHint` defaults to `true` when `readOnlyHint` is `false`. These tools only update the caller's own notification subscription preferences (watch/ignore/delete subscription record) and do not modify thread or repository content, so conformant clients were over-warning on consent UIs.

## What changed
- Set `DestructiveHint: jsonschema.Ptr(false)` on both notification subscription tools in `pkg/github/notifications.go`
- Add regression assertions in `pkg/github/notifications_test.go`
- Update tool snapshots for both tools

## MCP impact
- [x] Tool schema or behavior changed
- Annotation-only change: clients now receive `destructiveHint: false` instead of inheriting the schema default of `true`.

## Prompts tested (tool changes only)
- N/A (annotation-only; existing handler tests cover behavior)

## Security / limits
- [x] No security or limits impact

## Tool renaming
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `UPDATE_TOOLSNAPS=true go test ./pkg/github/ -run 'Test_ManageNotificationSubscription|Test_ManageRepositoryNotificationSubscription' -count=1`

## Docs
- [x] Not needed