### PR TITLE
perf(octicons): cache embedded data URIs on demand

### DIFF
--- a/pkg/octicons/octicons.go
+++ b/pkg/octicons/octicons.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -17,6 +18,47 @@ var iconsFS embed.FS
 
 //go:embed required_icons.txt
 var requiredIconsTxt string
+
+type dataURIKey struct {
+	name  string
+	theme Theme
+}
+
+type dataURICache struct {
+	mu     sync.RWMutex
+	values map[dataURIKey]string
+}
+
+// This covers the current embedded variants without encoding them at startup.
+const initialDataURICacheCapacity = 64
+
+func (c *dataURICache) load(name string, theme Theme) string {
+	key := dataURIKey{name: name, theme: theme}
+	c.mu.RLock()
+	cached, ok := c.values[key]
+	c.mu.RUnlock()
+	if ok {
+		return cached
+	}
+
+	dataURI := readDataURI(name, theme)
+	if dataURI == "" {
+		return ""
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cached, ok := c.values[key]; ok {
+		return cached
+	}
+	if c.values == nil {
+		c.values = make(map[dataURIKey]string, initialDataURICacheCapacity)
+	}
+	c.values[key] = dataURI
+	return dataURI
+}
+
+var dataURIs dataURICache
 
 // RequiredIcons returns the list of icon names from required_icons.txt.
 // This is the single source of truth for which icons should be embedded.
@@ -50,6 +92,10 @@ const (
 // - ThemeDark: light icons for dark backgrounds
 // If the icon is not found in the embedded filesystem, it returns an empty string.
 func DataURI(name string, theme Theme) string {
+	return dataURIs.load(name, theme)
+}
+
+func readDataURI(name string, theme Theme) string {
 	filename := fmt.Sprintf("icons/%s-%s.png", name, theme)
 	data, err := iconsFS.ReadFile(filename)
 	if err != nil {

--- a/pkg/octicons/octicons_benchmark_test.go
+++ b/pkg/octicons/octicons_benchmark_test.go
@@ -1,0 +1,73 @@
+package octicons
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var benchmarkDataURISink string
+var benchmarkIconsSink [][]mcp.Icon
+
+func BenchmarkDataURICache(b *testing.B) {
+	b.Run("cold", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			var cache dataURICache
+			benchmarkDataURISink = cache.load("repo", ThemeLight)
+		}
+	})
+
+	b.Run("warm", func(b *testing.B) {
+		var cache dataURICache
+		benchmarkDataURISink = cache.load("repo", ThemeLight)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			benchmarkDataURISink = cache.load("repo", ThemeLight)
+		}
+	})
+}
+
+// Run each ColdStart inventory separately with -benchtime=1x in a fresh
+// `go test` process so package-level cache state cannot cross-contaminate it.
+func BenchmarkIconsRegistrationColdStart(b *testing.B) {
+	benchmarkIconsRegistration(b, false)
+}
+
+func BenchmarkIconsRegistrationWarm(b *testing.B) {
+	benchmarkIconsRegistration(b, true)
+}
+
+func benchmarkIconsRegistration(b *testing.B, warm bool) {
+	inventories := map[string][]string{
+		"narrow":  {"repo"},
+		"default": RequiredIcons(),
+	}
+	for name, inventory := range inventories {
+		b.Run(name, func(b *testing.B) {
+			if warm {
+				for _, icon := range inventory {
+					_ = Icons(icon)
+				}
+			} else {
+				dataURIs.mu.Lock()
+				dataURIs.values = nil
+				dataURIs.mu.Unlock()
+			}
+
+			batch := make([][]mcp.Icon, len(inventory))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				for index, icon := range inventory {
+					batch[index] = Icons(icon)
+				}
+			}
+			b.StopTimer()
+			benchmarkIconsSink = batch
+			runtime.KeepAlive(batch)
+		})
+	}
+}

--- a/pkg/octicons/octicons_benchmark_test.go
+++ b/pkg/octicons/octicons_benchmark_test.go
@@ -30,8 +30,6 @@ func BenchmarkDataURICache(b *testing.B) {
 	})
 }
 
-// Run each ColdStart inventory separately with -benchtime=1x in a fresh
-// `go test` process so package-level cache state cannot cross-contaminate it.
 func BenchmarkIconsRegistrationColdStart(b *testing.B) {
 	benchmarkIconsRegistration(b, false)
 }
@@ -51,16 +49,19 @@ func benchmarkIconsRegistration(b *testing.B, warm bool) {
 				for _, icon := range inventory {
 					_ = Icons(icon)
 				}
-			} else {
-				dataURIs.mu.Lock()
-				dataURIs.values = nil
-				dataURIs.mu.Unlock()
 			}
 
 			batch := make([][]mcp.Icon, len(inventory))
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
+				if !warm {
+					b.StopTimer()
+					dataURIs.mu.Lock()
+					dataURIs.values = nil
+					dataURIs.mu.Unlock()
+					b.StartTimer()
+				}
 				for index, icon := range inventory {
 					batch[index] = Icons(icon)
 				}

--- a/pkg/octicons/octicons_test.go
+++ b/pkg/octicons/octicons_test.go
@@ -1,7 +1,9 @@
 package octicons
 
 import (
+	"io/fs"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -53,6 +55,65 @@ func TestDataURI(t *testing.T) {
 	}
 }
 
