### PR TITLE
ci: add Claude Code workflow to check Datadog MCP server connection

### DIFF
--- a/.github/workflows/claude-datadog-check.yml
+++ b/.github/workflows/claude-datadog-check.yml
@@ -1,0 +1,43 @@
+name: Claude Datadog MCP Check
+
+# 이슈 코멘트에 "@claude 데이터독 mcp서버 접속을 확인해줘" 와 같이 남기면
+# Claude Code Action 이 실행되어 Datadog MCP 서버 접속을 확인합니다.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-datadog-check:
+    # @claude 가 포함된 코멘트에만 반응합니다.
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "@claude"
+          # Datadog MCP 서버(원격 HTTP)를 등록하고, 접속 확인용 도구 사용을 허용합니다.
+          claude_args: |
+            --mcp-config '{
+              "mcpServers": {
+                "datadog": {
+                  "type": "http",
+                  "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+                  "headers": {
+                    "Authorization": "Bearer ${{ secrets.DD_BEARER_TOKEN }}"
+                  }
+                }
+              }
+            }'
+            --allowedTools "mcp__datadog"


### PR DESCRIPTION
Triggered by an issue comment containing "@claude". Registers the Datadog remote HTTP MCP server (Bearer token auth) so Claude can verify connectivity and reply on the issue.

<!--
Copilot: Fill all sections. Prefer short, concrete answers.
If a checkbox is selected, add a brief explanation.
-->

## Summary
<!-- In 1–2 sentences: what does this PR do? -->

## Why
<!-- Why is this change needed? Link issues or discussions. -->
Fixes #

## What changed
<!-- Bullet list of concrete changes. -->
- 
- 

## MCP impact
<!-- Select one or more. If selected, add 1–2 sentences. -->
- [ ] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

## Prompts tested (tool changes only)
<!-- If you changed or added tools, list example prompts you tested. -->
<!-- Include prompts that trigger the tool and describe the use case. -->
<!-- Example: "List all open issues in the repo assigned to me" -->
- 

## Security / limits
<!-- Select if relevant. Add a short note if checked. -->
- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

## Tool renaming
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go` 
- [ ] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests
<!-- Check what you ran. If not run, explain briefly. -->
- [ ] Linted locally with `./script/lint`
- [ ] Tested locally with `./script/test`

## Docs

- [ ] Not needed
- [ ] Updated (README / docs / examples)
