### PR TITLE
fix: refactor existing PR message format when calling create_pull_req…

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/go-github/v89/github"
@@ -647,6 +648,45 @@ var pullRequestUpdateFormParams = map[string]struct{}{
 	"_ui_submitted":         {},
 }
 
+// findExistingPullRequest checks whether the Create error was GitHub's
+// "a pull request already exists" 422, and if so, looks up and returns
+// that existing PR so callers can surface a useful link instead of the
+// raw validation error.
+func findExistingPullRequest(ctx context.Context, client *github.Client, owner, repo, head, base string, createErr error) (*github.PullRequest, error) {
+	ghErr, ok := createErr.(*github.ErrorResponse)
+	if !ok {
+		return nil, fmt.Errorf("not a github.ErrorResponse")
+	}
+
+	matched := false
+	for _, e := range ghErr.Errors {
+		if e.Code == "custom" && strings.Contains(e.Message, "A pull request already exists") {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("error is not an 'already exists' validation failure")
+	}
+
+	// head may or may not already be qualified with an owner (fork case);
+	// the List API wants "owner:branch" form.
+	headFilter := head
+	if !strings.Contains(head, ":") {
+		headFilter = fmt.Sprintf("%s:%s", owner, head)
+	}
+
+	prs, _, err := client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
+		Head:  headFilter,
+		Base:  base,
+		State: "all",
+	})
+	if err != nil || len(prs) == 0 {
+		return nil, fmt.Errorf("could not find existing pull request: %w", err)
+	}
+	return prs[0], nil
+}
+
 // CreatePullRequest creates a tool to create a new pull request.
 func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerTool {
 	return NewTool(
@@ -796,6 +836,25 @@ func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 			}
 			pr, resp, err := client.PullRequests.Create(ctx, owner, repo, newPR)
 			if err != nil {
+				if existingPR, findErr := findExistingPullRequest(ctx, client, owner, repo, head, base, err); findErr == nil && existingPR != nil {
+					minimalResponse := MinimalResponse{
+						ID:  fmt.Sprintf("%d", existingPR.GetID()),
+						URL: existingPR.GetHTMLURL(),
+					}
+					r, marshalErr := json.Marshal(struct {
+						MinimalResponse
+						Message string `json:"message"`
+					}{
+						MinimalResponse: minimalResponse,
+						Message: fmt.Sprintf(
+							"An open pull request already exists for %q into %q: #%d, titled %q at %s",
+							head, base, existingPR.GetNumber(), existingPR.GetTitle(), existingPR.GetHTMLURL(),
+						),
+					})
+					if marshalErr == nil {
+						return utils.NewToolResultText(string(r)), nil, nil
+					}
+				}
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,
 					"failed to create pull request",
 					resp,


### PR DESCRIPTION
<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
Catch the "pull request already exists" 422 from `create_pull_request` and return a clean message with the existing PR's URL instead of forwarding GitHub's raw, unformatted validation error.

## Why
When `create_pull_request` fails because a PR already exists for the given head/base, the tool currently forwards GitHub's raw API error verbatim (e.g. `failed to create pull request: POST .../pulls: 422 Validation Failed [{Resource:PullRequest Field: Code:custom Message:A pull request already exists for owner:branch.}]`). This is unreadable and gives the caller no way to find the existing PR without a separate lookup.

Fixes #2931

## What changed
- Added `findExistingPullRequest`, which detects the specific `code:"custom"` / "A pull request already exists" 422 shape and calls `PullRequests.List` (filtered by `head`/`base`) to resolve the existing PR
- Updated `CreatePullRequest`'s error handling: on this specific error, return a structured `{id, url, message}` result pointing at the existing PR instead of the raw error; all other `Create` errors are unaffected and still return the original error path

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
"Create a pull request from `test/dup-pr` into `main`" (when a PR already exists for that branch pair) returns the existing PR's number and link instead of an error

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [x] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [x] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [ ] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)
