### PR TITLE
fix(notifications): mark subscription tools destructive

### DIFF
--- a/pkg/github/__toolsnaps__/manage_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_notification_subscription.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": true,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Manage notification subscription"

--- a/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": true,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Manage repository notification subscription"

--- a/pkg/github/notifications.go
+++ b/pkg/github/notifications.go
@@ -413,8 +413,9 @@ func ManageNotificationSubscription(t translations.TranslationHelperFunc) invent
 			Name:        "manage_notification_subscription",
 			Description: t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a notification subscription: ignore, watch, or delete a notification thread subscription."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
@@ -509,8 +510,9 @@ func ManageRepositoryNotificationSubscription(t translations.TranslationHelperFu
 			Name:        "manage_repository_notification_subscription",
 			Description: t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a repository notification subscription: ignore, watch, or delete repository notifications subscription for the provided repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(true),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/github/notifications_test.go
+++ b/pkg/github/notifications_test.go
@@ -146,6 +146,9 @@ func Test_ManageNotificationSubscription(t *testing.T) {
 
 	assert.Equal(t, "manage_notification_subscription", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations)
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	assert.True(t, *tool.Annotations.DestructiveHint, "delete removes the notification subscription")
 
 	schema, ok := tool.InputSchema.(*jsonschema.Schema)
 	require.True(t, ok, "InputSchema should be *jsonschema.Schema")
@@ -282,6 +285,9 @@ func Test_ManageRepositoryNotificationSubscription(t *testing.T) {
 
 	assert.Equal(t, "manage_repository_notification_subscription", tool.Name)
 	assert.NotEmpty(t, tool.Description)
+	require.NotNil(t, tool.Annotations)
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	assert.True(t, *tool.Annotations.DestructiveHint, "delete removes the repository notification subscription")
 
 	schema, ok := tool.InputSchema.(*jsonschema.Schema)
 	require.True(t, ok, "InputSchema should be *jsonschema.Schema")


### PR DESCRIPTION
## Summary

- explicitly mark both notification subscription management tools as destructive
- assert the annotation in unit tests and tool snapshots
- preserve the existing conservative client UX while making the intent independent of protocol defaults

## Rationale

The MCP `2026-07-28` specification defines `destructiveHint: false` to mean that a tool performs **only additive updates**. Both tools expose a `delete` action that removes a subscription, and annotations apply to the whole tool rather than individual action values. They therefore need to advertise `destructiveHint: true`.

The protocol default remains `true`, so this does not change effective behavior. It makes the behavior conscious and explicit under `modelcontextprotocol/go-sdk` `v1.7.0`, which represents this default-true field as an optional pointer.

Specification: https://modelcontextprotocol.io/specification/2026-07-28/schema#toolannotations

This supersedes #2845 and #2884, which set the hint to `false`.

Closes #2841