### PR TITLE
feat(http): add --authorization-server flag to override OAuth AS URL

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -180,6 +180,7 @@ var (
 				ListenHost:           viper.GetString("listen-host"),
 				BaseURL:              viper.GetString("base-url"),
 				ResourcePath:         viper.GetString("base-path"),
+				AuthorizationServer:  viper.GetString("authorization-server"),
 				ExportTranslations:   viper.GetBool("export-translations"),
 				EnableCommandLogging: viper.GetBool("enable-command-logging"),
 				LogFilePath:          viper.GetString("log-file"),
@@ -235,6 +236,7 @@ func init() {
 	httpCmd.Flags().String("listen-host", "", "Host the HTTP server binds to (e.g. 127.0.0.1). Empty binds to all interfaces.")
 	httpCmd.Flags().String("base-url", "", "Base URL where this server is publicly accessible (for OAuth resource metadata)")
 	httpCmd.Flags().String("base-path", "", "Externally visible base path for the HTTP server (for OAuth resource metadata)")
+	httpCmd.Flags().String("authorization-server", "", "Override the authorization server URL in OAuth resource metadata. Useful when deploying behind an OAuth proxy (e.g. for GHES). Env: GITHUB_AUTHORIZATION_SERVER")
 	httpCmd.Flags().Bool("scope-challenge", false, "Enable OAuth scope challenge responses")
 	httpCmd.Flags().Bool("trust-proxy-headers", false, "Honor X-Forwarded-Host and X-Forwarded-Proto when constructing OAuth resource metadata URLs. Only enable when the server is deployed behind a trusted proxy that sets these headers. Ignored when --base-url is set.")
 
@@ -260,6 +262,7 @@ func init() {
 	_ = viper.BindPFlag("listen-host", httpCmd.Flags().Lookup("listen-host"))
 	_ = viper.BindPFlag("base-url", httpCmd.Flags().Lookup("base-url"))
 	_ = viper.BindPFlag("base-path", httpCmd.Flags().Lookup("base-path"))
+	_ = viper.BindPFlag("authorization-server", httpCmd.Flags().Lookup("authorization-server"))
 	_ = viper.BindPFlag("scope-challenge", httpCmd.Flags().Lookup("scope-challenge"))
 	_ = viper.BindPFlag("trust-proxy-headers", httpCmd.Flags().Lookup("trust-proxy-headers"))
 	// Add subcommands

--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -203,6 +203,7 @@ var (
 				ListenHost:           viper.GetString("listen-host"),
 				BaseURL:              viper.GetString("base-url"),
 				ResourcePath:         viper.GetString("base-path"),
+				AuthorizationServer:  viper.GetString("authorization-server"),
 				ExportTranslations:   viper.GetBool("export-translations"),
 				EnableCommandLogging: viper.GetBool("enable-command-logging"),
 				LogFilePath:          viper.GetString("log-file"),
@@ -264,6 +265,7 @@ func init() {
 	httpCmd.Flags().String("listen-host", "", "Host the HTTP server binds to (e.g. 127.0.0.1). Empty binds to all interfaces.")
 	httpCmd.Flags().String("base-url", "", "Base URL where this server is publicly accessible (for OAuth resource metadata)")
 	httpCmd.Flags().String("base-path", "", "Externally visible base path for the HTTP server (for OAuth resource metadata)")
+	httpCmd.Flags().String("authorization-server", "", "Override the authorization server URL in OAuth resource metadata. Useful when deploying behind an OAuth proxy (e.g. for GHES). Env: GITHUB_AUTHORIZATION_SERVER")
 	httpCmd.Flags().Bool("scope-challenge", false, "Enable OAuth scope challenge responses")
 	httpCmd.Flags().Bool("trust-proxy-headers", false, "Honor X-Forwarded-Host and X-Forwarded-Proto when constructing OAuth resource metadata URLs. Only enable when the server is deployed behind a trusted proxy that sets these headers. Ignored when --base-url is set.")
 
@@ -292,6 +294,7 @@ func init() {
 	_ = viper.BindPFlag("listen-host", httpCmd.Flags().Lookup("listen-host"))
 	_ = viper.BindPFlag("base-url", httpCmd.Flags().Lookup("base-url"))
 	_ = viper.BindPFlag("base-path", httpCmd.Flags().Lookup("base-path"))
+	_ = viper.BindPFlag("authorization-server", httpCmd.Flags().Lookup("authorization-server"))
 	_ = viper.BindPFlag("scope-challenge", httpCmd.Flags().Lookup("scope-challenge"))
 	_ = viper.BindPFlag("trust-proxy-headers", httpCmd.Flags().Lookup("trust-proxy-headers"))
 	// Add subcommands

--- a/cmd/github-mcp-server/main_test.go
+++ b/cmd/github-mcp-server/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +40,20 @@ func TestLoadAppPrivateKey(t *testing.T) {
 func TestGitHubAppFlagsAreStdioOnly(t *testing.T) {
 	assert.NotNil(t, stdioCmd.Flags().Lookup("app-id"))
 	assert.Nil(t, httpCmd.Flags().Lookup("app-id"))
+}
+
+func TestAuthorizationServerConfigurationIsHTTPOnly(t *testing.T) {
+	flag := httpCmd.Flags().Lookup("authorization-server")
+	require.NotNil(t, flag)
+	assert.Empty(t, flag.DefValue)
+	assert.Nil(t, stdioCmd.Flags().Lookup("authorization-server"))
+
+	t.Setenv("GITHUB_AUTHORIZATION_SERVER", "")
+	initConfig()
+	assert.Empty(t, viper.GetString("authorization-server"))
+
+	t.Setenv("GITHUB_AUTHORIZATION_SERVER", "https://oauth-proxy.example.com")
+	assert.Equal(t, "https://oauth-proxy.example.com", viper.GetString("authorization-server"))
 }
 
 func TestWriteToolDocScopeSemantics(t *testing.T) {

--- a/docs/streamable-http.md
+++ b/docs/streamable-http.md
@@ -71,6 +71,31 @@ github-mcp-server http --trust-proxy-headers
 
 Equivalent environment variable: `GITHUB_TRUST_PROXY_HEADERS=1`. Only enable this when the upstream proxy is trusted to set or strip these headers; otherwise prefer `--base-url`. When `--base-url` is set, it always takes precedence and `--trust-proxy-headers` has no effect.
 
+### With an OAuth Proxy (GHES / non-standard authorization server)
+
+When deploying against GitHub Enterprise Server, GHES does not natively support the OAuth extensions required by MCP (RFC 8414 metadata discovery, RFC 7591 Dynamic Client Registration, PKCE). In this case you can run a separate OAuth proxy that implements the MCP OAuth spec and forwards authentication to GHES. Use `--authorization-server` to advertise the proxy's URL in the protected resource metadata instead of the one derived from `--gh-host`:
+
+```bash
+github-mcp-server http \
+  --gh-host https://github.example.com \
+  --base-url https://mcp.example.com \
+  --authorization-server https://mcp.example.com/oauth-proxy
+```
+
+The `authorization_servers` field in the protected resource metadata will then point at your proxy:
+
+```json
+{
+  "resource": "https://mcp.example.com",
+  "authorization_servers": [
+    "https://mcp.example.com/oauth-proxy"
+  ],
+  ...
+}
+```
+
+Equivalent environment variable: `GITHUB_AUTHORIZATION_SERVER=https://mcp.example.com/oauth-proxy`.
+
 ## Client Configuration
 
 ### Using OAuth Authentication

--- a/docs/streamable-http.md
+++ b/docs/streamable-http.md
@@ -92,6 +92,31 @@ github-mcp-server http --trust-proxy-headers
 
 Equivalent environment variable: `GITHUB_TRUST_PROXY_HEADERS=1`. Only enable this when the upstream proxy is trusted to set or strip these headers; otherwise prefer `--base-url`. When `--base-url` is set, it always takes precedence and `--trust-proxy-headers` has no effect.
 
+### With an OAuth Proxy (GHES / non-standard authorization server)
+
+When deploying against GitHub Enterprise Server, GHES does not natively support the OAuth extensions required by MCP (RFC 8414 metadata discovery, RFC 7591 Dynamic Client Registration, PKCE). In this case you can run a separate OAuth proxy that implements the MCP OAuth spec and forwards authentication to GHES. Use `--authorization-server` to advertise the proxy's URL in the protected resource metadata instead of the one derived from `--gh-host`:
+
+```bash
+github-mcp-server http \
+  --gh-host https://github.example.com \
+  --base-url https://mcp.example.com \
+  --authorization-server https://mcp.example.com/oauth-proxy
+```
+
+The `authorization_servers` field in the protected resource metadata will then point at your proxy:
+
+```json
+{
+  "resource": "https://mcp.example.com",
+  "authorization_servers": [
+    "https://mcp.example.com/oauth-proxy"
+  ],
+  ...
+}
+```
+
+Equivalent environment variable: `GITHUB_AUTHORIZATION_SERVER=https://mcp.example.com/oauth-proxy`.
+
 ## Client Configuration
 
 ### Using OAuth Authentication

--- a/docs/streamable-http.md
+++ b/docs/streamable-http.md
@@ -117,6 +117,8 @@ The `authorization_servers` field in the protected resource metadata will then p
 
 Equivalent environment variable: `GITHUB_AUTHORIZATION_SERVER=https://mcp.example.com/oauth-proxy`.
 
+When neither the flag nor environment variable is set, the server preserves the existing behavior and derives the authorization server from `--gh-host`. The override only changes the URL advertised in OAuth protected resource metadata; it does not change token validation or the GitHub API host.
+
 ## Client Configuration
 
 ### Using OAuth Authentication

--- a/pkg/http/oauth/oauth_test.go
+++ b/pkg/http/oauth/oauth_test.go
@@ -1,10 +1,12 @@
 package oauth
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/github/github-mcp-server/pkg/http/headers"
@@ -17,6 +19,16 @@ import (
 var (
 	defaultAuthorizationServer = "https://github.com/login/oauth"
 )
+
+type countingAPIHostResolver struct {
+	utils.APIHostResolver
+	authorizationServerURLCalls int
+}
+
+func (r *countingAPIHostResolver) AuthorizationServerURL(ctx context.Context) (*url.URL, error) {
+	r.authorizationServerURLCalls++
+	return r.APIHostResolver.AuthorizationServerURL(ctx)
+}
 
 func TestNewAuthHandler(t *testing.T) {
 	t.Parallel()
@@ -729,6 +741,7 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			countingAPIHost := &countingAPIHostResolver{APIHostResolver: apiHost}
 
 			config := tc.oauthConfig
 			if config == nil {
@@ -736,7 +749,7 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 			}
 			config.BaseURL = tc.host
 
-			handler, err := NewAuthHandler(config, apiHost)
+			handler, err := NewAuthHandler(config, countingAPIHost)
 			require.NoError(t, err)
 
 			router := chi.NewRouter()
@@ -767,6 +780,11 @@ func TestAPIHostResolver_AuthorizationServerURL(t *testing.T) {
 			require.True(t, ok)
 			require.Len(t, responseAuthServers, 1)
 			assert.Equal(t, tc.expectedURL, responseAuthServers[0])
+			if config.AuthorizationServer == "" {
+				assert.Equal(t, 1, countingAPIHost.authorizationServerURLCalls)
+			} else {
+				assert.Zero(t, countingAPIHost.authorizationServerURLCalls)
+			}
 		})
 	}
 }

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -49,6 +49,13 @@ type ServerConfig struct {
 	// This is used to restore the original path when a proxy strips a base path before forwarding.
 	ResourcePath string
 
+	// AuthorizationServer overrides the authorization server URL advertised in the
+	// OAuth Protected Resource Metadata (/.well-known/oauth-protected-resource).
+	// When set, this URL is used instead of the one derived from the GitHub host.
+	// Useful when deploying behind an OAuth proxy (e.g. for GHES, which does not
+	// natively support RFC 8414 / RFC 7591 / PKCE).
+	AuthorizationServer string
+
 	// TrustProxyHeaders indicates whether X-Forwarded-Host and X-Forwarded-Proto
 	// should be honored when constructing OAuth resource metadata URLs. Only
 	// enable this when the server is deployed behind a trusted proxy that sets
@@ -163,9 +170,10 @@ func RunHTTPServer(cfg ServerConfig) error {
 
 	// Register OAuth protected resource metadata endpoints
 	oauthCfg := &oauth.Config{
-		BaseURL:           cfg.BaseURL,
-		ResourcePath:      cfg.ResourcePath,
-		TrustProxyHeaders: cfg.TrustProxyHeaders,
+		BaseURL:             cfg.BaseURL,
+		ResourcePath:        cfg.ResourcePath,
+		TrustProxyHeaders:   cfg.TrustProxyHeaders,
+		AuthorizationServer: cfg.AuthorizationServer,
 	}
 
 	serverOptions := []HandlerOption{}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -197,12 +197,7 @@ func RunHTTPServer(cfg ServerConfig) error {
 	}
 
 	// Register OAuth protected resource metadata endpoints
-	oauthCfg := &oauth.Config{
-		BaseURL:             cfg.BaseURL,
-		ResourcePath:        cfg.ResourcePath,
-		TrustProxyHeaders:   cfg.TrustProxyHeaders,
-		AuthorizationServer: cfg.AuthorizationServer,
-	}
+	oauthCfg := newOAuthConfig(cfg)
 
 	serverOptions := []HandlerOption{
 		WithInventoryFactory(inventoryFactory),
@@ -262,6 +257,15 @@ func RunHTTPServer(cfg ServerConfig) error {
 
 	logger.Info("server stopped gracefully")
 	return nil
+}
+
+func newOAuthConfig(cfg ServerConfig) *oauth.Config {
+	return &oauth.Config{
+		BaseURL:             cfg.BaseURL,
+		ResourcePath:        cfg.ResourcePath,
+		TrustProxyHeaders:   cfg.TrustProxyHeaders,
+		AuthorizationServer: cfg.AuthorizationServer,
+	}
 }
 
 // resolveListenAddress returns the address string passed to http.Server.

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -53,6 +53,13 @@ type ServerConfig struct {
 	// This is used to restore the original path when a proxy strips a base path before forwarding.
 	ResourcePath string
 
+	// AuthorizationServer overrides the authorization server URL advertised in the
+	// OAuth Protected Resource Metadata (/.well-known/oauth-protected-resource).
+	// When set, this URL is used instead of the one derived from the GitHub host.
+	// Useful when deploying behind an OAuth proxy (e.g. for GHES, which does not
+	// natively support RFC 8414 / RFC 7591 / PKCE).
+	AuthorizationServer string
+
 	// TrustProxyHeaders indicates whether X-Forwarded-Host and X-Forwarded-Proto
 	// should be honored when constructing OAuth resource metadata URLs. Only
 	// enable this when the server is deployed behind a trusted proxy that sets
@@ -191,9 +198,10 @@ func RunHTTPServer(cfg ServerConfig) error {
 
 	// Register OAuth protected resource metadata endpoints
 	oauthCfg := &oauth.Config{
-		BaseURL:           cfg.BaseURL,
-		ResourcePath:      cfg.ResourcePath,
-		TrustProxyHeaders: cfg.TrustProxyHeaders,
+		BaseURL:             cfg.BaseURL,
+		ResourcePath:        cfg.ResourcePath,
+		TrustProxyHeaders:   cfg.TrustProxyHeaders,
+		AuthorizationServer: cfg.AuthorizationServer,
 	}
 
 	serverOptions := []HandlerOption{

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -9,6 +9,7 @@ import (
 
 	ghcontext "github.com/github/github-mcp-server/pkg/context"
 	"github.com/github/github-mcp-server/pkg/github"
+	"github.com/github/github-mcp-server/pkg/http/oauth"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,39 @@ func TestRunHTTPServerRejectsInvalidStaticTools(t *testing.T) {
 
 			require.ErrorIs(t, err, inventory.ErrUnknownTools)
 			assert.ErrorContains(t, err, "failed to build inventory")
+		})
+	}
+}
+
+func TestNewOAuthConfig(t *testing.T) {
+	tests := []struct {
+		name                string
+		authorizationServer string
+	}{
+		{
+			name: "unset preserves host-derived authorization server",
+		},
+		{
+			name:                "explicit override is propagated",
+			authorizationServer: "https://oauth-proxy.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newOAuthConfig(ServerConfig{
+				BaseURL:             "https://mcp.example.com",
+				ResourcePath:        "/mcp",
+				TrustProxyHeaders:   true,
+				AuthorizationServer: tt.authorizationServer,
+			})
+
+			assert.Equal(t, &oauth.Config{
+				BaseURL:             "https://mcp.example.com",
+				ResourcePath:        "/mcp",
+				TrustProxyHeaders:   true,
+				AuthorizationServer: tt.authorizationServer,
+			}, cfg)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `--authorization-server` CLI flag (and `GITHUB_AUTHORIZATION_SERVER` env var) to the `http` subcommand, allowing operators to override the authorization server URL advertised in the OAuth Protected Resource Metadata (`/.well-known/oauth-protected-resource`).

## Why

When deploying the MCP server against GitHub Enterprise Server, GHES does not natively support RFC 8414, RFC 7591, or PKCE — making direct MCP OAuth impossible. A common solution is to deploy a thin OAuth proxy in front of GHES that implements the MCP OAuth spec. However, the MCP server always derives `authorization_servers` from `GITHUB_HOST`, so clients are pointed at GHES directly instead of the proxy. Without this flag, operators must intercept `/.well-known/oauth-protected-resource` at the ingress layer as a workaround.

The `AuthorizationServer` field already exists in `pkg/http/oauth/oauth.Config` with the conditional in place — it simply wasn't reachable from any configuration surface.

## What changed

- Added `AuthorizationServer string` field to `pkg/http/server.go` `ServerConfig`
- Wired `cfg.AuthorizationServer` into the `oauth.Config` struct in `RunHTTPServer`
- Added `--authorization-server` flag on `httpCmd` in `cmd/github-mcp-server/main.go`
- Added viper binding so `GITHUB_AUTHORIZATION_SERVER` env var works automatically

## MCP impact

- [x] No tool or API changes — only affects OAuth metadata discovery; no tools, schemas, or API behavior changed

## Prompts tested (tool changes only)

- N/A

## Security / limits

- [x] Auth / permissions considered — when set, this flag redirects clients to a different authorization server. Operators are responsible for ensuring the configured URL points to a trusted proxy. No change to token validation or API access control.

## Tool renaming

- [x] I am not renaming tools as part of this PR

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [x] Updated (README / docs / examples)