+func TestDataURIForEveryEmbeddedIcon(t *testing.T) {
+	paths, err := fs.Glob(iconsFS, "icons/*.png")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, paths)
+
+	for _, path := range paths {
+		filename := strings.TrimSuffix(strings.TrimPrefix(path, "icons/"), ".png")
+		separator := strings.LastIndexByte(filename, '-')
+		if separator <= 0 {
+			t.Errorf("cannot parse embedded icon path %q", path)
+			continue
+		}
+		name := filename[:separator]
+		theme := Theme(filename[separator+1:])
+		t.Run(filename, func(t *testing.T) {
+			assert.True(t, strings.HasPrefix(DataURI(name, theme), "data:image/png;base64,"))
+		})
+	}
+}
+
+func TestDataURICacheOnlyStoresSuccessfulReads(t *testing.T) {
+	var cache dataURICache
+	missingKey := dataURIKey{name: "nonexistent-icon", theme: ThemeLight}
+
+	assert.Empty(t, cache.load(missingKey.name, missingKey.theme))
+	assert.Nil(t, cache.values, "missing icons must not initialize the cache")
+	_, found := cache.values[missingKey]
+	assert.False(t, found, "missing icons must not be cached")
+
+	validKey := dataURIKey{name: "repo", theme: ThemeLight}
+	assert.NotEmpty(t, cache.load(validKey.name, validKey.theme))
+	_, found = cache.values[validKey]
+	assert.True(t, found, "successful reads should be cached")
+}
+
+func TestDataURICacheConcurrentFirstUse(t *testing.T) {
+	var cache dataURICache
+	want := readDataURI("repo", ThemeLight)
+	assert.NotEmpty(t, want)
+
+	const workers = 64
+	start := make(chan struct{})
+	results := make(chan string, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			<-start
+			results <- cache.load("repo", ThemeLight)
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		assert.Equal(t, want, result)
+	}
+}
+
 func TestIcons(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -97,6 +158,23 @@ func TestIcons(t *testing.T) {
 			assert.Equal(t, mcp.IconThemeDark, result[1].Theme)
 		})
 	}
+}
+
+func TestIconsReturnsFreshSlice(t *testing.T) {
+	lightSource := DataURI("repo", ThemeLight)
+	darkSource := DataURI("repo", ThemeDark)
+
+	icons := Icons("repo")
+	icons[0] = mcp.Icon{}
+	icons[1].Source = "mutated"
+
+	fresh := Icons("repo")
+	assert.Equal(t, lightSource, fresh[0].Source)
+	assert.Equal(t, darkSource, fresh[1].Source)
+	assert.Equal(t, "image/png", fresh[0].MIMEType)
+	assert.Equal(t, "image/png", fresh[1].MIMEType)
+	assert.Equal(t, mcp.IconThemeLight, fresh[0].Theme)
+	assert.Equal(t, mcp.IconThemeDark, fresh[1].Theme)
 }
 
 func TestThemeConstants(t *testing.T) {


### PR DESCRIPTION

## Summary

Cache successful embedded Octicon data-URI reads on first use so repeated stateless server and tool registration no longer rereads and base64-encodes the same PNGs. Missing lookups remain uncached, and every `Icons` call still returns a fresh mutable slice.

## Why

Fixes #2850

Repeated all-tool registration currently allocates a median `193,085 B/op` and `527 allocs/op` for the 31 required icons after warmup. The same process may rebuild this inventory for multiple stateless HTTP requests.

## What changed

- Add a race-safe, on-demand cache for successful `(name, theme)` `DataURI` reads.
- Preserve lookup for every embedded PNG, including files not listed in `required_icons.txt`.
- Add missing-lookup, all-embedded-file, mutation-isolation, and concurrent-first-use tests.
- Add reproducible cold and warm benchmarks for one-icon and default inventories.

## Performance

| Inventory | State | Main B/op | This PR B/op | Main allocs/op | This PR allocs/op |
| --- | --- | ---: | ---: | ---: | ---: |
| 31 icons | first registration | 240,464 | 247,080 | 534 | 538 |
| 31 icons | warm registration | 193,085 | 4,464 | 527 | 31 |
| 1 icon | first registration | 53,592 | 60,208 | 23 | 27 |
| 1 icon | warm registration | 4,160 | 144 | 17 | 1 |

For the default inventory, warm allocation bytes fall by `97.69%` and allocation count falls by `94.12%`. The disclosed cold cost is `+6,616 B` and `+4 allocations` while the cache is populated. No icon is read or encoded in `init()`.

Supplementary autoresearch: [20-step public dashboard](https://dashboard.weco.ai/share/fjAWu5mPOUVfukNm4FzIQSavKqxRrGtu).

## MCP impact

- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)

- Not applicable; this does not change tool schemas or behavior.

## Security / limits

- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

Only embedded PNG data is cached. Missing lookups are not retained. With all current variants used, retained data-URI payload is `46,840` bytes plus bounded map overhead.

## Tool renaming

- [ ] I am renaming tools as part of this PR
- [x] I am not renaming tools as part of this PR

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`
- [x] `go test -race ./...`
- [x] Strict cold/warm evaluator with concurrent-first-use race coverage
- [x] `git diff --check`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
