### PR TITLE
Bump go-github to pick up SearchType support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.12
 require (
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-viper/mapstructure/v2 v2.5.0
-	github.com/google/go-github/v89 v89.0.0
+	github.com/google/go-github/v89 v89.0.1-0.20260728185857-34349a88bac3
 	github.com/google/jsonschema-go v0.4.3
 	github.com/josephburnett/jd/v2 v2.5.0
 	github.com/lithammer/fuzzysearch v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArs
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
-github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
+github.com/google/go-github/v89 v89.0.1-0.20260728185857-34349a88bac3 h1:0a/p9KtPso8UBauBD/p9Go1oaZrrEydBNHjaaKkSHJo=
+github.com/google/go-github/v89 v89.0.1-0.20260728185857-34349a88bac3/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -2382,11 +2382,11 @@ func CreateIssue(ctx context.Context, client *github.Client, owner string, repo 
 	}
 
 	// Create the issue request
-	issueRequest := &github.IssueRequest{
-		Title:            github.Ptr(title),
+	issueRequest := github.CreateIssueRequest{
+		Title:            title,
 		Body:             github.Ptr(body),
-		Assignees:        &assignees,
-		Labels:           &labels,
+		Assignees:        assignees,
+		Labels:           labels,
 		IssueFieldValues: issueFieldValues,
 	}
 
@@ -2449,7 +2449,7 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 	}
 
 	// Create the issue request with only provided fields
-	issueRequest := &github.IssueRequest{}
+	issueRequest := github.UpdateIssueRequest{}
 
 	// Set optional parameters if provided
 	if title != "" {
@@ -2461,11 +2461,11 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 	}
 
 	if updateOptions.LabelsProvided {
-		issueRequest.Labels = &labels
+		issueRequest.Labels = labels
 	}
 
 	if updateOptions.AssigneesProvided {
-		issueRequest.Assignees = &assignees
+		issueRequest.Assignees = assignees
 	}
 
 	if milestoneNum != 0 {
@@ -2519,7 +2519,7 @@ func UpdateIssue(ctx context.Context, client *github.Client, gqlClient *githubv4
 		}
 	}
 
-	updatedIssue, resp, err := client.Issues.Edit(ctx, owner, repo, issueNumber, issueRequest)
+	updatedIssue, resp, err := client.Issues.Update(ctx, owner, repo, issueNumber, issueRequest)
 	if err != nil {
 		return ghErrors.NewGitHubAPIErrorResponse(ctx,
 			"failed to update issue",

--- a/pkg/github/issues_delete_test.go
+++ b/pkg/github/issues_delete_test.go
@@ -23,7 +23,7 @@ import (
 func Test_IssueRequest_EmptyFieldValues_OmittedByJSON(t *testing.T) {
 	t.Parallel()
 
-	req := &gogithub.IssueRequest{
+	req := &gogithub.UpdateIssueRequest{
 		Title:            gogithub.Ptr("still here"),
 		IssueFieldValues: []*gogithub.IssueRequestFieldValue{},
 	}

--- a/pkg/github/issues_granular.go
+++ b/pkg/github/issues_granular.go
@@ -29,7 +29,7 @@ func issueUpdateTool(
 	name, description, title string,
 	extraProps map[string]*jsonschema.Schema,
 	extraRequired []string,
-	buildRequest func(args map[string]any) (*github.IssueRequest, error),
+	buildRequest func(args map[string]any) (github.UpdateIssueRequest, error),
 ) inventory.ServerTool {
 	props := map[string]*jsonschema.Schema{
 		"owner": {
@@ -92,7 +92,7 @@ func issueUpdateTool(
 				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
 
-			issue, resp, err := client.Issues.Edit(ctx, owner, repo, issueNumber, issueReq)
+			issue, resp, err := client.Issues.Update(ctx, owner, repo, issueNumber, issueReq)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to update issue", resp, err), nil, nil
 			}
@@ -164,8 +164,8 @@ func GranularCreateIssue(t translations.TranslationHelperFunc) inventory.ServerT
 			}
 			body, _ := OptionalParam[string](args, "body")
 
-			issueReq := &github.IssueRequest{
-				Title: &title,
+			issueReq := github.CreateIssueRequest{
+				Title: title,
 			}
 			if body != "" {
 				issueReq.Body = &body
@@ -206,12 +206,12 @@ func GranularUpdateIssueTitle(t translations.TranslationHelperFunc) inventory.Se
 			"title": {Type: "string", Description: "The new title for the issue"},
 		},
 		[]string{"title"},
-		func(args map[string]any) (*github.IssueRequest, error) {
+		func(args map[string]any) (github.UpdateIssueRequest, error) {
 			title, err := RequiredParam[string](args, "title")
 			if err != nil {
-				return nil, err
+				return github.UpdateIssueRequest{}, err
 			}
-			return &github.IssueRequest{Title: &title}, nil
+			return github.UpdateIssueRequest{Title: &title}, nil
 		},
 	)
 }
@@ -226,12 +226,12 @@ func GranularUpdateIssueBody(t translations.TranslationHelperFunc) inventory.Ser
 			"body": {Type: "string", Description: "The new body content for the issue"},
 		},
 		[]string{"body"},
-		func(args map[string]any) (*github.IssueRequest, error) {
+		func(args map[string]any) (github.UpdateIssueRequest, error) {
 			body, err := RequiredParam[string](args, "body")
 			if err != nil {
-				return nil, err
+				return github.UpdateIssueRequest{}, err
 			}
-			return &github.IssueRequest{Body: &body}, nil
+			return github.UpdateIssueRequest{Body: &body}, nil
 		},
 	)
 }
@@ -392,7 +392,7 @@ func GranularUpdateIssueAssignees(t translations.TranslationHelperFunc) inventor
 				for i, p := range payload {
 					logins[i] = p.(string)
 				}
-				body = &github.IssueRequest{Assignees: &logins}
+				body = &github.UpdateIssueRequest{Assignees: logins}
 			}
 
 			apiURL := fmt.Sprintf("repos/%s/%s/issues/%d", owner, repo, issueNumber)
@@ -610,7 +610,7 @@ func GranularUpdateIssueLabels(t translations.TranslationHelperFunc) inventory.S
 				for i, p := range payload {
 					names[i] = p.(string)
 				}
-				body = &github.IssueRequest{Labels: &names}
+				body = &github.UpdateIssueRequest{Labels: names}
 			}
 
 			apiURL := fmt.Sprintf("repos/%s/%s/issues/%d", owner, repo, issueNumber)
@@ -654,12 +654,12 @@ func GranularUpdateIssueMilestone(t translations.TranslationHelperFunc) inventor
 			},
 		},
 		[]string{"milestone"},
-		func(args map[string]any) (*github.IssueRequest, error) {
+		func(args map[string]any) (github.UpdateIssueRequest, error) {
 			milestone, err := RequiredInt(args, "milestone")
 			if err != nil {
-				return nil, err
+				return github.UpdateIssueRequest{}, err
 			}
-			return &github.IssueRequest{Milestone: &milestone}, nil
+			return github.UpdateIssueRequest{Milestone: &milestone}, nil
 		},
 	)
 }
@@ -787,7 +787,7 @@ func GranularUpdateIssueType(t translations.TranslationHelperFunc) inventory.Ser
 					},
 				}
 			} else {
-				body = &github.IssueRequest{Type: &issueType}
+				body = &github.UpdateIssueRequest{Type: &issueType}
 			}
 
 			apiURL := fmt.Sprintf("repos/%s/%s/issues/%d", owner, repo, issueNumber)
