### PR TITLE
Clarify that create_or_update_file content is plain text, not base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,7 +1278,7 @@ The following sets of tools are available:
 - **create_or_update_file** - Create or update file
   - **Required OAuth Scopes**: `repo`
   - `branch`: Branch to create/update the file in (string, required)
-  - `content`: Content of the file (string, required)
+  - `content`: Content of the file, exactly as it should appear once written. Do not base64-encode it; this server does that before calling the REST API. (string, required)
   - `message`: Commit message (string, required)
   - `owner`: Repository owner (username or organization) (string, required)
   - `path`: Path where to create/update the file (string, required)

--- a/pkg/github/__toolsnaps__/create_or_update_file.snap
+++ b/pkg/github/__toolsnaps__/create_or_update_file.snap
@@ -12,7 +12,7 @@
         "type": "string"
       },
       "content": {
-        "description": "Content of the file",
+        "description": "Content of the file, exactly as it should appear once written. Do not base64-encode it; this server does that before calling the REST API.",
         "type": "string"
       },
       "message": {

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -436,7 +436,7 @@ SHA MUST be provided for existing file updates.
 					},
 					"content": {
 						Type:        "string",
-						Description: "Content of the file",
+						Description: "Content of the file, exactly as it should appear once written. Do not base64-encode it; this server does that before calling the REST API.",
 					},
 					"message": {
 						Type:        "string",


### PR DESCRIPTION
Fixes the ambiguity reported in #2981.

`content` is passed to the API as plain text and this server base64-encodes it, but the description said only "Content of the file". The REST endpoint this wraps documents *its* `content` field as base64, so a model reading the tool description has a strong reason to encode the value itself. When it does, the server encodes again and the file is committed containing base64 text, with success reported at every layer.

The new description says how the value should end up on disk rather than only what not to do, so a file whose contents are legitimately base64 stays unambiguous. It also names the encoding step, so the conflict with the REST API docs is resolved rather than merely overridden.

```
Content of the file, exactly as it should appear once written. Do not base64-encode it;
this server does that before calling the REST API.
```

Scoped to `create_or_update_file` only. `push_files` and the gist tools pass content through without encoding, so this bug does not apply to them (see the follow-up comment on #2981).

Regenerated toolsnaps and README per CONTRIBUTING. `go test ./...` and `script/lint` both pass.
