### PR TITLE
Enable fields param in Insiders mode

### DIFF
--- a/docs/insiders-features.md
+++ b/docs/insiders-features.md
@@ -133,6 +133,96 @@ The list below is generated from the Go source. It covers tool **inventory and s
     - 'blocked_by' - the subject issue is blocked by the related issue.
     - 'blocking' - the subject issue blocks the related issue. (string, required)
 
+### `fields_param`
+
+- **get_file_contents** - Get file or directory contents
+  - **Required OAuth Scopes**: `repo`
+  - `fields`: Subset of fields to return for each entry when the path is a directory. If omitted, all fields are returned. Ignored when the path is a single file. Use this to reduce response size when listing directories and you only need specific fields, e.g. just 'name' and 'type'. (string[], optional)
+  - `owner`: Repository owner (username or organization) (string, required)
+  - `path`: Path to file/directory (string, optional)
+  - `ref`: Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head` (string, optional)
+  - `repo`: Repository name (string, required)
+  - `sha`: Accepts optional commit SHA. If specified, it will be used instead of ref (string, optional)
+
+- **list_commits** - List commits
+  - **Required OAuth Scopes**: `repo`
+  - `author`: Author username or email address to filter commits by (string, optional)
+  - `fields`: Subset of fields to return for each commit. If omitted, all fields are returned. Use this to reduce response size when you only need specific fields, e.g. just 'sha' and 'html_url'. (string[], optional)
+  - `owner`: Repository owner (string, required)
+  - `page`: Page number for pagination (min 1) (number, optional)
+  - `path`: Only commits containing this file path will be returned (string, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `repo`: Repository name (string, required)
+  - `sha`: Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA. (string, optional)
+  - `since`: Only commits after this date will be returned (ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DD) (string, optional)
+  - `until`: Only commits before this date will be returned (ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DD) (string, optional)
+
+- **list_issues** - List issues
+  - **Required OAuth Scopes**: `repo`
+  - `after`: Cursor for pagination. Use the cursor from the previous response. (string, optional)
+  - `direction`: Order direction. If provided, the 'orderBy' also needs to be provided. (string, optional)
+  - `field_filters`: Filter by custom issue field values. Each entry takes a field_name and a value; the server looks up the field and coerces the value to its type (single-select option name, text, number, or YYYY-MM-DD date). (object[], optional)
+  - `fields`: Subset of fields to return for each issue. If omitted, all fields are returned. Use this to reduce response size when you only need specific fields; omitting 'body' and 'field_values' in particular drops the largest per-result data. (string[], optional)
+  - `labels`: Filter by labels (string[], optional)
+  - `orderBy`: Order issues by field. If provided, the 'direction' also needs to be provided. (string, optional)
+  - `owner`: Repository owner (string, required)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `repo`: Repository name (string, required)
+  - `since`: Filter by date (ISO 8601 timestamp) (string, optional)
+  - `state`: Filter by state, by default both open and closed issues are returned when not provided (string, optional)
+
+- **list_pull_requests** - List pull requests
+  - **Required OAuth Scopes**: `repo`
+  - `base`: Filter by base branch (string, optional)
+  - `direction`: Sort direction (string, optional)
+  - `fields`: Subset of fields to return for each pull request. If omitted, all fields are returned. Use this to reduce response size when you only need specific fields; omitting 'body' in particular drops the largest per-result data. (string[], optional)
+  - `head`: Filter by head user/org and branch (string, optional)
+  - `owner`: Repository owner (string, required)
+  - `page`: Page number for pagination (min 1) (number, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `repo`: Repository name (string, required)
+  - `sort`: Sort by (string, optional)
+  - `state`: Filter by state (string, optional)
+
+- **list_releases** - List releases
+  - **Required OAuth Scopes**: `repo`
+  - `fields`: Subset of fields to return for each release. If omitted, all fields are returned. Use this to reduce response size when you only need specific fields; omitting 'body' in particular drops the largest per-release data. (string[], optional)
+  - `owner`: Repository owner (string, required)
+  - `page`: Page number for pagination (min 1) (number, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `repo`: Repository name (string, required)
+
+- **search_code** - Search code
+  - **Required OAuth Scopes**: `repo`
+  - `fields`: Subset of fields to return for each code search result. If omitted, all fields are returned. Use this to reduce response size when you only need specific fields; omitting 'repository' and 'text_matches' in particular drops the largest per-result data. (string[], optional)
+  - `order`: Sort order for results (string, optional)
+  - `page`: Page number for pagination (min 1) (number, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `query`: Search query (GitHub code search REST). Implicit AND between terms; supports `OR`, `NOT`, and `"quoted phrase"` for exact match. Qualifiers: `repo:owner/repo`, `org:`, `user:`, `language:`, `path:dir` (prefix match), `filename:exact.ext`, `extension:`, `in:file`, `in:path`, `size:`, `is:archived`, `is:fork`. Max 256 chars. Examples: `WithContext language:go org:github`; `"package main" repo:o/r`; `func extension:go path:cmd repo:o/r`; `NOT TODO language:go repo:o/r`. (string, required)
+  - `sort`: Sort field ('indexed' only) (string, optional)
+
+- **search_issues** - Search issues
+  - **Required OAuth Scopes**: `repo`
+  - `fields`: Subset of fields to return for each issue result. If omitted, all fields are returned. Use this to reduce response size when you only need specific fields; omitting 'body', 'reactions', and 'labels' in particular drops the largest per-result data. (string[], optional)
+  - `order`: Sort order (string, optional)
+  - `owner`: Optional repository owner. If provided with repo, only issues for this repository are listed. (string, optional)
+  - `page`: Page number for pagination (min 1) (number, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `query`: Search query using GitHub issues search syntax (string, required)
+  - `repo`: Optional repository name. If provided with owner, only issues for this repository are listed. (string, optional)
+  - `sort`: Sort field by number of matches of categories, defaults to best match (string, optional)
+
+- **search_pull_requests** - Search pull requests
+  - **Required OAuth Scopes**: `repo`
+  - `fields`: Subset of fields to return for each pull request result. If omitted, all fields are returned. Use this to reduce response size when you only need specific fields; omitting 'body', 'reactions', and 'labels' in particular drops the largest per-result data. (string[], optional)
+  - `order`: Sort order (string, optional)
+  - `owner`: Optional repository owner. If provided with repo, only pull requests for this repository are listed. (string, optional)
+  - `page`: Page number for pagination (min 1) (number, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `query`: Search query using GitHub pull request search syntax (string, required)
+  - `repo`: Optional repository name. If provided with owner, only pull requests for this repository are listed. (string, optional)
+  - `sort`: Sort field by number of matches of categories, defaults to best match (string, optional)
+
 <!-- END AUTOMATED INSIDERS TOOLS -->
 
 ---

--- a/pkg/github/feature_flags.go
+++ b/pkg/github/feature_flags.go
@@ -55,6 +55,7 @@ var InsidersFeatureFlags = []string{
 	FeatureFlagCSVOutput,
 	FeatureFlagFileBlame,
 	FeatureFlagIssueDependencies,
+	FeatureFlagFieldsParam,
 }
 
 // FeatureFlags defines runtime feature toggles that adjust tool behavior.

--- a/pkg/github/feature_flags_test.go
+++ b/pkg/github/feature_flags_test.go
@@ -156,10 +156,26 @@ func TestResolveFeatureFlags(t *testing.T) {
 			expectedFlags:   []string{MCPAppsFeatureFlag},
 		},
 		{
+			name:            "fields param is not enabled by default",
+			enabledFeatures: nil,
+			unexpectedFlags: []string{FeatureFlagFieldsParam},
+		},
+		{
+			name:            "fields param can be directly enabled",
+			enabledFeatures: []string{FeatureFlagFieldsParam},
+			expectedFlags:   []string{FeatureFlagFieldsParam},
+		},
+		{
 			name:            "insiders mode enables insiders flags",
 			enabledFeatures: nil,
 			insidersMode:    true,
 			expectedFlags:   InsidersFeatureFlags,
+		},
+		{
+			name:            "insiders mode enables fields param",
+			enabledFeatures: nil,
+			insidersMode:    true,
+			expectedFlags:   []string{FeatureFlagFieldsParam},
 		},
 		{
 			name:            "insiders mode does not auto-enable ifc labels",


### PR DESCRIPTION
## Summary

Enable the `fields_param` feature flag automatically in Insiders mode while preserving direct opt-in through the existing feature allowlist.

## Why

The response-filtering parameter introduced in #2775 and #2810 is experimental, so it should be available to Insiders users without changing the standard server's default tool schemas.

No linked issue.

## What changed

- Added `FeatureFlagFieldsParam` to `InsidersFeatureFlags`.
- Added coverage for default-off, direct opt-in, and Insiders resolution behavior.
- Regenerated the Insiders feature documentation with the affected tool schema deltas.

## MCP impact

- [ ] No tool or API changes
- [x] Tool schema or behavior changed - Insiders mode now advertises the existing `fields` parameter on supported tools.
- [ ] New tool added

## Prompts tested (tool changes only)

- N/A - existing tool behavior is unchanged; feature flag resolution is covered by automated tests.

## Security / limits

- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [x] Data exposure, filtering, or token/size limits considered - filtering behavior is unchanged; this only enables the existing response-size feature for Insiders.

## Tool renaming

- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [x] Updated (README / docs / examples)
