### PR TITLE
Paginate project item lookup across memberships

### DIFF
--- a/pkg/github/projects_resolver.go
+++ b/pkg/github/projects_resolver.go
@@ -271,18 +271,20 @@ func resolveProjectItemIDByIssueNumber(ctx context.Context, gqlClient *githubv4.
 		return 0, err
 	}
 
-	var query struct {
+	type projectItemsConnection struct {
+		Nodes []struct {
+			FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
+			Project        struct {
+				ID githubv4.ID
+			}
+		}
+		PageInfo PageInfoFragment
+	}
+
+	var firstPageQuery struct {
 		Repository struct {
 			Issue struct {
-				ProjectItems struct {
-					Nodes []struct {
-						FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
-						Project        struct {
-							ID githubv4.ID
-						}
-					}
-					PageInfo PageInfoFragment
-				} `graphql:"projectItems(first: 50, includeArchived: true)"`
+				ProjectItems projectItemsConnection `graphql:"projectItems(first: 50, includeArchived: true)"`
 			} `graphql:"issue(number: $issueNumber)"`
 		} `graphql:"repository(owner: $issueOwner, name: $issueRepo)"`
 	}
@@ -293,18 +295,38 @@ func resolveProjectItemIDByIssueNumber(ctx context.Context, gqlClient *githubv4.
 		"issueNumber": githubv4.Int(int32(issueNumber)), //nolint:gosec // Issue numbers are small
 	}
 
-	if err := gqlClient.Query(ctx, &query, vars); err != nil {
+	if err := gqlClient.Query(ctx, &firstPageQuery, vars); err != nil {
 		return 0, fmt.Errorf("failed to resolve project item for %s/%s#%d: %w", issueOwner, issueRepo, issueNumber, err)
 	}
 
-	for _, item := range query.Repository.Issue.ProjectItems.Nodes {
-		if item.Project.ID == projectID {
-			itemID, parseErr := parseInt64(string(item.FullDatabaseID))
-			if parseErr != nil {
-				return 0, fmt.Errorf("project item ID %q is not an integer: %w", string(item.FullDatabaseID), parseErr)
+	projectItems := firstPageQuery.Repository.Issue.ProjectItems
+	for {
+		for _, item := range projectItems.Nodes {
+			if item.Project.ID == projectID {
+				itemID, parseErr := parseInt64(string(item.FullDatabaseID))
+				if parseErr != nil {
+					return 0, fmt.Errorf("project item ID %q is not an integer: %w", string(item.FullDatabaseID), parseErr)
+				}
+				return itemID, nil
 			}
-			return itemID, nil
 		}
+
+		if !projectItems.PageInfo.HasNextPage {
+			break
+		}
+
+		var nextPageQuery struct {
+			Repository struct {
+				Issue struct {
+					ProjectItems projectItemsConnection `graphql:"projectItems(first: 50, after: $after, includeArchived: true)"`
+				} `graphql:"issue(number: $issueNumber)"`
+			} `graphql:"repository(owner: $issueOwner, name: $issueRepo)"`
+		}
+		vars["after"] = projectItems.PageInfo.EndCursor
+		if err := gqlClient.Query(ctx, &nextPageQuery, vars); err != nil {
+			return 0, fmt.Errorf("failed to resolve project item for %s/%s#%d: %w", issueOwner, issueRepo, issueNumber, err)
+		}
+		projectItems = nextPageQuery.Repository.Issue.ProjectItems
 	}
 
 	return 0, ghErrors.NewStructuredResolutionError(

--- a/pkg/github/projects_resolver_test.go
+++ b/pkg/github/projects_resolver_test.go
@@ -215,6 +215,32 @@ type resolveItemByIssueQuery struct {
 	} `graphql:"repository(owner: $issueOwner, name: $issueRepo)"`
 }
 
+type resolveItemByIssuePageQuery struct {
+	Repository struct {
+		Issue struct {
+			ProjectItems struct {
+				Nodes []struct {
+					FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
+					Project        struct {
+						ID githubv4.ID
+					}
+				}
+				PageInfo PageInfoFragment
+			} `graphql:"projectItems(first: 50, after: $after, includeArchived: true)"`
+		} `graphql:"issue(number: $issueNumber)"`
+	} `graphql:"repository(owner: $issueOwner, name: $issueRepo)"`
+}
+
+type requestCountingTransport struct {
+	inner http.RoundTripper
+	count int
+}
+
+func (t *requestCountingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.count++
+	return t.inner.RoundTrip(req)
+}
+
 func Test_ResolveProjectItemIDByIssueNumber_Success(t *testing.T) {
 	mocked := githubv4mock.NewMockedHTTPClient(
 		// project node id lookup (org)
@@ -265,6 +291,91 @@ func Test_ResolveProjectItemIDByIssueNumber_Success(t *testing.T) {
 								"hasPreviousPage": false,
 								"startCursor":     "",
 								"endCursor":       "",
+							},
+						},
+					},
+				},
+			}),
+		),
+	)
+	gql := githubv4.NewClient(mocked)
+
+	itemID, err := resolveProjectItemIDByIssueNumber(context.Background(), gql, "octo-org", "org", 1, "octo-issue-owner", "repo", 123)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4242), itemID)
+}
+
+func Test_ResolveProjectItemIDByIssueNumber_TargetOnSecondPage(t *testing.T) {
+	mocked := githubv4mock.NewMockedHTTPClient(
+		githubv4mock.NewQueryMatcher(
+			struct {
+				Organization struct {
+					ProjectV2 struct {
+						ID githubv4.ID
+					} `graphql:"projectV2(number: $projectNumber)"`
+				} `graphql:"organization(login: $owner)"`
+			}{},
+			map[string]any{
+				"owner":         githubv4.String("octo-org"),
+				"projectNumber": githubv4.Int(1),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{"id": "PVT_project1"},
+				},
+			}),
+		),
+		githubv4mock.NewQueryMatcher(
+			resolveItemByIssueQuery{},
+			map[string]any{
+				"issueOwner":  githubv4.String("octo-issue-owner"),
+				"issueRepo":   githubv4.String("repo"),
+				"issueNumber": githubv4.Int(123),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issue": map[string]any{
+						"projectItems": map[string]any{
+							"nodes": []any{
+								map[string]any{
+									"fullDatabaseId": "9999",
+									"project":        map[string]any{"id": "PVT_other"},
+								},
+							},
+							"pageInfo": map[string]any{
+								"hasNextPage":     true,
+								"hasPreviousPage": false,
+								"startCursor":     "first",
+								"endCursor":       "page-one",
+							},
+						},
+					},
+				},
+			}),
+		),
+		githubv4mock.NewQueryMatcher(
+			resolveItemByIssuePageQuery{},
+			map[string]any{
+				"issueOwner":  githubv4.String("octo-issue-owner"),
+				"issueRepo":   githubv4.String("repo"),
+				"issueNumber": githubv4.Int(123),
+				"after":       githubv4.String("page-one"),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issue": map[string]any{
+						"projectItems": map[string]any{
+							"nodes": []any{
+								map[string]any{
+									"fullDatabaseId": "4242",
+									"project":        map[string]any{"id": "PVT_project1"},
+								},
+							},
+							"pageInfo": map[string]any{
+								"hasNextPage":     false,
+								"hasPreviousPage": true,
+								"startCursor":     "page-two",
+								"endCursor":       "page-two",
 							},
 						},
 					},
@@ -340,6 +451,97 @@ func Test_ResolveProjectItemIDByIssueNumber_NotInProject(t *testing.T) {
 	assert.Equal(t, "item_not_in_project", msg["error"])
 }
 
+func Test_ResolveProjectItemIDByIssueNumber_NotInProjectAfterMultiplePages(t *testing.T) {
+	mocked := githubv4mock.NewMockedHTTPClient(
+		githubv4mock.NewQueryMatcher(
+			struct {
+				Organization struct {
+					ProjectV2 struct {
+						ID githubv4.ID
+					} `graphql:"projectV2(number: $projectNumber)"`
+				} `graphql:"organization(login: $owner)"`
+			}{},
+			map[string]any{
+				"owner":         githubv4.String("octo-org"),
+				"projectNumber": githubv4.Int(1),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{"id": "PVT_project1"},
+				},
+			}),
+		),
+		githubv4mock.NewQueryMatcher(
+			resolveItemByIssueQuery{},
+			map[string]any{
+				"issueOwner":  githubv4.String("octo-issue-owner"),
+				"issueRepo":   githubv4.String("repo"),
+				"issueNumber": githubv4.Int(123),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issue": map[string]any{
+						"projectItems": map[string]any{
+							"nodes": []any{
+								map[string]any{
+									"fullDatabaseId": "9999",
+									"project":        map[string]any{"id": "PVT_other"},
+								},
+							},
+							"pageInfo": map[string]any{
+								"hasNextPage":     true,
+								"hasPreviousPage": false,
+								"startCursor":     "first",
+								"endCursor":       "page-one",
+							},
+						},
+					},
+				},
+			}),
+		),
+		githubv4mock.NewQueryMatcher(
+			resolveItemByIssuePageQuery{},
+			map[string]any{
+				"issueOwner":  githubv4.String("octo-issue-owner"),
+				"issueRepo":   githubv4.String("repo"),
+				"issueNumber": githubv4.Int(123),
+				"after":       githubv4.String("page-one"),
+			},
+			githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{
+					"issue": map[string]any{
+						"projectItems": map[string]any{
+							"nodes": []any{
+								map[string]any{
+									"fullDatabaseId": "8888",
+									"project":        map[string]any{"id": "PVT_another"},
+								},
+							},
+							"pageInfo": map[string]any{
+								"hasNextPage":     false,
+								"hasPreviousPage": true,
+								"startCursor":     "page-two",
+								"endCursor":       "page-two",
+							},
+						},
+					},
+				},
+			}),
+		),
+	)
+	countingTransport := &requestCountingTransport{inner: mocked.Transport}
+	mocked.Transport = countingTransport
+	gql := githubv4.NewClient(mocked)
+
+	_, err := resolveProjectItemIDByIssueNumber(context.Background(), gql, "octo-org", "org", 1, "octo-issue-owner", "repo", 123)
+	require.Error(t, err)
+	assert.Equal(t, 3, countingTransport.count)
+
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal([]byte(err.Error()), &msg))
+	assert.Equal(t, "item_not_in_project", msg["error"])
+}
+
 func Test_ResolveFieldNamesToIDs_Success(t *testing.T) {
 	mocked := githubv4mock.NewMockedHTTPClient(
 		githubv4mock.NewQueryMatcher(
@@ -358,7 +560,7 @@ func Test_ResolveFieldNamesToIDs_Success(t *testing.T) {
 	assert.Equal(t, []int64{100, 200}, ids)
 }
 
-// Field and single-select option name matching is case-insensitive so agents passing lowercase 
+// Field and single-select option name matching is case-insensitive so agents passing lowercase
 // names like "status" or "in progress" resolve to "Status" and "In Progress" respectively.
 func Test_ResolveProjectFieldByName_CaseInsensitive(t *testing.T) {
 	mocked := githubv4mock.NewMockedHTTPClient(


### PR DESCRIPTION
## Summary

Paginate issue project-item memberships when resolving an issue to a Project item.

## Why

Resolves github/planning-tracking#3696

## What changed

- Follow `pageInfo.endCursor` until the target Project is found or all memberships are exhausted.
- Preserve the existing first-page query shape and `includeArchived: true`; #2903 requires no test adjustment.

## MCP impact

- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

The existing `projects_write` issue-reference path now resolves memberships beyond the first 50.

## Prompts tested (tool changes only)

- "Update an issue's project field when the issue belongs to more than 50 projects."

## Security / limits

- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [x] Data exposure, filtering, or token/size limits considered

Pagination remains bounded to 50 memberships per request and stops as soon as the target is found.

## Tool renaming

- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)