### PR TITLE
Add adaptive Markdown tool responses

### DIFF
--- a/pkg/github/csv_output.go
+++ b/pkg/github/csv_output.go
@@ -51,7 +51,7 @@ func withCSVOutput(tools []inventory.ServerTool) []inventory.ServerTool {
 		if !isCSVOutputTool(tools[i]) {
 			continue
 		}
-		tools[i].HandlerFunc = wrapHandlerWithCSVOutput(tools[i].HandlerFunc)
+		tools[i].HandlerFunc = wrapHandlerWithCSVOutput(tools[i].Tool.Name, tools[i].HandlerFunc)
 	}
 	return tools
 }
@@ -68,7 +68,7 @@ func isCSVOutputTool(tool inventory.ServerTool) bool {
 	return strings.HasPrefix(tool.Tool.Name, "list_")
 }
 
-func wrapHandlerWithCSVOutput(next inventory.HandlerFunc) inventory.HandlerFunc {
+func wrapHandlerWithCSVOutput(toolName string, next inventory.HandlerFunc) inventory.HandlerFunc {
 	return func(deps any) mcp.ToolHandler {
 		handler := next(deps)
 		csvDeps, _ := deps.(ToolDependencies)
@@ -78,6 +78,9 @@ func wrapHandlerWithCSVOutput(next inventory.HandlerFunc) inventory.HandlerFunc 
 				return result, err
 			}
 			if csvDeps == nil || !csvDeps.IsFeatureEnabled(ctx, FeatureFlagCSVOutput) {
+				return result, nil
+			}
+			if isAdaptiveMarkdownOutputTool(toolName) && csvDeps.IsFeatureEnabled(ctx, FeatureFlagMarkdownOutput) {
 				return result, nil
 			}
 			return convertJSONTextResultToCSV(result), nil

--- a/pkg/github/feature_flags.go
+++ b/pkg/github/feature_flags.go
@@ -12,6 +12,10 @@ const MCPAppsDisableFormDeferralFeatureFlag = "mcp_apps_disable_form_deferral"
 // FeatureFlagCSVOutput is the feature flag name for CSV output on list tools.
 const FeatureFlagCSVOutput = "csv_output"
 
+// FeatureFlagMarkdownOutput is the feature flag name for adaptive Markdown
+// output on selected high-value collection responses.
+const FeatureFlagMarkdownOutput = "markdown_output"
+
 // FeatureFlagIFCLabels is the feature flag name for IFC security labels in tool results.
 const FeatureFlagIFCLabels = "ifc_labels"
 
@@ -35,6 +39,7 @@ var AllowedFeatureFlags = []string{
 	MCPAppsFeatureFlag,
 	MCPAppsDisableFormDeferralFeatureFlag,
 	FeatureFlagCSVOutput,
+	FeatureFlagMarkdownOutput,
 	FeatureFlagIFCLabels,
 	FeatureFlagIssuesGranular,
 	FeatureFlagPullRequestsGranular,

--- a/pkg/github/feature_flags_test.go
+++ b/pkg/github/feature_flags_test.go
@@ -173,6 +173,12 @@ func TestResolveFeatureFlags(t *testing.T) {
 			unexpectedFlags: []string{FeatureFlagIFCLabels},
 		},
 		{
+			name:            "insiders mode does not auto-enable Markdown output",
+			enabledFeatures: nil,
+			insidersMode:    true,
+			unexpectedFlags: []string{FeatureFlagMarkdownOutput},
+		},
+		{
 			name:            "insiders mode does not disable MCP Apps form deferral",
 			enabledFeatures: nil,
 			insidersMode:    true,
@@ -182,6 +188,11 @@ func TestResolveFeatureFlags(t *testing.T) {
 			name:            "ifc_labels can be directly enabled",
 			enabledFeatures: []string{FeatureFlagIFCLabels},
 			expectedFlags:   []string{FeatureFlagIFCLabels},
+		},
+		{
+			name:            "Markdown output can be directly enabled",
+			enabledFeatures: []string{FeatureFlagMarkdownOutput},
+			expectedFlags:   []string{FeatureFlagMarkdownOutput},
 		},
 		{
 			name:            "unknown flags are filtered out",

--- a/pkg/github/markdown_output.go
+++ b/pkg/github/markdown_output.go
@@ -1,0 +1,378 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	adaptiveMarkdownMinimumRows    = 10
+	adaptiveMarkdownMaxSizePercent = 95
+)
+
+type adaptiveMarkdownPolicy struct {
+	rowPath []string
+}
+
+var adaptiveMarkdownPolicies = map[string]adaptiveMarkdownPolicy{
+	"get_file_contents":    {},
+	"list_issues":          {rowPath: []string{"issues"}},
+	"search_issues":        {rowPath: []string{"items"}},
+	"list_pull_requests":   {},
+	"search_pull_requests": {rowPath: []string{"items"}},
+}
+
+var markdownColumnPriority = map[string]int{
+	"id":                 -1,
+	"number":             0,
+	"title":              1,
+	"body":               2,
+	"state":              3,
+	"draft":              4,
+	"merged":             5,
+	"status":             6,
+	"conclusion":         7,
+	"name":               8,
+	"path":               9,
+	"filename":           10,
+	"sha":                11,
+	"html_url":           12,
+	"url":                13,
+	"created_at":         14,
+	"updated_at":         15,
+	"total_count":        16,
+	"totalCount":         17,
+	"incomplete_results": 18,
+}
+
+// withAdaptiveMarkdownOutput wraps only the high-value tools whose successful
+// responses contain a known collection of repeated records.
+func withAdaptiveMarkdownOutput(tools []inventory.ServerTool) []inventory.ServerTool {
+	for i := range tools {
+		policy, ok := adaptiveMarkdownPolicies[tools[i].Tool.Name]
+		if !ok {
+			continue
+		}
+		tools[i].HandlerFunc = wrapHandlerWithAdaptiveMarkdownOutput(tools[i].HandlerFunc, policy)
+	}
+	return tools
+}
+
+func isAdaptiveMarkdownOutputTool(name string) bool {
+	_, ok := adaptiveMarkdownPolicies[name]
+	return ok
+}
+
+func wrapHandlerWithAdaptiveMarkdownOutput(next inventory.HandlerFunc, policy adaptiveMarkdownPolicy) inventory.HandlerFunc {
+	return func(deps any) mcp.ToolHandler {
+		handler := next(deps)
+		markdownDeps, _ := deps.(ToolDependencies)
+		return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			result, err := handler(ctx, req)
+			if err != nil || result == nil || result.IsError {
+				return result, err
+			}
+			if markdownDeps == nil || !markdownDeps.IsFeatureEnabled(ctx, FeatureFlagMarkdownOutput) {
+				return result, nil
+			}
+
+			converted, err := convertJSONTextResultToAdaptiveMarkdown(result, policy)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert response to Markdown: %w", err)
+			}
+			return converted, nil
+		}
+	}
+}
+
+func convertJSONTextResultToAdaptiveMarkdown(result *mcp.CallToolResult, policy adaptiveMarkdownPolicy) (*mcp.CallToolResult, error) {
+	if result == nil || result.IsError || len(result.Content) != 1 {
+		return result, nil
+	}
+
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok || !json.Valid([]byte(text.Text)) {
+		return result, nil
+	}
+
+	markdown, rowCount, ok, err := renderAdaptiveMarkdown(text.Text, policy)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || rowCount < adaptiveMarkdownMinimumRows {
+		return result, nil
+	}
+	if len(markdown)*100 > len(text.Text)*adaptiveMarkdownMaxSizePercent {
+		return result, nil
+	}
+
+	text.Text = markdown
+	result.StructuredContent = nil
+	return result, nil
+}
+
+func renderAdaptiveMarkdown(text string, policy adaptiveMarkdownPolicy) (string, int, bool, error) {
+	decoder := json.NewDecoder(strings.NewReader(text))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", 0, false, fmt.Errorf("failed to unmarshal JSON text: %w", err)
+	}
+
+	rows, metadata, collectionName, ok := markdownRows(value, policy.rowPath)
+	if !ok {
+		return "", 0, false, nil
+	}
+	if len(rows) < adaptiveMarkdownMinimumRows {
+		return "", len(rows), true, nil
+	}
+
+	flattenedRows := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		object, ok := row.(map[string]any)
+		if !ok {
+			return "", 0, false, nil
+		}
+		flattened := flattenedMarkdownFields(object)
+		if len(flattened) == 0 {
+			flattened = map[string]any{"value": map[string]any{}}
+		}
+		flattenedRows = append(flattenedRows, flattened)
+	}
+
+	var buf bytes.Buffer
+	if len(metadata) > 0 {
+		if err := writeMarkdownFields(&buf, metadata); err != nil {
+			return "", 0, false, err
+		}
+		buf.WriteString("\n\n")
+	}
+	if collectionName != "" {
+		fmt.Fprintf(&buf, "## %s\n\n", escapeMarkdownText(collectionName, false))
+	}
+	if err := writeMarkdownTable(&buf, flattenedRows); err != nil {
+		return "", 0, false, err
+	}
+
+	return strings.TrimSuffix(buf.String(), "\n"), len(rows), true, nil
+}
+
+func markdownRows(value any, path []string) ([]any, map[string]any, string, bool) {
+	if len(path) == 0 {
+		rows, ok := value.([]any)
+		return rows, nil, "", ok
+	}
+
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil, nil, "", false
+	}
+
+	var current any = root
+	for _, key := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, nil, "", false
+		}
+		current, ok = object[key]
+		if !ok {
+			return nil, nil, "", false
+		}
+	}
+
+	rows, ok := current.([]any)
+	if !ok {
+		return nil, nil, "", false
+	}
+	return rows, metadataWithoutPath(root, path), strings.Join(path, "."), true
+}
+
+func writeMarkdownFields(buf *bytes.Buffer, value map[string]any) error {
+	headers := markdownHeaders([]map[string]any{value})
+	for i, header := range headers {
+		rendered, err := markdownValue(value[header])
+		if err != nil {
+			return err
+		}
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		fmt.Fprintf(buf, "- %s: %s", markdownColumnName("", header), rendered)
+	}
+	return nil
+}
+
+func writeMarkdownTable(buf *bytes.Buffer, rows []map[string]any) error {
+	headers := markdownHeaders(rows)
+	writeMarkdownTableRow(buf, headers)
+
+	separators := make([]string, len(headers))
+	for i := range separators {
+		separators[i] = "---"
+	}
+	writeMarkdownTableRow(buf, separators)
+
+	for _, row := range rows {
+		cells := make([]string, len(headers))
+		for i, header := range headers {
+			value, ok := row[header]
+			if !ok {
+				continue
+			}
+			rendered, err := markdownValue(value)
+			if err != nil {
+				return err
+			}
+			cells[i] = rendered
+		}
+		writeMarkdownTableRow(buf, cells)
+	}
+	return nil
+}
+
+func writeMarkdownTableRow(buf *bytes.Buffer, cells []string) {
+	buf.WriteString("| ")
+	buf.WriteString(strings.Join(cells, " | "))
+	buf.WriteString(" |\n")
+}
+
+func flattenedMarkdownFields(value map[string]any) map[string]any {
+	fields := make(map[string]any)
+	appendFlattenedMarkdownFields(fields, value, "")
+	return fields
+}
+
+func appendFlattenedMarkdownFields(fields map[string]any, value map[string]any, prefix string) {
+	for key, raw := range value {
+		column := markdownColumnName(prefix, key)
+		child, ok := raw.(map[string]any)
+		if !ok {
+			fields[column] = raw
+			continue
+		}
+		if len(child) == 0 {
+			fields[column] = child
+			continue
+		}
+		appendFlattenedMarkdownFields(fields, child, column)
+	}
+}
+
+func markdownColumnName(prefix, key string) string {
+	key = strings.ReplaceAll(escapeMarkdownText(key, false), `.`, `\.`)
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
+}
+
+func markdownHeaders(rows []map[string]any) []string {
+	headerSet := make(map[string]struct{})
+	for _, row := range rows {
+		for header := range row {
+			headerSet[header] = struct{}{}
+		}
+	}
+
+	headers := make([]string, 0, len(headerSet))
+	for header := range headerSet {
+		headers = append(headers, header)
+	}
+	sort.Slice(headers, func(i, j int) bool {
+		leftPriority, leftPreferred := markdownColumnPriority[headers[i]]
+		rightPriority, rightPreferred := markdownColumnPriority[headers[j]]
+		switch {
+		case leftPreferred && rightPreferred:
+			return leftPriority < rightPriority
+		case leftPreferred:
+			return true
+		case rightPreferred:
+			return false
+		default:
+			return headers[i] < headers[j]
+		}
+	})
+	return headers
+}
+
+func markdownValue(value any) (string, error) {
+	switch v := value.(type) {
+	case nil:
+		return "null", nil
+	case string:
+		return markdownString(v), nil
+	case json.Number:
+		return v.String(), nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal Markdown value: %w", err)
+		}
+		return escapeMarkdownText(string(encoded), false), nil
+	}
+}
+
+func markdownString(value string) string {
+	quoted := markdownStringNeedsQuotes(value)
+	return escapeMarkdownText(value, quoted)
+}
+
+func markdownStringNeedsQuotes(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value {
+		return true
+	}
+	if json.Valid([]byte(value)) {
+		return true
+	}
+	_, err := strconv.ParseFloat(value, 64)
+	return err == nil
+}
+
+func escapeMarkdownText(value string, quoted bool) string {
+	var buf strings.Builder
+	if quoted {
+		buf.WriteByte('"')
+	}
+	for _, r := range value {
+		switch r {
+		case '\\':
+			buf.WriteString(`\\`)
+		case '|':
+			buf.WriteString(`\|`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '"':
+			if quoted {
+				buf.WriteString(`\"`)
+			} else {
+				buf.WriteRune(r)
+			}
+		default:
+			if unicode.IsControl(r) {
+				fmt.Fprintf(&buf, `\u%04x`, r)
+			} else {
+				buf.WriteRune(r)
+			}
+		}
+	}
+	if quoted {
+		buf.WriteByte('"')
+	}
+	return buf.String()
+}

--- a/pkg/github/markdown_output_test.go
+++ b/pkg/github/markdown_output_test.go
@@ -1,0 +1,289 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/utils"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdaptiveMarkdownOutputConvertsEligibleTools(t *testing.T) {
+	for name, policy := range adaptiveMarkdownPolicies {
+		t.Run(name, func(t *testing.T) {
+			response := markdownTestResponse(t, policy, markdownTestRows(adaptiveMarkdownMinimumRows))
+			tools := withAdaptiveMarkdownOutput([]inventory.ServerTool{testCSVOutputTool(name, response)})
+			deps := newMarkdownOutputTestDeps(FeatureFlagMarkdownOutput)
+
+			result, err := tools[0].Handler(deps)(
+				ContextWithDeps(context.Background(), deps),
+				testCSVOutputRequest(),
+			)
+			require.NoError(t, err)
+
+			text := textResult(t, result)
+			assert.Contains(t, text, "| number | title | body | user.login |")
+			assert.False(t, strings.HasPrefix(text, "{"))
+			assert.False(t, strings.HasPrefix(text, "["))
+			if len(policy.rowPath) > 0 {
+				assert.Contains(t, text, "## "+strings.Join(policy.rowPath, "."))
+			}
+		})
+	}
+}
+
+func TestAdaptiveMarkdownOutputPreservesJSONBelowThreshold(t *testing.T) {
+	policy := adaptiveMarkdownPolicies["list_pull_requests"]
+	response := markdownTestResponse(t, policy, markdownTestRows(adaptiveMarkdownMinimumRows-1))
+	tools := withAdaptiveMarkdownOutput([]inventory.ServerTool{
+		testCSVOutputTool("list_pull_requests", response),
+	})
+	deps := newMarkdownOutputTestDeps(FeatureFlagMarkdownOutput)
+
+	result, err := tools[0].Handler(deps)(
+		ContextWithDeps(context.Background(), deps),
+		testCSVOutputRequest(),
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, response, textResult(t, result))
+}
+
+func TestAdaptiveMarkdownOutputPreservesJSONWhenMarkdownIsNotSmaller(t *testing.T) {
+	rows := make([]map[string]any, adaptiveMarkdownMinimumRows)
+	for i := range rows {
+		rows[i] = map[string]any{fmt.Sprintf("field_%d", i): "x"}
+	}
+	policy := adaptiveMarkdownPolicies["list_pull_requests"]
+	response := markdownTestResponse(t, policy, rows)
+	tools := withAdaptiveMarkdownOutput([]inventory.ServerTool{
+		testCSVOutputTool("list_pull_requests", response),
+	})
+	deps := newMarkdownOutputTestDeps(FeatureFlagMarkdownOutput)
+
+	result, err := tools[0].Handler(deps)(
+		ContextWithDeps(context.Background(), deps),
+		testCSVOutputRequest(),
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, response, textResult(t, result))
+}
+
+func TestAdaptiveMarkdownOutputPreservesJSONWhenFlagDisabled(t *testing.T) {
+	policy := adaptiveMarkdownPolicies["list_pull_requests"]
+	response := markdownTestResponse(t, policy, markdownTestRows(adaptiveMarkdownMinimumRows))
+	tools := withAdaptiveMarkdownOutput([]inventory.ServerTool{
+		testCSVOutputTool("list_pull_requests", response),
+	})
+	deps := newMarkdownOutputTestDeps()
+
+	result, err := tools[0].Handler(deps)(
+		ContextWithDeps(context.Background(), deps),
+		testCSVOutputRequest(),
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, response, textResult(t, result))
+}
+
+func TestAdaptiveMarkdownOutputWrapsOnlySelectedTools(t *testing.T) {
+	response := markdownTestResponse(t, adaptiveMarkdownPolicy{rowPath: []string{"items"}}, markdownTestRows(adaptiveMarkdownMinimumRows))
+	tools := withAdaptiveMarkdownOutput([]inventory.ServerTool{
+		testCSVOutputTool("search_repositories", response),
+	})
+	deps := newMarkdownOutputTestDeps(FeatureFlagMarkdownOutput)
+
+	result, err := tools[0].Handler(deps)(
+		ContextWithDeps(context.Background(), deps),
+		testCSVOutputRequest(),
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, response, textResult(t, result))
+}
+
+func TestAdaptiveMarkdownOutputPreservesDistinctValuesAndMetadata(t *testing.T) {
+	rows := markdownTestRows(adaptiveMarkdownMinimumRows)
+	rows[0]["body"] = "line 1\nline 2 | value"
+	rows[0]["empty"] = ""
+	rows[0]["labels"] = []any{"bug", "help wanted"}
+	rows[0]["literal_boolean"] = "true"
+	rows[0]["missing"] = nil
+
+	encoded, err := json.Marshal(map[string]any{
+		"issues": rows,
+		"pageInfo": map[string]any{
+			"endCursor":   "cursor-10",
+			"hasNextPage": false,
+		},
+		"totalCount": len(rows),
+	})
+	require.NoError(t, err)
+
+	response := string(encoded)
+	result := utils.NewToolResultText(response)
+	result.Meta = mcp.Meta{"ifc": map[string]any{"confidentiality": "public"}}
+	result.StructuredContent = map[string]any{"issues": rows}
+
+	converted, err := convertJSONTextResultToAdaptiveMarkdown(result, adaptiveMarkdownPolicies["list_issues"])
+	require.NoError(t, err)
+
+	text := textResult(t, converted)
+	assert.Contains(t, text, "- totalCount: 10")
+	assert.Contains(t, text, `- pageInfo: {"endCursor":"cursor-10","hasNextPage":false}`)
+	assert.Contains(t, text, "## issues")
+	assert.Contains(t, text, "user.login")
+	assert.Contains(t, text, `line 1\nline 2 \| value`)
+	assert.Contains(t, text, `["bug","help wanted"]`)
+	assert.Contains(t, text, `""`)
+	assert.Contains(t, text, `"true"`)
+	assert.Contains(t, text, "null")
+	assert.Equal(t, mcp.Meta{"ifc": map[string]any{"confidentiality": "public"}}, converted.Meta)
+	assert.Nil(t, converted.StructuredContent)
+}
+
+func TestAdaptiveMarkdownOutputKeepsLiteralAndNestedColumnPathsDistinct(t *testing.T) {
+	rows := make([]map[string]any, adaptiveMarkdownMinimumRows)
+	for i := range rows {
+		rows[i] = map[string]any{
+			"a.b":      fmt.Sprintf("literal %d", i),
+			"a":        map[string]any{"b": fmt.Sprintf("nested %d", i)},
+			"pipe|key": fmt.Sprintf("pipe %d", i),
+		}
+	}
+
+	response := markdownTestResponse(t, adaptiveMarkdownPolicies["list_pull_requests"], rows)
+	result := utils.NewToolResultText(response)
+	converted, err := convertJSONTextResultToAdaptiveMarkdown(result, adaptiveMarkdownPolicies["list_pull_requests"])
+	require.NoError(t, err)
+
+	text := textResult(t, converted)
+	assert.Contains(t, text, `| a.b | a\.b | pipe\|key |`)
+	assert.Contains(t, text, "| nested 0 | literal 0 | pipe 0 |")
+}
+
+func TestAdaptiveMarkdownOutputLeavesOtherContentUnchanged(t *testing.T) {
+	policy := adaptiveMarkdownPolicies["list_pull_requests"]
+
+	raw := utils.NewToolResultText("diff --git a/file b/file")
+	converted, err := convertJSONTextResultToAdaptiveMarkdown(raw, policy)
+	require.NoError(t, err)
+	assert.Same(t, raw, converted)
+
+	resource := utils.NewToolResultResource("downloaded file", &mcp.ResourceContents{
+		URI:      "repo://owner/repo/refs/heads/main/contents/file",
+		Text:     "contents",
+		MIMEType: "text/plain",
+	})
+	converted, err = convertJSONTextResultToAdaptiveMarkdown(resource, policy)
+	require.NoError(t, err)
+	assert.Same(t, resource, converted)
+
+	errorResult := utils.NewToolResultError(markdownTestResponse(t, policy, markdownTestRows(adaptiveMarkdownMinimumRows)))
+	converted, err = convertJSONTextResultToAdaptiveMarkdown(errorResult, policy)
+	require.NoError(t, err)
+	assert.Same(t, errorResult, converted)
+	assert.True(t, converted.IsError)
+}
+
+func TestAdaptiveMarkdownOutputTakesPrecedenceOverCSVForSelectedTools(t *testing.T) {
+	candidateResponse := markdownTestResponse(
+		t,
+		adaptiveMarkdownPolicies["list_pull_requests"],
+		markdownTestRows(adaptiveMarkdownMinimumRows),
+	)
+	otherResponse := `[{"name":"main"},{"name":"release"}]`
+	tools := withAdaptiveMarkdownOutput(withCSVOutput([]inventory.ServerTool{
+		testCSVOutputTool("list_pull_requests", candidateResponse),
+		testCSVOutputTool("list_branches", otherResponse),
+	}))
+	deps := newMarkdownOutputTestDeps(FeatureFlagCSVOutput, FeatureFlagMarkdownOutput)
+
+	candidateResult, err := tools[0].Handler(deps)(
+		ContextWithDeps(context.Background(), deps),
+		testCSVOutputRequest(),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, textResult(t, candidateResult), "| number | title | body | user.login |")
+
+	otherResult, err := tools[1].Handler(deps)(
+		ContextWithDeps(context.Background(), deps),
+		testCSVOutputRequest(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "name\nmain\nrelease\n", textResult(t, otherResult))
+}
+
+func TestAdaptiveMarkdownOutputKeepsSmallSelectedResponsesAsJSONWhenCSVIsAlsoEnabled(t *testing.T) {
+	policy := adaptiveMarkdownPolicies["list_pull_requests"]
+	response := markdownTestResponse(t, policy, markdownTestRows(1))
+	tools := withAdaptiveMarkdownOutput(withCSVOutput([]inventory.ServerTool{
+		testCSVOutputTool("list_pull_requests", response),
+	}))
+	deps := newMarkdownOutputTestDeps(FeatureFlagCSVOutput, FeatureFlagMarkdownOutput)
+
+	result, err := tools[0].Handler(deps)(
+		ContextWithDeps(context.Background(), deps),
+		testCSVOutputRequest(),
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, response, textResult(t, result))
+}
+
+func markdownTestRows(count int) []map[string]any {
+	rows := make([]map[string]any, count)
+	for i := range rows {
+		rows[i] = map[string]any{
+			"number": i + 1,
+			"title":  fmt.Sprintf("Item %d", i+1),
+			"body":   "Looks good!",
+			"user": map[string]any{
+				"login": fmt.Sprintf("user-%d", i+1),
+			},
+		}
+	}
+	return rows
+}
+
+func markdownTestResponse(t *testing.T, policy adaptiveMarkdownPolicy, rows []map[string]any) string {
+	t.Helper()
+
+	var value any = rows
+	if len(policy.rowPath) > 0 {
+		value = map[string]any{
+			policy.rowPath[0]: rows,
+			"pageInfo": map[string]any{
+				"endCursor":   fmt.Sprintf("cursor-%d", len(rows)),
+				"hasNextPage": false,
+			},
+			"total_count": len(rows),
+		}
+	}
+
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+type markdownOutputTestDeps struct {
+	stubDeps
+	enabled map[string]bool
+}
+
+func newMarkdownOutputTestDeps(flags ...string) markdownOutputTestDeps {
+	enabled := make(map[string]bool, len(flags))
+	for _, flag := range flags {
+		enabled[flag] = true
+	}
+	return markdownOutputTestDeps{
+		stubDeps: stubDeps{obsv: stubExporters()},
+		enabled:  enabled,
+	}
+}
+
+func (d markdownOutputTestDeps) IsFeatureEnabled(_ context.Context, flag string) bool {
+	return d.enabled[flag]
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -183,7 +183,7 @@ var (
 // AllTools returns all tools with their embedded toolset metadata.
 // Tool functions return ServerTool directly with toolset info.
 func AllTools(t translations.TranslationHelperFunc) []inventory.ServerTool {
-	return withCSVOutput([]inventory.ServerTool{
+	return withAdaptiveMarkdownOutput(withCSVOutput([]inventory.ServerTool{
 		// Context tools
 		GetMe(t),
 		GetTeams(t),
@@ -345,7 +345,7 @@ func AllTools(t translations.TranslationHelperFunc) []inventory.ServerTool {
 		GranularResolveReviewThread(t),
 		GranularUnresolveReviewThread(t),
 		GranularAddPullRequestReviewCommentReaction(t),
-	})
+	}))
 }
 
 // ToBoolPtr converts a bool to a *bool pointer.


### PR DESCRIPTION
## Summary

Adds an opt-in adaptive Markdown response format for selected high-value collection tools, while retaining JSON whenever semantic compression is unlikely to help.


Tools affected: `get_file_contents`, `list_issues`, `search_issues`, `list_pull_requests`, `search_pull_requests`

</div>

## Why

Large, repeated JSON records spend context on duplicated keys and structural punctuation. Markdown tables can reduce that overhead for sufficiently large collections, but small responses should remain JSON because the fixed table syntax can be neutral or larger.

N/A — exploratory implementation for evaluation.

## What changed

- Added the `markdown_output` feature flag for directory listings and issue/pull-request list and search responses.
- Converts only collections with at least 10 object rows when the Markdown representation is at least 5% smaller by UTF-8 byte count; otherwise preserves the original JSON.
- Preserves metadata, values, row ordering, missing/null/empty distinctions, raw text, resources, errors, and unrelated tool responses.
- Keeps adaptive Markdown authoritative for selected tools when both Markdown and CSV experiments are enabled, while leaving CSV behavior unchanged for other list tools.

## MCP impact

- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

Successful responses from the selected tools may use Markdown instead of JSON only when `markdown_output` is explicitly enabled and the adaptive policy predicts a meaningful reduction. Tool names and input schemas are unchanged.

## Prompts tested (tool changes only)

- N/A — exercised through focused mocked handler tests rather than a live model prompt.

## Security / limits

- [ ] No security or limits impact
- [ ] Auth / permissions considered
- [x] Data exposure, filtering, or token/size limits considered

The renderer preserves every emitted field and value, composes with `fields` filtering, and leaves non-JSON content and MCP resources unchanged.

## Tool renaming

- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

Note: if you're renaming tools, you *must* add the tool aliases. For more information on how to do so, please refer to the [official docs](https://github.com/github/github-mcp-server/blob/main/docs/tool-renaming.md).

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)