### PR TITLE
fix: list supported methods in unknown method errors

### DIFF
--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -397,7 +397,7 @@ Use this tool to list workflows in a repository, or list workflow runs, jobs, an
 				result, payload, err := listWorkflowArtifacts(ctx, client, owner, repo, resourceIDInt, pagination)
 				return attachIFC(result), payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: list_workflows, list_workflow_runs, list_workflow_jobs, list_workflow_run_artifacts", method)), nil, nil
 			}
 		},
 	)
@@ -519,7 +519,7 @@ Use this tool to get details about individual workflows, workflow runs, jobs, an
 				result, payload, err := getWorkflowRunLogsURL(ctx, client, owner, repo, resourceIDInt)
 				return attachIFC(result), payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: get_workflow, get_workflow_run, get_workflow_job, download_workflow_run_artifact, get_workflow_run_usage, get_workflow_run_logs_url", method)), nil, nil
 			}
 		},
 	)
@@ -636,7 +636,7 @@ func ActionsRunTrigger(t translations.TranslationHelperFunc) inventory.ServerToo
 			case actionsMethodDeleteWorkflowRunLogs:
 				return deleteWorkflowRunLogs(ctx, client, owner, repo, int64(runID))
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: run_workflow, rerun_workflow_run, rerun_failed_jobs, cancel_workflow_run, delete_workflow_run_logs", method)), nil, nil
 			}
 		},
 	)

--- a/pkg/github/issue_dependencies.go
+++ b/pkg/github/issue_dependencies.go
@@ -100,7 +100,7 @@ Options are:
 				result, err := GetIssueBlocking(ctx, client, owner, repo, issueNumber, opts)
 				return result, nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: get_blocked_by, get_blocking", method)), nil, nil
 			}
 		})
 	st.FeatureFlagEnable = FeatureFlagIssueDependencies
@@ -292,7 +292,7 @@ Options are:
 			method = strings.ToLower(method)
 			relationshipType = strings.ToLower(relationshipType)
 			if method != "add" && method != "remove" {
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: add, remove", method)), nil, nil
 			}
 			if relationshipType != "blocked_by" && relationshipType != "blocking" {
 				return utils.NewToolResultError(fmt.Sprintf("unknown type: %s", relationshipType)), nil, nil
@@ -373,7 +373,7 @@ func writeIssueDependency(ctx context.Context, client *github.Client, method str
 		}
 		return dependencyWriteResult("dependency removed", blockedIssue, blockingIssue, blocked, blocking), nil
 	default:
-		return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil
+		return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: add, remove", method)), nil
 	}
 }
 

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -707,7 +707,7 @@ func IssueRead(t translations.TranslationHelperFunc) inventory.ServerTool {
 				result, err := GetIssueLabels(ctx, gqlClient, owner, repo, issueNumber)
 				return attachIFC(result), nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: get, get_comments, get_sub_issues, get_parent, get_labels", method)), nil, nil
 			}
 		})
 }
@@ -1485,7 +1485,7 @@ func SubIssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 				result, err := ReprioritizeSubIssue(ctx, client, owner, repo, issueNumber, subIssueID, afterID, beforeID)
 				return result, nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: add, remove, reprioritize", method)), nil, nil
 			}
 		})
 	st.FeatureFlagDisable = []string{FeatureFlagIssuesGranular}

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -296,10 +296,10 @@ Use this tool to list projects for a user or organization, or list project field
 					result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelProjectContent(isPrivate))
 					return result, payload, err
 				default:
-					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: list_project_fields, list_project_items, list_project_status_updates", method)), nil, nil
 				}
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: list_projects, list_project_fields, list_project_items, list_project_status_updates", method)), nil, nil
 			}
 		},
 	)
@@ -483,7 +483,7 @@ Use this tool to get details about individual projects, project fields, and proj
 				}
 				return result, payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: get_project, get_project_field, get_project_item, get_project_status_update", method)), nil, nil
 			}
 		},
 	)
@@ -749,7 +749,7 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			case projectsMethodCreateIterationField:
 				return createIterationField(ctx, gqlClient, owner, ownerType, projectNumber, args)
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: add_project_item, update_project_item, delete_project_item, create_project_status_update, create_iteration_field, create_project", method)), nil, nil
 			}
 		},
 	)

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -155,7 +155,7 @@ Possible options:
 				result, err := GetPullRequestCheckRuns(ctx, client, owner, repo, pullNumber, pagination)
 				return attachIFC(result), nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: get, get_diff, get_status, get_files, get_commits, get_review_comments, get_reviews, get_comments, get_check_runs", method)), nil, nil
 			}
 		})
 }
@@ -1892,6 +1892,10 @@ Available methods:
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
+			if params.Method == "" {
+				return utils.NewToolResultError("missing required parameter: method. Supported methods are: create, submit_pending, delete_pending, resolve_thread, unresolve_thread"), nil, nil
+			}
+
 			// Given our owner, repo and PR number, lookup the GQL ID of the PR.
 			client, err := deps.GetGQLClient(ctx)
 			if err != nil {
@@ -1915,7 +1919,7 @@ Available methods:
 				result, err := ResolveReviewThread(ctx, client, params.ThreadID, false)
 				return result, nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", params.Method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: create, submit_pending, delete_pending, resolve_thread, unresolve_thread", params.Method)), nil, nil
 			}
 		})
 	st.FeatureFlagDisable = []string{FeatureFlagPullRequestsGranular}

--- a/pkg/github/ui_tools.go
+++ b/pkg/github/ui_tools.go
@@ -96,7 +96,7 @@ func UIGet(t translations.TranslationHelperFunc) inventory.ServerTool {
 			case "reviewers":
 				return uiGetReviewers(ctx, deps, args, owner)
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s. Supported methods are: labels, assignees, milestones, issue_types, branches, issue_fields, reviewers", method)), nil, nil
 			}
 		})
 	st.FeatureFlagEnable = MCPAppsFeatureFlag


### PR DESCRIPTION
## Summary

Fixes #2712

The consolidated method-dispatch tools returned a bare `unknown method: <value>` without listing valid methods, unlike `labels.go` which already says `Supported methods are: create, update, delete`. This makes the behavior inconsistent and unhelpful for callers.

## Changes

Appended the list of supported methods to every `unknown method` error across the method-dispatch tools:

| File | Tool(s) |
|---|---|
| `issues.go` | `issue_read`, sub-issue write |
| `issue_dependencies.go` | sub-issue read / write |
| `ui_tools.go` | `ui_get` |
| `pullrequests.go` | `pull_request_read`, `pull_request_review_write` |
| `projects.go` | projects list / get / write |
| `actions.go` | actions list / get / run |

Additionally, `pull_request_review_write` used `mapstructure.WeakDecode` and did **not** validate that `method` was provided, so omitting it produced a confusing `unknown method: ` (empty value) — which reads like a routing bug rather than a missing argument. Added an explicit check:

```go
if params.Method == "" {
    return utils.NewToolResultError("missing required parameter: method. Supported methods are: create, submit_pending, delete_pending, resolve_thread, unresolve_thread"), nil, nil
}
```

## Testing

All existing tests that assert on `unknown method` use `assert.Contains`, so the appended text preserves the existing substring matches — no test changes required. The new error messages are strict supersets of the previous ones.
