### PR TITLE
build: use patched Go toolchain and UI dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/github-mcp-server
 
-go 1.25.0
+go 1.25.12
 
 require (
 	github.com/go-chi/chi/v5 v5.3.1

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2730,9 +2730,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
Ensures release binaries are built with Go 1.25.12 and removes the remaining high-severity UI dependency finding.

## Why
Main's Docker builder was updated by #2867, but GoReleaser reads the exact Go version from `go.mod`, which remained at 1.25.0. That could leave future release archives built with an older, vulnerable Go standard library even though the container image was patched. The broader Go 1.26 upgrade in #2705 can proceed separately from this focused correction.

No linked issue. Related: #2705.

## What changed
- Raise the `go.mod` minimum from Go 1.25.0 to 1.25.12 so setup-go and GoReleaser use the patched toolchain.
- Update transitive `fast-uri` from 3.1.2 to 3.1.4 to resolve its high-severity host-confusion advisories.

## MCP impact
- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

This only changes build inputs; MCP tools and behavior are unchanged.

## Prompts tested (tool changes only)
- N/A — no tool changes.

## Security / limits
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

This is a build and dependency security update. It does not change runtime authentication, data exposure, filtering, or limits.

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

Also verified `govulncheck`, license generation, UI typecheck/audit/build, GoReleaser snapshot artifacts, and amd64/arm64 container builds.

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)