### PR TITLE
fix: set DestructiveHint to false for notification subscription tools

### DIFF
--- a/pkg/github/notifications.go
+++ b/pkg/github/notifications.go
@@ -412,9 +412,10 @@ func ManageNotificationSubscription(t translations.TranslationHelperFunc) invent
 		mcp.Tool{
 			Name:        "manage_notification_subscription",
 			Description: t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a notification subscription: ignore, watch, or delete a notification thread subscription."),
-			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
-				ReadOnlyHint: false,
+		Annotations: &mcp.ToolAnnotations{
+				Title:           t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(false),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
@@ -508,9 +509,10 @@ func ManageRepositoryNotificationSubscription(t translations.TranslationHelperFu
 		mcp.Tool{
 			Name:        "manage_repository_notification_subscription",
 			Description: t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a repository notification subscription: ignore, watch, or delete repository notifications subscription for the provided repository."),
-			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
-				ReadOnlyHint: false,
+		Annotations: &mcp.ToolAnnotations{
+				Title:           t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(false),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",


### PR DESCRIPTION
## Summary

Under MCP schema 2025-06-18, an omitted `DestructiveHint` defaults to `true`. Both `manage_notification_subscription` and `manage_repository_notification_subscription` only modify the caller's own subscription preferences — they do not modify thread or repository content — so they should be marked non-destructive.

## Changes

```diff
 Annotations: &mcp.ToolAnnotations{
-    Title:        t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", ...),
-    ReadOnlyHint: false,
+    Title:           t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", ...),
+    ReadOnlyHint:    false,
+    DestructiveHint: jsonschema.Ptr(false),
 },
```

Same change applied to both `ManageNotificationSubscription` and `ManageRepositoryNotificationSubscription` in `pkg/github/notifications.go`.

This follows the existing pattern used by other non-destructive write tools like the issue tools in `pkg/github/issues_granular.go`.

Fixes #2841
