### PR TITLE
[eval only, do not merge] Reword search_issues for natural-language semantic queries

### DIFF
--- a/pkg/github/__toolsnaps__/search_issues.snap
+++ b/pkg/github/__toolsnaps__/search_issues.snap
@@ -4,7 +4,7 @@
     "readOnlyHint": true,
     "title": "Search issues"
   },
-  "description": "Search for issues in GitHub repositories using natural-language semantic matching. Write the query as a natural-language description of what you're looking for (e.g. \"login fails after password reset\"); best for conceptual or paraphrased queries. Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical keyword search.",
+  "description": "Search issues using natural-language semantic matching. Best for conceptual or paraphrased queries (e.g. \"login fails after password reset\"). Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical search.",
   "inputSchema": {
     "properties": {
       "order": {
@@ -31,7 +31,7 @@
         "type": "number"
       },
       "query": {
-        "description": "The search query. Write it as a natural-language description of what you're looking for (e.g. \"login fails after password reset\") rather than exact keywords or boolean operators.",
+        "description": "The search query. Write it as natural language for semantic and hybrid variants.",
         "type": "string"
       },
       "repo": {

--- a/pkg/github/__toolsnaps__/search_issues.snap
+++ b/pkg/github/__toolsnaps__/search_issues.snap
@@ -4,7 +4,7 @@
     "readOnlyHint": true,
     "title": "Search issues"
   },
-  "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+  "description": "Search for issues in GitHub repositories using natural-language semantic matching. Write the query as a natural-language description of what you're looking for (e.g. \"login fails after password reset\"); best for conceptual or paraphrased queries. Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical keyword search.",
   "inputSchema": {
     "properties": {
       "order": {
@@ -31,7 +31,7 @@
         "type": "number"
       },
       "query": {
-        "description": "Search query using GitHub issues search syntax",
+        "description": "The search query. Write it as a natural-language description of what you're looking for (e.g. \"login fails after password reset\") rather than exact keywords or boolean operators.",
         "type": "string"
       },
       "repo": {

--- a/pkg/github/__toolsnaps__/search_issues_ff_fields_param.snap
+++ b/pkg/github/__toolsnaps__/search_issues_ff_fields_param.snap
@@ -4,7 +4,7 @@
     "readOnlyHint": true,
     "title": "Search issues"
   },
-  "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+  "description": "Search for issues in GitHub repositories using natural-language semantic matching. Write the query as a natural-language description of what you're looking for (e.g. \"login fails after password reset\"); best for conceptual or paraphrased queries. Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical keyword search.",
   "inputSchema": {
     "properties": {
       "fields": {
@@ -64,7 +64,7 @@
         "type": "number"
       },
       "query": {
-        "description": "Search query using GitHub issues search syntax",
+        "description": "The search query. Write it as a natural-language description of what you're looking for (e.g. \"login fails after password reset\") rather than exact keywords or boolean operators.",
         "type": "string"
       },
       "repo": {

--- a/pkg/github/__toolsnaps__/search_issues_ff_fields_param.snap
+++ b/pkg/github/__toolsnaps__/search_issues_ff_fields_param.snap
@@ -4,7 +4,7 @@
     "readOnlyHint": true,
     "title": "Search issues"
   },
-  "description": "Search for issues in GitHub repositories using natural-language semantic matching. Write the query as a natural-language description of what you're looking for (e.g. \"login fails after password reset\"); best for conceptual or paraphrased queries. Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical keyword search.",
+  "description": "Search issues using natural-language semantic matching. Best for conceptual or paraphrased queries (e.g. \"login fails after password reset\"). Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical search.",
   "inputSchema": {
     "properties": {
       "fields": {
@@ -64,7 +64,7 @@
         "type": "number"
       },
       "query": {
-        "description": "The search query. Write it as a natural-language description of what you're looking for (e.g. \"login fails after password reset\") rather than exact keywords or boolean operators.",
+        "description": "The search query. Write it as natural language for semantic and hybrid variants.",
         "type": "string"
       },
       "repo": {

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1628,7 +1628,7 @@ func searchIssuesTool(t translations.TranslationHelperFunc, includeFields bool) 
 		Properties: map[string]*jsonschema.Schema{
 			"query": {
 				Type:        "string",
-				Description: "The search query. Write it as a natural-language description of what you're looking for (e.g. \"login fails after password reset\") rather than exact keywords or boolean operators.",
+				Description: "The search query. Write it as natural language for semantic and hybrid variants.",
 			},
 			"owner": {
 				Type:        "string",
@@ -1675,7 +1675,7 @@ func searchIssuesTool(t translations.TranslationHelperFunc, includeFields bool) 
 		ToolsetMetadataIssues,
 		mcp.Tool{
 			Name:        "search_issues",
-			Description: t("TOOL_SEARCH_ISSUES_DESCRIPTION", "Search for issues in GitHub repositories using natural-language semantic matching. Write the query as a natural-language description of what you're looking for (e.g. \"login fails after password reset\"); best for conceptual or paraphrased queries. Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical keyword search."),
+			Description: t("TOOL_SEARCH_ISSUES_DESCRIPTION", "Search issues using natural-language semantic matching. Best for conceptual or paraphrased queries (e.g. \"login fails after password reset\"). Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical search."),
 			Annotations: &mcp.ToolAnnotations{
 				Title:        t("TOOL_SEARCH_ISSUES_USER_TITLE", "Search issues"),
 				ReadOnlyHint: true,

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1628,7 +1628,7 @@ func searchIssuesTool(t translations.TranslationHelperFunc, includeFields bool) 
 		Properties: map[string]*jsonschema.Schema{
 			"query": {
 				Type:        "string",
-				Description: "Search query using GitHub issues search syntax",
+				Description: "The search query. Write it as a natural-language description of what you're looking for (e.g. \"login fails after password reset\") rather than exact keywords or boolean operators.",
 			},
 			"owner": {
 				Type:        "string",
@@ -1675,7 +1675,7 @@ func searchIssuesTool(t translations.TranslationHelperFunc, includeFields bool) 
 		ToolsetMetadataIssues,
 		mcp.Tool{
 			Name:        "search_issues",
-			Description: t("TOOL_SEARCH_ISSUES_DESCRIPTION", "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue"),
+			Description: t("TOOL_SEARCH_ISSUES_DESCRIPTION", "Search for issues in GitHub repositories using natural-language semantic matching. Write the query as a natural-language description of what you're looking for (e.g. \"login fails after password reset\"); best for conceptual or paraphrased queries. Already scoped to is:issue. Avoid boolean OR operators, which fall back to lexical keyword search."),
 			Annotations: &mcp.ToolAnnotations{
 				Title:        t("TOOL_SEARCH_ISSUES_USER_TITLE", "Search issues"),
 				ReadOnlyHint: true,


### PR DESCRIPTION
## Do not merge — eval scaffold

Draft branch for the [copilot-offline-eval](https://github.com/github/copilot-offline-eval) MCP tool-selection harness. It exists so the eval can containerise this branch (`github-mcp-server-branch` input) and measure query formation against the current lexical wording. Not intended to land.

## What it changes

Rewrites the `search_issues` tool description and `query` param description to steer models toward **natural-language** queries instead of qualifier/boolean syntax:

- Tool: `…using natural-language semantic matching. Write the query as a natural-language description of what you're looking for… Avoid boolean OR operators, which fall back to lexical keyword search.`
- `query` param: `Write it as a natural-language description… rather than exact keywords or boolean operators.`

This matches the end-state of the issue-search experiment (github/plan-track-agentic-toolkit#415): once `search_issues` defaults to semantic, the description should stop advertising lexical syntax.

## Why

The experiment showed models over-produce boolean/qualifier queries that trip the monolith's semantic→lexical fallback. Before committing to the remote-side wording, we want offline eval evidence that the reworded description actually shifts query formation (`QUERY_AGENT_RATING` / `QUERY_WORD_MATCH`) without regressing legitimate qualifier queries (guard cases in the benchmark PR).

## Validation

- `go build ./cmd/github-mcp-server` ✅
- `go test ./pkg/github/ -run Test_SearchIssues` ✅
- `gofmt` clean ✅
- Toolsnaps regenerated (`search_issues.snap`, `search_issues_ff_fields_param.snap`)