### PR TITLE
fix: tolerate duplicate initialize requests on the same session

### DIFF
--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -190,8 +191,63 @@ func NewStdioMCPServer(ctx context.Context, cfg github.MCPServerConfig) (*mcp.Se
 	}
 
 	ghServer.AddReceivingMiddleware(addUserAgentsMiddleware(cfg, clients.restUATransp, clients.gqlHTTP))
+	ghServer.AddReceivingMiddleware(dedupeInitializeMiddleware())
 
 	return ghServer, nil
+}
+
+// dedupeInitializeMiddleware makes a repeated "initialize" call on an
+// already-initialized session return the original result instead of
+// erroring.
+//
+// go-sdk v1.7.0-pre.1 (picked up by github-mcp-server v1.6.0, see go.mod)
+// started rejecting a second "initialize" on the same session with
+// `duplicate "initialize" received" (upstream: TestServerRejectsDuplicateInitialize
+// in mcp/server_test.go, added to fix modelcontextprotocol/go-sdk#961). go-sdk
+// v1.6.1 and earlier (github-mcp-server v1.5.0) silently accepted repeat
+// calls, returning the same result every time. Some MCP clients resend
+// "initialize" on the same transport/session when a handshake is retried
+// (e.g. after a slow first response), relying on that old idempotent
+// behavior. Restore it here instead of depending on unreleased upstream
+// behavior, since the response for "initialize" is otherwise constant for
+// the lifetime of this server.
+func dedupeInitializeMiddleware() func(next mcp.MethodHandler) mcp.MethodHandler {
+	var (
+		mu     sync.Mutex
+		cached *mcp.InitializeResult
+	)
+
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, request mcp.Request) (mcp.Result, error) {
+			if method != "initialize" {
+				return next(ctx, method, request)
+			}
+
+			if sess, ok := request.GetSession().(*mcp.ServerSession); ok && sess.InitializeParams() != nil {
+				mu.Lock()
+				result := cached
+				mu.Unlock()
+				if result != nil {
+					return result, nil
+				}
+				// No cached result yet even though the session is already
+				// initialized: fall through and let the SDK produce its own
+				// error rather than guess at a response.
+			}
+
+			result, err := next(ctx, method, request)
+			if err == nil {
+				if initResult, ok := result.(*mcp.InitializeResult); ok {
+					mu.Lock()
+					if cached == nil {
+						cached = initResult
+					}
+					mu.Unlock()
+				}
+			}
+			return result, err
+		}
+	}
 }
 
 type StdioServerConfig struct {


### PR DESCRIPTION
## Summary
go-sdk v1.7.0-pre.1 (bumped in #2787) started rejecting a second "initialize" call on an already-initialized session with `duplicate "initialize" received`, fixing modelcontextprotocol/go-sdk#961 (a duplicate initialize with changed params could silently overwrite the session's stored InitializeParams). go-sdk v1.6.1 and earlier (github-mcp-server v1.5.0) accepted repeat calls and returned the same result every time.

Some MCP clients resend "initialize" on the same transport/session when a handshake is retried (e.g. a slow first response triggers a client-side retry without tearing down the connection), which relied on that old idempotent behavior and now hard-fails on v1.6.0+. I found this change in behavior while using Stacklok [ToolHive](https://github.com/stacklok/toolhive) w/ the vMCP feature.

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes #(no issues for this yet)

## What changed
<!-- Bullet list of concrete changes. -->
- Adds a receiving middleware that caches the first successful InitializeResult and replays it for later "initialize" calls on the same server, instead of forwarding to the SDK and hitting its error. The response is otherwise constant for the process's lifetime, so a single cached result (not a per-session cache) is enough and avoids any per-session memory growth

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [x] Auth / permissions considered
- [x] Data exposure, filtering, or token/size limits considered

Upstream's issue (go-sdk#961) was that a duplicate initialize with changed parameters could silently overwrite ServerSession.InitializeParams() mid-session — letting a later request quietly change the negotiated protocol version/capabilities that other code relies on. My middleware short-circuits before calling next() whenever the session is already initialized, so the SDK's own ss.initialize() (the code that does the overwrite) never runs for a duplicate call. InitializeParams() stays pinned to whatever the first call sent, for the life of the session — same protection as upstream's fix. The difference is just what the client sees in response: instead of an error, it gets the original negotiated result. A second call with different params is silently ignored, never honored.

Auth interaction: I checked whether OAuth logic hooks into initialize and could be skipped by my short-circuit. On current main it doesn't — OAuth was refactored (PR #2870) into a ToolHandlerMiddleware that runs at tool-call time, not a receiving-middleware on initialize. (On v1.6.0 there was an OAuth receiving-middleware gated on initialize — worth re-checking if this is ever backported to that older base.)

Data exposure: the cached InitializeResult only holds ProtocolVersion, Capabilities, Instructions, ServerInfo — static server config, nothing per-user or secret.

Blast radius: dedupeInitializeMiddleware() is only wired into NewStdioMCPServer. The HTTP/remote path (pkg/http/handler.go) builds its server via a separate factory and never gets this middleware — so there's no scenario where one HTTP client's negotiated capabilities could leak into another's session through this cache. For stdio, there's exactly one session per process, so the single shared (not per-session) cache never crosses a trust boundary.

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
