### PR TITLE
Add node IDs to project resolver results

### DIFF
--- a/pkg/github/projects_resolver.go
+++ b/pkg/github/projects_resolver.go
@@ -20,10 +20,11 @@ type ResolvedFieldOption struct {
 	Name string
 }
 
-// ResolvedField is a project field resolved by name; Options is only set when
-// DataType == "SINGLE_SELECT".
+// ResolvedField contains a project's numeric database ID, GraphQL node ID, and
+// type-specific options.
 type ResolvedField struct {
 	ID       string
+	NodeID   string
 	Name     string
 	DataType string
 	Options  []ResolvedFieldOption
@@ -117,6 +118,7 @@ func listAllProjectFields(ctx context.Context, gqlClient *githubv4.Client, owner
 				}
 				all = append(all, ResolvedField{
 					ID:       fmt.Sprintf("%d", n.ProjectV2SingleSelectField.DatabaseID),
+					NodeID:   fmt.Sprintf("%v", n.ProjectV2SingleSelectField.ID),
 					Name:     string(n.ProjectV2SingleSelectField.Name),
 					DataType: string(n.ProjectV2SingleSelectField.DataType),
 					Options:  opts,
@@ -124,12 +126,14 @@ func listAllProjectFields(ctx context.Context, gqlClient *githubv4.Client, owner
 			case n.ProjectV2IterationField.ID != nil:
 				all = append(all, ResolvedField{
 					ID:       fmt.Sprintf("%d", n.ProjectV2IterationField.DatabaseID),
+					NodeID:   fmt.Sprintf("%v", n.ProjectV2IterationField.ID),
 					Name:     string(n.ProjectV2IterationField.Name),
 					DataType: string(n.ProjectV2IterationField.DataType),
 				})
 			case n.ProjectV2Field.ID != nil:
 				all = append(all, ResolvedField{
 					ID:       fmt.Sprintf("%d", n.ProjectV2Field.DatabaseID),
+					NodeID:   fmt.Sprintf("%v", n.ProjectV2Field.ID),
 					Name:     string(n.ProjectV2Field.Name),
 					DataType: string(n.ProjectV2Field.DataType),
 				})
@@ -266,13 +270,22 @@ func resolveSingleSelectOptionByName(field *ResolvedField, optionName string) (s
 // project item's full database ID in one GraphQL hop. Returns a structured
 // error if the issue is not an item on the project.
 func resolveProjectItemIDByIssueNumber(ctx context.Context, gqlClient *githubv4.Client, owner, ownerType string, projectNumber int, issueOwner, issueRepo string, issueNumber int) (int64, error) {
+	_, itemID, err := resolveProjectItemByIssueNumber(ctx, gqlClient, owner, ownerType, projectNumber, issueOwner, issueRepo, issueNumber)
+	return itemID, err
+}
+
+func resolveProjectItemByIssueNumber(ctx context.Context, gqlClient *githubv4.Client, owner, ownerType string, projectNumber int, issueOwner, issueRepo string, issueNumber int) (nodeID string, itemID int64, err error) {
 	projectID, err := resolveProjectNodeID(ctx, gqlClient, owner, ownerType, projectNumber)
 	if err != nil {
-		return 0, err
+		return "", 0, err
 	}
+	return resolveProjectItemByIssueNumberWithProjectID(ctx, gqlClient, projectID, issueOwner, issueRepo, issueNumber)
+}
 
+func resolveProjectItemByIssueNumberWithProjectID(ctx context.Context, gqlClient *githubv4.Client, projectID githubv4.ID, issueOwner, issueRepo string, issueNumber int) (nodeID string, itemID int64, err error) {
 	type projectItemsConnection struct {
 		Nodes []struct {
+			ID             githubv4.ID
 			FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
 			Project        struct {
 				ID githubv4.ID
@@ -296,18 +309,18 @@ func resolveProjectItemIDByIssueNumber(ctx context.Context, gqlClient *githubv4.
 	}
 
 	if err := gqlClient.Query(ctx, &firstPageQuery, vars); err != nil {
-		return 0, fmt.Errorf("failed to resolve project item for %s/%s#%d: %w", issueOwner, issueRepo, issueNumber, err)
+		return "", 0, fmt.Errorf("failed to resolve project item for %s/%s#%d: %w", issueOwner, issueRepo, issueNumber, err)
 	}
 
 	projectItems := firstPageQuery.Repository.Issue.ProjectItems
 	for {
 		for _, item := range projectItems.Nodes {
 			if item.Project.ID == projectID {
-				itemID, parseErr := parseInt64(string(item.FullDatabaseID))
+				parsedItemID, parseErr := parseInt64(string(item.FullDatabaseID))
 				if parseErr != nil {
-					return 0, fmt.Errorf("project item ID %q is not an integer: %w", string(item.FullDatabaseID), parseErr)
+					return "", 0, fmt.Errorf("project item ID %q is not an integer: %w", string(item.FullDatabaseID), parseErr)
 				}
-				return itemID, nil
+				return fmt.Sprintf("%v", item.ID), parsedItemID, nil
 			}
 		}
 
@@ -324,12 +337,12 @@ func resolveProjectItemIDByIssueNumber(ctx context.Context, gqlClient *githubv4.
 		}
 		vars["after"] = projectItems.PageInfo.EndCursor
 		if err := gqlClient.Query(ctx, &nextPageQuery, vars); err != nil {
-			return 0, fmt.Errorf("failed to resolve project item for %s/%s#%d: %w", issueOwner, issueRepo, issueNumber, err)
+			return "", 0, fmt.Errorf("failed to resolve project item for %s/%s#%d: %w", issueOwner, issueRepo, issueNumber, err)
 		}
 		projectItems = nextPageQuery.Repository.Issue.ProjectItems
 	}
 
-	return 0, ghErrors.NewStructuredResolutionError(
+	return "", 0, ghErrors.NewStructuredResolutionError(
 		"item_not_in_project",
 		fmt.Sprintf("%s/%s#%d", issueOwner, issueRepo, issueNumber),
 		"the issue exists but is not an item on the named project; add it first via add_project_item",

--- a/pkg/github/projects_resolver_test.go
+++ b/pkg/github/projects_resolver_test.go
@@ -204,6 +204,7 @@ type resolveItemByIssueQuery struct {
 		Issue struct {
 			ProjectItems struct {
 				Nodes []struct {
+					ID             githubv4.ID
 					FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
 					Project        struct {
 						ID githubv4.ID
@@ -220,6 +221,7 @@ type resolveItemByIssuePageQuery struct {
 		Issue struct {
 			ProjectItems struct {
 				Nodes []struct {
+					ID             githubv4.ID
 					FullDatabaseID githubv4.String `graphql:"fullDatabaseId"`
 					Project        struct {
 						ID githubv4.ID
@@ -282,6 +284,7 @@ func Test_ResolveProjectItemIDByIssueNumber_Success(t *testing.T) {
 									"project":        map[string]any{"id": "PVT_other"},
 								},
 								map[string]any{
+									"id":             "PVTI_target",
 									"fullDatabaseId": "4242",
 									"project":        map[string]any{"id": "PVT_project1"},
 								},
@@ -300,12 +303,13 @@ func Test_ResolveProjectItemIDByIssueNumber_Success(t *testing.T) {
 	)
 	gql := githubv4.NewClient(mocked)
 
-	itemID, err := resolveProjectItemIDByIssueNumber(context.Background(), gql, "octo-org", "org", 1, "octo-issue-owner", "repo", 123)
+	nodeID, itemID, err := resolveProjectItemByIssueNumber(context.Background(), gql, "octo-org", "org", 1, "octo-issue-owner", "repo", 123)
 	require.NoError(t, err)
+	assert.Equal(t, "PVTI_target", nodeID)
 	assert.Equal(t, int64(4242), itemID)
 }
 
-func Test_ResolveProjectItemIDByIssueNumber_TargetOnSecondPage(t *testing.T) {
+func Test_ResolveProjectItemByIssueNumber_TargetOnSecondPage(t *testing.T) {
 	mocked := githubv4mock.NewMockedHTTPClient(
 		githubv4mock.NewQueryMatcher(
 			struct {
@@ -367,6 +371,7 @@ func Test_ResolveProjectItemIDByIssueNumber_TargetOnSecondPage(t *testing.T) {
 						"projectItems": map[string]any{
 							"nodes": []any{
 								map[string]any{
+									"id":             "PVTI_target",
 									"fullDatabaseId": "4242",
 									"project":        map[string]any{"id": "PVT_project1"},
 								},
@@ -385,8 +390,9 @@ func Test_ResolveProjectItemIDByIssueNumber_TargetOnSecondPage(t *testing.T) {
 	)
 	gql := githubv4.NewClient(mocked)
 
-	itemID, err := resolveProjectItemIDByIssueNumber(context.Background(), gql, "octo-org", "org", 1, "octo-issue-owner", "repo", 123)
+	nodeID, itemID, err := resolveProjectItemByIssueNumber(context.Background(), gql, "octo-org", "org", 1, "octo-issue-owner", "repo", 123)
 	require.NoError(t, err)
+	assert.Equal(t, "PVTI_target", nodeID)
 	assert.Equal(t, int64(4242), itemID)
 }
 

--- a/pkg/github/projects_resolver_test.go
+++ b/pkg/github/projects_resolver_test.go
@@ -71,6 +71,27 @@ func statusFieldNode(nodeID string, databaseID int, name string, options []map[s
 	}
 }
 
+// iterationFieldNode is an iteration field response node for use in mock data.
+func iterationFieldNode(nodeID string, databaseID int, name string) map[string]any {
+	return map[string]any{
+		"id":         nodeID,
+		"databaseId": databaseID,
+		"name":       name,
+		"dataType":   "ITERATION",
+	}
+}
+
+// genericFieldNode is a plain field response node (neither single-select nor
+// iteration, e.g. TEXT or NUMBER) for use in mock data.
+func genericFieldNode(nodeID string, databaseID int, name, dataType string) map[string]any {
+	return map[string]any{
+		"id":         nodeID,
+		"databaseId": databaseID,
+		"name":       name,
+		"dataType":   dataType,
+	}
+}
+
 func fieldsResponse(nodes []map[string]any) map[string]any {
 	return map[string]any{
 		"organization": map[string]any{
@@ -109,12 +130,49 @@ func Test_ResolveProjectFieldByName_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, field)
 	assert.Equal(t, "12345", field.ID)
+	assert.Equal(t, "PVTSSF_lADOBBcDeFg123", field.NodeID)
 	assert.Equal(t, "SINGLE_SELECT", field.DataType)
 	assert.Len(t, field.Options, 3)
 
 	optionID, err := resolveSingleSelectOptionByName(field, "In Progress")
 	require.NoError(t, err)
 	assert.Equal(t, "OPT_b", optionID)
+}
+
+func Test_ResolveProjectFieldByName_NodeIDsForAllVariants(t *testing.T) {
+	mocked := githubv4mock.NewMockedHTTPClient(
+		githubv4mock.NewQueryMatcher(
+			projectFieldsTestQuery{},
+			fieldsQueryVars("octo-org", 7),
+			githubv4mock.DataResponse(fieldsResponse([]map[string]any{
+				statusFieldNode("PVTSSF_single1", 111, "Status", []map[string]any{
+					{"id": "OPT_a", "name": "Todo"},
+				}),
+				iterationFieldNode("PVTIF_iteration1", 222, "Sprint"),
+				genericFieldNode("PVTF_text1", 333, "Notes", "TEXT"),
+			})),
+		),
+	)
+	gql := githubv4.NewClient(mocked)
+
+	variants := []struct {
+		fieldName    string
+		expectedType string
+		wantNodeID   string
+	}{
+		{"Status", "SINGLE_SELECT", "PVTSSF_single1"},
+		{"Sprint", "ITERATION", "PVTIF_iteration1"},
+		{"Notes", "TEXT", "PVTF_text1"},
+	}
+	for _, v := range variants {
+		t.Run(v.fieldName, func(t *testing.T) {
+			field, err := resolveProjectFieldByName(context.Background(), gql, "octo-org", "org", 7, v.fieldName, v.expectedType)
+			require.NoError(t, err)
+			require.NotNil(t, field)
+			assert.Equal(t, v.wantNodeID, field.NodeID)
+			assert.Equal(t, v.expectedType, field.DataType)
+		})
+	}
 }
 
 func Test_ResolveProjectFieldByName_NotFound_ReturnsStructuredError(t *testing.T) {
@@ -243,7 +301,7 @@ func (t *requestCountingTransport) RoundTrip(req *http.Request) (*http.Response,
 	return t.inner.RoundTrip(req)
 }
 
-func Test_ResolveProjectItemIDByIssueNumber_Success(t *testing.T) {
+func Test_ResolveProjectItemByIssueNumber_Success(t *testing.T) {
 	mocked := githubv4mock.NewMockedHTTPClient(
 		// project node id lookup (org)
 		githubv4mock.NewQueryMatcher(


### PR DESCRIPTION
## Summary
Small prerequisite refactor: the project resolver helpers now surface GraphQL node IDs for project items and fields.

## Why
Split out of #2903 to keep that PR reviewable. An upcoming change performs batched project-item writes and needs the item/field node IDs exposed here.

## What changed
- Add `NodeID` to `ResolvedField`, populated for all three field variants in `listAllProjectFields`.
- Refactor `resolveProjectItemIDByIssueNumber` into a thin wrapper over a new `resolveProjectItemByIssueNumber` (returns the item node ID alongside its database ID), which delegates to `resolveProjectItemByIssueNumberWithProjectID` for an already-resolved project ID. The `projectItems` query now selects the item node ID.

## MCP impact
- [x] No tool or API changes

## Prompts tested (tool changes only)
N/A - internal resolver refactor, no tool changes.

## Security / limits
- [x] No security or limits impact

## Tool renaming
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs
- [x] Not needed