### PR TITLE
Name the root command after the installed binary

### DIFF
--- a/cmd/github-mcp-server/main.go
+++ b/cmd/github-mcp-server/main.go
@@ -28,7 +28,7 @@ var date = "date"
 
 var (
 	rootCmd = &cobra.Command{
-		Use:     "server",
+		Use:     "github-mcp-server",
 		Short:   "GitHub MCP Server",
 		Long:    `A GitHub MCP server that handles various tools and resources.`,
 		Version: fmt.Sprintf("Version: %s\nCommit: %s\nBuild Date: %s", version, commit, date),


### PR DESCRIPTION
The cobra root command is declared as `Use: "server"`, but the binary is built and distributed as `github-mcp-server`. That mismatch has two user-visible consequences.

**Shell completions never fire.** `github-mcp-server completion bash` emits a dispatcher keyed on `server`:

```
$ github-mcp-server completion bash | grep -E "^(complete|__start)" 
__start_server()
complete -o default -F __start_server server
```

Installed as the completion file for `github-mcp-server` (which is how a distribution package ships it), none of it ever runs — the registration binds to a command name that is not on the user's PATH. The same applies to zsh (`#compdef server`) and fish.

**`--help` names a command that does not exist:**

```
$ github-mcp-server --help
...
Usage:
  server [command]
```

This changes the root command's `Use` to match the binary. After the change:

```
$ github-mcp-server completion bash | grep -E "^complete"
complete -o default -F __start_github-mcp-server github-mcp-server
$ github-mcp-server completion zsh | head -1
#compdef github-mcp-server
```

`cmd/mcpcurl` already does this correctly (`Use: "mcpcurl"`), so this only brings the server in line with its sibling. Nothing else in the tree refers to the root command by name and no test asserts it.

Found while packaging github-mcp-server for openSUSE, where the broken completions would otherwise have to be shipped or dropped.