@@ -981,7 +981,7 @@ func GranularUpdateIssueState(t translations.TranslationHelperFunc) inventory.Se
 				}
 				body = req
 			} else {
-				req := &github.IssueRequest{State: &state}
+				req := &github.UpdateIssueRequest{State: &state}
 				if stateReason != "" {
 					req.StateReason = &stateReason
 				}

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -1449,7 +1449,7 @@ func Test_CreateIssue(t *testing.T) {
 		State:     github.Ptr("open"),
 		HTMLURL:   github.Ptr("https://github.com/owner/repo/issues/123"),
 		Assignees: []*github.User{{Login: github.Ptr("user1")}, {Login: github.Ptr("user2")}},
-		Labels:    []*github.Label{{Name: github.Ptr("bug")}, {Name: github.Ptr("help wanted")}},
+		Labels:    []*github.Label{{Name: "bug"}, {Name: "help wanted"}},
 		Milestone: &github.Milestone{Number: github.Ptr(5)},
 		Type:      &github.IssueType{Name: github.Ptr("Bug")},
 	}
@@ -1520,10 +1520,8 @@ func Test_CreateIssue(t *testing.T) {
 			name: "successful issue creation with issue fields reconciled by names",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				PostReposIssuesByOwnerByRepo: expectRequestBody(t, map[string]any{
-					"title":     "Issue with fields",
-					"body":      "",
-					"labels":    []any{},
-					"assignees": []any{},
+					"title": "Issue with fields",
+					"body":  "",
 					"issue_field_values": []any{
 						map[string]any{"field_id": float64(101), "value": "P1"},
 						map[string]any{"field_id": float64(102), "value": "Acme"},
@@ -2851,7 +2849,7 @@ func Test_UpdateIssue(t *testing.T) {
 		State:     github.Ptr("open"),
 		HTMLURL:   github.Ptr("https://github.com/owner/repo/issues/123"),
 		Assignees: []*github.User{{Login: github.Ptr("assignee1")}, {Login: github.Ptr("assignee2")}},
-		Labels:    []*github.Label{{Name: github.Ptr("bug")}, {Name: github.Ptr("priority")}},
+		Labels:    []*github.Label{{Name: "bug"}, {Name: "priority"}},
 		Milestone: &github.Milestone{Number: github.Ptr(5)},
 		Type:      &github.IssueType{Name: github.Ptr("Bug")},
 	}
@@ -2864,7 +2862,7 @@ func Test_UpdateIssue(t *testing.T) {
 		StateReason: github.Ptr("duplicate"),
 		HTMLURL:     github.Ptr("https://github.com/owner/repo/issues/123"),
 		Assignees:   []*github.User{{Login: github.Ptr("assignee1")}, {Login: github.Ptr("assignee2")}},
-		Labels:      []*github.Label{{Name: github.Ptr("bug")}, {Name: github.Ptr("priority")}},
+		Labels:      []*github.Label{{Name: "bug"}, {Name: "priority"}},
 		Milestone:   &github.Milestone{Number: github.Ptr(5)},
 		Type:        &github.IssueType{Name: github.Ptr("Bug")},
 	}
@@ -3265,7 +3263,7 @@ func Test_UpdateIssue(t *testing.T) {
 						Number:    github.Ptr(123),
 						Title:     github.Ptr("Updated Title"),
 						Body:      github.Ptr("Updated Description"),
-						Labels:    []*github.Label{{Name: github.Ptr("bug")}, {Name: github.Ptr("priority")}},
+						Labels:    []*github.Label{{Name: "bug"}, {Name: "priority"}},
 						Assignees: []*github.User{{Login: github.Ptr("assignee1")}, {Login: github.Ptr("assignee2")}},
 						Milestone: &github.Milestone{Number: github.Ptr(5)},
 						Type:      &github.IssueType{Name: github.Ptr("Bug")},
@@ -3970,8 +3968,8 @@ func Test_AddSubIssue(t *testing.T) {
 		},
 		Labels: []*github.Label{
 			{
-				Name:        github.Ptr("enhancement"),
-				Color:       github.Ptr("84b6eb"),
+				Name:        "enhancement",
+				Color:       "84b6eb",
 				Description: github.Ptr("New feature or request"),
 			},
 		},
@@ -4195,8 +4193,8 @@ func Test_GetSubIssues(t *testing.T) {
 			},
 			Labels: []*github.Label{
 				{
-					Name:        github.Ptr("bug"),
-					Color:       github.Ptr("d73a4a"),
+					Name:        "bug",
+					Color:       "d73a4a",
 					Description: github.Ptr("Something isn't working"),
 				},
 			},
@@ -4684,8 +4682,8 @@ func Test_RemoveSubIssue(t *testing.T) {
 		},
 		Labels: []*github.Label{
 			{
-				Name:        github.Ptr("enhancement"),
-				Color:       github.Ptr("84b6eb"),
+				Name:        "enhancement",
+				Color:       "84b6eb",
 				Description: github.Ptr("New feature or request"),
 			},
 		},
@@ -4892,8 +4890,8 @@ func Test_ReprioritizeSubIssue(t *testing.T) {
 		},
 		Labels: []*github.Label{
 			{
-				Name:        github.Ptr("enhancement"),
-				Color:       github.Ptr("84b6eb"),
+				Name:        "enhancement",
+				Color:       "84b6eb",
 				Description: github.Ptr("New feature or request"),
 			},
 		},

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -777,10 +777,10 @@ func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
-			newPR := &github.NewPullRequest{
+			newPR := &github.CreatePullRequest{
 				Title: github.Ptr(title),
-				Head:  github.Ptr(head),
-				Base:  github.Ptr(base),
+				Head:  head,
+				Base:  base,
 			}
 
 			if body != "" {
@@ -794,7 +794,7 @@ func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 			if err != nil {
 				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
 			}
-			pr, resp, err := client.PullRequests.Create(ctx, owner, repo, newPR)
+			pr, resp, err := client.PullRequests.Create(ctx, owner, repo, *newPR)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,
 					"failed to create pull request",

--- a/third-party-licenses.darwin.md
+++ b/third-party-licenses.darwin.md
@@ -17,7 +17,7 @@ The following packages are included for the amd64, arm64 architectures.
  - [github.com/github/github-mcp-server](https://pkg.go.dev/github.com/github/github-mcp-server) ([MIT](https://github.com/github/github-mcp-server/blob/HEAD/LICENSE))
  - [github.com/go-chi/chi/v5](https://pkg.go.dev/github.com/go-chi/chi/v5) ([MIT](https://github.com/go-chi/chi/blob/v5.3.1/LICENSE))
  - [github.com/go-viper/mapstructure/v2](https://pkg.go.dev/github.com/go-viper/mapstructure/v2) ([MIT](https://github.com/go-viper/mapstructure/blob/v2.5.0/LICENSE))
- - [github.com/google/go-github/v89/github](https://pkg.go.dev/github.com/google/go-github/v89/github) ([BSD-3-Clause](https://github.com/google/go-github/blob/v89.0.0/LICENSE))
+ - [github.com/google/go-github/v89/github](https://pkg.go.dev/github.com/google/go-github/v89/github) ([BSD-3-Clause](https://github.com/google/go-github/blob/34349a88bac3/LICENSE))
  - [github.com/google/go-querystring/query](https://pkg.go.dev/github.com/google/go-querystring/query) ([BSD-3-Clause](https://github.com/google/go-querystring/blob/v1.2.0/LICENSE))
  - [github.com/google/jsonschema-go/jsonschema](https://pkg.go.dev/github.com/google/jsonschema-go/jsonschema) ([MIT](https://github.com/google/jsonschema-go/blob/v0.4.3/LICENSE))
  - [github.com/gorilla/css/scanner](https://pkg.go.dev/github.com/gorilla/css/scanner) ([BSD-3-Clause](https://github.com/gorilla/css/blob/v1.0.1/LICENSE))

--- a/third-party-licenses.linux.md
+++ b/third-party-licenses.linux.md
@@ -17,7 +17,7 @@ The following packages are included for the 386, amd64, arm64 architectures.
  - [github.com/github/github-mcp-server](https://pkg.go.dev/github.com/github/github-mcp-server) ([MIT](https://github.com/github/github-mcp-server/blob/HEAD/LICENSE))
  - [github.com/go-chi/chi/v5](https://pkg.go.dev/github.com/go-chi/chi/v5) ([MIT](https://github.com/go-chi/chi/blob/v5.3.1/LICENSE))
  - [github.com/go-viper/mapstructure/v2](https://pkg.go.dev/github.com/go-viper/mapstructure/v2) ([MIT](https://github.com/go-viper/mapstructure/blob/v2.5.0/LICENSE))
- - [github.com/google/go-github/v89/github](https://pkg.go.dev/github.com/google/go-github/v89/github) ([BSD-3-Clause](https://github.com/google/go-github/blob/v89.0.0/LICENSE))
+ - [github.com/google/go-github/v89/github](https://pkg.go.dev/github.com/google/go-github/v89/github) ([BSD-3-Clause](https://github.com/google/go-github/blob/34349a88bac3/LICENSE))
  - [github.com/google/go-querystring/query](https://pkg.go.dev/github.com/google/go-querystring/query) ([BSD-3-Clause](https://github.com/google/go-querystring/blob/v1.2.0/LICENSE))
  - [github.com/google/jsonschema-go/jsonschema](https://pkg.go.dev/github.com/google/jsonschema-go/jsonschema) ([MIT](https://github.com/google/jsonschema-go/blob/v0.4.3/LICENSE))
  - [github.com/gorilla/css/scanner](https://pkg.go.dev/github.com/gorilla/css/scanner) ([BSD-3-Clause](https://github.com/gorilla/css/blob/v1.0.1/LICENSE))

--- a/third-party-licenses.windows.md
+++ b/third-party-licenses.windows.md
@@ -17,7 +17,7 @@ The following packages are included for the 386, amd64, arm64 architectures.
  - [github.com/github/github-mcp-server](https://pkg.go.dev/github.com/github/github-mcp-server) ([MIT](https://github.com/github/github-mcp-server/blob/HEAD/LICENSE))
  - [github.com/go-chi/chi/v5](https://pkg.go.dev/github.com/go-chi/chi/v5) ([MIT](https://github.com/go-chi/chi/blob/v5.3.1/LICENSE))
  - [github.com/go-viper/mapstructure/v2](https://pkg.go.dev/github.com/go-viper/mapstructure/v2) ([MIT](https://github.com/go-viper/mapstructure/blob/v2.5.0/LICENSE))
- - [github.com/google/go-github/v89/github](https://pkg.go.dev/github.com/google/go-github/v89/github) ([BSD-3-Clause](https://github.com/google/go-github/blob/v89.0.0/LICENSE))
+ - [github.com/google/go-github/v89/github](https://pkg.go.dev/github.com/google/go-github/v89/github) ([BSD-3-Clause](https://github.com/google/go-github/blob/34349a88bac3/LICENSE))
  - [github.com/google/go-querystring/query](https://pkg.go.dev/github.com/google/go-querystring/query) ([BSD-3-Clause](https://github.com/google/go-querystring/blob/v1.2.0/LICENSE))
  - [github.com/google/jsonschema-go/jsonschema](https://pkg.go.dev/github.com/google/jsonschema-go/jsonschema) ([MIT](https://github.com/google/jsonschema-go/blob/v0.4.3/LICENSE))
  - [github.com/gorilla/css/scanner](https://pkg.go.dev/github.com/gorilla/css/scanner) ([BSD-3-Clause](https://github.com/gorilla/css/blob/v1.0.1/LICENSE))


### PR DESCRIPTION
## Summary
Bumps `google/go-github` to a pseudo-version off upstream `master` ([google/go-github#4414](https://github.com/google/go-github/pull/4414)), which adds `SearchType` support to `SearchOptions`/`IssuesSearchResult`.

## Why
This is a prerequisite for making `search_issues` semantic by default (#2964) without a transport-level workaround. go-github only cuts full version releases, so this uses a commit-pinned pseudo-version rather than waiting on the next tag.

## What changed
- `go.mod`/`go.sum`: `google/go-github/v89` → `v89.0.1-0.20260728185857-34349a88bac3`
- Mechanical fixups for unrelated upstream API changes picked up by the bump:
  - `IssueRequest` split into `CreateIssueRequest` / `UpdateIssueRequest`; `Issues.Edit` renamed to `Issues.Update`
  - `NewPullRequest` renamed to `CreatePullRequest`
  - `Label.Name` / `Label.Color` changed from `*string` to `string`
- No behavior change on our side.

## MCP impact
- [x] No tool or API changes

## Prompts tested (tool changes only)
N/A — no tool schema or behavior changes.

## Security / limits
- [x] No security or limits impact

## Tool renaming
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs
- [x] Not needed
