### PR TITLE
Add non-default find_duplicate tool gated by duplicate_detection flag

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -338,4 +338,15 @@ runtime behavior (such as output formatting) won't appear here.
     - 'blocked_by' - the subject issue is blocked by the related issue.
     - 'blocking' - the subject issue blocks the related issue. (string, required)
 
+### `duplicate_detection`
+
+- **find_duplicate** - Find duplicate issues
+  - **Required OAuth Scopes**: `repo`
+  - `confidence_threshold`: Minimum similarity threshold for a candidate to be returned. When omitted, the API's high-precision default is used. (number, optional)
+  - `issue_number`: The number of the existing issue to find duplicates for (number, required)
+  - `owner`: The owner of the repository (string, required)
+  - `page`: Page number for pagination (min 1) (number, optional)
+  - `perPage`: Results per page for pagination (min 1, max 100) (number, optional)
+  - `repo`: The name of the repository (string, required)
+
 <!-- END AUTOMATED FEATURE FLAG TOOLS -->

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -342,7 +342,7 @@ runtime behavior (such as output formatting) won't appear here.
 
 - **find_duplicate** - Find duplicate issues
   - **Required OAuth Scopes**: `repo`
-  - `confidence_threshold`: Minimum similarity threshold for a candidate to be returned. When omitted, the API's high-precision default is used. (number, optional)
+  - `confidence_threshold`: Minimum similarity threshold a candidate must meet to be returned; higher values are stricter. When omitted, the API's high-precision default is used. The scale is defined by the API, so no client-side bounds are enforced. (number, optional)
   - `issue_number`: The number of the existing issue to find duplicates for (number, required)
   - `owner`: The owner of the repository (string, required)
   - `page`: Page number for pagination (min 1) (number, optional)

--- a/pkg/github/__toolsnaps__/find_duplicate_ff_duplicate_detection.snap
+++ b/pkg/github/__toolsnaps__/find_duplicate_ff_duplicate_detection.snap
@@ -1,0 +1,48 @@
+{
+  "annotations": {
+    "idempotentHint": false,
+    "readOnlyHint": true,
+    "title": "Find duplicate issues"
+  },
+  "description": "Find likely duplicate issues for an existing issue in a GitHub repository. This is a read-only search scoped to the source issue's repository: it returns ranked candidate issues with a similarity score and confidence, and does not close, link, comment on, or otherwise modify any issue.",
+  "inputSchema": {
+    "properties": {
+      "confidence_threshold": {
+        "description": "Minimum similarity threshold for a candidate to be returned. When omitted, the API's high-precision default is used.",
+        "maximum": 1,
+        "minimum": 0,
+        "type": "number"
+      },
+      "issue_number": {
+        "description": "The number of the existing issue to find duplicates for",
+        "type": "number"
+      },
+      "owner": {
+        "description": "The owner of the repository",
+        "type": "string"
+      },
+      "page": {
+        "description": "Page number for pagination (min 1)",
+        "minimum": 1,
+        "type": "number"
+      },
+      "perPage": {
+        "description": "Results per page for pagination (min 1, max 100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "repo": {
+        "description": "The name of the repository",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "issue_number"
+    ],
+    "type": "object"
+  },
+  "name": "find_duplicate"
+}

--- a/pkg/github/__toolsnaps__/find_duplicate_ff_duplicate_detection.snap
+++ b/pkg/github/__toolsnaps__/find_duplicate_ff_duplicate_detection.snap
@@ -8,9 +8,7 @@
   "inputSchema": {
     "properties": {
       "confidence_threshold": {
-        "description": "Minimum similarity threshold for a candidate to be returned. When omitted, the API's high-precision default is used.",
-        "maximum": 1,
-        "minimum": 0,
+        "description": "Minimum similarity threshold a candidate must meet to be returned; higher values are stricter. When omitted, the API's high-precision default is used. The scale is defined by the API, so no client-side bounds are enforced.",
         "type": "number"
       },
       "issue_number": {

--- a/pkg/github/feature_flags.go
+++ b/pkg/github/feature_flags.go
@@ -27,6 +27,13 @@ const FeatureFlagFileBlame = "file_blame"
 // unless explicitly opted in.
 const FeatureFlagIssueDependencies = "issue_dependencies"
 
+// FeatureFlagDuplicateDetection is the feature flag name for the find_duplicate
+// tool, which returns ranked duplicate candidates for an existing issue. It is
+// gated so the extra tool is not advertised by default, and is deliberately
+// excluded from insiders mode so duplicate detection is only ever an explicit
+// opt-in.
+const FeatureFlagDuplicateDetection = "duplicate_detection"
+
 // AllowedFeatureFlags is the allowlist of feature flags that can be enabled
 // by users via --features CLI flag or X-MCP-Features HTTP header.
 // Only flags in this list are accepted; unknown flags are silently ignored.
@@ -40,6 +47,7 @@ var AllowedFeatureFlags = []string{
 	FeatureFlagPullRequestsGranular,
 	FeatureFlagFileBlame,
 	FeatureFlagIssueDependencies,
+	FeatureFlagDuplicateDetection,
 }
 
 // InsidersFeatureFlags is the list of feature flags that insiders mode enables.

--- a/pkg/github/find_duplicate.go
+++ b/pkg/github/find_duplicate.go
@@ -1,0 +1,152 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/scopes"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/github/github-mcp-server/pkg/utils"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// duplicateIssueResult mirrors a single "Ranked Similar Issue" element returned
+// by the semantic-similarity endpoint. Issue is kept as raw JSON so the full
+// issue representation is preserved verbatim, and Score is nullable because the
+// API may omit a similarity score.
+type duplicateIssueResult struct {
+	Issue           json.RawMessage `json:"issue"`
+	Score           *float64        `json:"score"`
+	Confidence      string          `json:"confidence"`
+	LikelyDuplicate bool            `json:"likely_duplicate"`
+}
+
+// FindDuplicate creates a read-only tool that returns ranked duplicate
+// candidates for an existing issue. It is a separate, feature-flagged tool so
+// duplicate detection is only advertised when explicitly opted in, keeping the
+// default tool surface small. The semantic ranking itself is owned by the API;
+// this tool only forwards the request and projects the ranked results.
+func FindDuplicate(t translations.TranslationHelperFunc) inventory.ServerTool {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"owner": {
+				Type:        "string",
+				Description: "The owner of the repository",
+			},
+			"repo": {
+				Type:        "string",
+				Description: "The name of the repository",
+			},
+			"issue_number": {
+				Type:        "number",
+				Description: "The number of the existing issue to find duplicates for",
+			},
+			"confidence_threshold": {
+				Type:        "number",
+				Description: "Minimum similarity threshold for a candidate to be returned. When omitted, the API's high-precision default is used.",
+				Minimum:     jsonschema.Ptr(0.0),
+				Maximum:     jsonschema.Ptr(1.0),
+			},
+		},
+		Required: []string{"owner", "repo", "issue_number"},
+	}
+	WithPagination(schema)
+
+	st := NewTool(
+		ToolsetMetadataIssues,
+		mcp.Tool{
+			Name:        "find_duplicate",
+			Description: t("TOOL_FIND_DUPLICATE_DESCRIPTION", "Find likely duplicate issues for an existing issue in a GitHub repository. This is a read-only search scoped to the source issue's repository: it returns ranked candidate issues with a similarity score and confidence, and does not close, link, comment on, or otherwise modify any issue."),
+			Annotations: &mcp.ToolAnnotations{
+				Title:        t("TOOL_FIND_DUPLICATE_USER_TITLE", "Find duplicate issues"),
+				ReadOnlyHint: true,
+			},
+			InputSchema: schema,
+		},
+		[]scopes.Scope{scopes.Repo},
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			issueNumber, err := RequiredInt(args, "issue_number")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// Build the query preserving whether each optional value was supplied
+			// so unset parameters fall back to the API's own defaults.
+			query := url.Values{}
+			if threshold, ok, err := OptionalParamOK[float64](args, "confidence_threshold"); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			} else if ok {
+				query.Set("threshold", strconv.FormatFloat(threshold, 'g', -1, 64))
+			}
+			if _, ok := args["perPage"]; ok {
+				perPage, err := OptionalIntParam(args, "perPage")
+				if err != nil {
+					return utils.NewToolResultError(err.Error()), nil, nil
+				}
+				query.Set("per_page", strconv.Itoa(perPage))
+			}
+			if _, ok := args["page"]; ok {
+				page, err := OptionalIntParam(args, "page")
+				if err != nil {
+					return utils.NewToolResultError(err.Error()), nil, nil
+				}
+				query.Set("page", strconv.Itoa(page))
+			}
+
+			client, err := deps.GetClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub client", err), nil, nil
+			}
+
+			apiURL := fmt.Sprintf("repos/%s/%s/issues/%d/semantically_similar", owner, repo, issueNumber)
+			if encoded := query.Encode(); encoded != "" {
+				apiURL += "?" + encoded
+			}
+
+			req, err := client.NewRequest(ctx, http.MethodGet, apiURL, nil)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to create request", err), nil, nil
+			}
+
+			var results []duplicateIssueResult
+			resp, err := client.Do(req, &results)
+			if err != nil {
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to find duplicate issues", resp, err), nil, nil
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			// When ranked duplicate detection is not enabled for the caller, the
+			// endpoint returns bare issue resources instead of ranked results.
+			// Surface that as an explicit error rather than incomplete candidates.
+			for i := range results {
+				if results[i].Confidence == "" || len(results[i].Issue) == 0 {
+					return utils.NewToolResultError("ranked duplicate detection is unavailable: the semantic-similarity endpoint returned issues without ranking metadata (the server-side duplicate-ranking feature is not enabled for this caller or repository)"), nil, nil
+				}
+			}
+
+			r, err := json.Marshal(results)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to marshal duplicate candidates", err), nil, nil
+			}
+
+			return utils.NewToolResultText(string(r)), nil, nil
+		})
+	st.FeatureFlagEnable = FeatureFlagDuplicateDetection
+	return st
+}

--- a/pkg/github/find_duplicate.go
+++ b/pkg/github/find_duplicate.go
@@ -17,12 +17,25 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// duplicateIssueResult mirrors a single "Ranked Similar Issue" element returned
-// by the semantic-similarity endpoint. Issue is kept as raw JSON so the full
-// issue representation is preserved verbatim, and Score is nullable because the
-// API may omit a similarity score.
-type duplicateIssueResult struct {
-	Issue           json.RawMessage `json:"issue"`
+// rankedSimilarIssue is a single "Ranked Similar Issue" element returned by the
+// semantic-similarity endpoint. Only the issue fields the tool surfaces are
+// decoded, and Score is nullable because the API may omit a similarity score.
+type rankedSimilarIssue struct {
+	Issue *struct {
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		State   string `json:"state"`
+		HTMLURL string `json:"html_url"`
+	} `json:"issue"`
+	Score           *float64 `json:"score"`
+	Confidence      string   `json:"confidence"`
+	LikelyDuplicate bool     `json:"likely_duplicate"`
+}
+
+// duplicateCandidate is the trimmed output for a ranked duplicate candidate,
+// carrying only what an agent needs to explain and act on it.
+type duplicateCandidate struct {
+	Issue           MinimalIssueRef `json:"issue"`
 	Score           *float64        `json:"score"`
 	Confidence      string          `json:"confidence"`
 	LikelyDuplicate bool            `json:"likely_duplicate"`
@@ -51,9 +64,7 @@ func FindDuplicate(t translations.TranslationHelperFunc) inventory.ServerTool {
 			},
 			"confidence_threshold": {
 				Type:        "number",
-				Description: "Minimum similarity threshold for a candidate to be returned. When omitted, the API's high-precision default is used.",
-				Minimum:     jsonschema.Ptr(0.0),
-				Maximum:     jsonschema.Ptr(1.0),
+				Description: "Minimum similarity threshold a candidate must meet to be returned; higher values are stricter. When omitted, the API's high-precision default is used. The scale is defined by the API, so no client-side bounds are enforced.",
 			},
 		},
 		Required: []string{"owner", "repo", "issue_number"},
@@ -124,23 +135,35 @@ func FindDuplicate(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultErrorFromErr("failed to create request", err), nil, nil
 			}
 
-			var results []duplicateIssueResult
+			var results []rankedSimilarIssue
 			resp, err := client.Do(req, &results)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to find duplicate issues", resp, err), nil, nil
 			}
 			defer func() { _ = resp.Body.Close() }()
 
-			// When ranked duplicate detection is not enabled for the caller, the
-			// endpoint returns bare issue resources instead of ranked results.
-			// Surface that as an explicit error rather than incomplete candidates.
-			for i := range results {
-				if results[i].Confidence == "" || len(results[i].Issue) == 0 {
+			candidates := make([]duplicateCandidate, 0, len(results))
+			for _, res := range results {
+				// A bare issue (no ranking metadata) means ranked duplicate
+				// detection is not enabled for this caller; fail clearly rather
+				// than returning incomplete candidates.
+				if res.Confidence == "" || res.Issue == nil {
 					return utils.NewToolResultError("ranked duplicate detection is unavailable: the semantic-similarity endpoint returned issues without ranking metadata (the server-side duplicate-ranking feature is not enabled for this caller or repository)"), nil, nil
 				}
+				candidates = append(candidates, duplicateCandidate{
+					Issue: MinimalIssueRef{
+						Number: res.Issue.Number,
+						Title:  res.Issue.Title,
+						State:  res.Issue.State,
+						URL:    res.Issue.HTMLURL,
+					},
+					Score:           res.Score,
+					Confidence:      res.Confidence,
+					LikelyDuplicate: res.LikelyDuplicate,
+				})
 			}
 
-			r, err := json.Marshal(results)
+			r, err := json.Marshal(candidates)
 			if err != nil {
 				return utils.NewToolResultErrorFromErr("failed to marshal duplicate candidates", err), nil, nil
 			}

--- a/pkg/github/find_duplicate.go
+++ b/pkg/github/find_duplicate.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
@@ -168,7 +169,11 @@ func FindDuplicate(t translations.TranslationHelperFunc) inventory.ServerTool {
 				return utils.NewToolResultErrorFromErr("failed to marshal duplicate candidates", err), nil, nil
 			}
 
-			return utils.NewToolResultText(string(r)), nil, nil
+			// Candidate issue titles are user-authored content scoped to the source
+			// repository, so classify the result like issue_read.
+			result := utils.NewToolResultText(string(r))
+			result = attachRepoVisibilityIFCLabel(ctx, deps, client, owner, repo, result, ifc.LabelRepoUserContent)
+			return result, nil, nil
 		})
 	st.FeatureFlagEnable = FeatureFlagDuplicateDetection
 	return st

--- a/pkg/github/find_duplicate_test.go
+++ b/pkg/github/find_duplicate_test.go
@@ -238,3 +238,102 @@ func Test_FindDuplicate_Errors(t *testing.T) {
 		getErrorResult(t, result)
 	})
 }
+
+func Test_FindDuplicate_IFCLabels(t *testing.T) {
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+
+	rankedResults := []map[string]any{
+		{
+			"issue": map[string]any{
+				"number":   585,
+				"title":    "Improve the onboarding flow for new users",
+				"state":    "open",
+				"html_url": "https://github.com/owner/repo/issues/585",
+			},
+			"score":            1.93,
+			"confidence":       "high",
+			"likely_duplicate": true,
+		},
+	}
+
+	// makeClient serves the semantic-similarity endpoint plus the repo lookup
+	// that the IFC labeler uses to resolve visibility.
+	makeClient := func(isPrivate bool, repoStatus int) *http.Client {
+		handlers := map[string]http.HandlerFunc{
+			string(endpointSemanticallySimilar): mockResponse(t, http.StatusOK, rankedResults),
+		}
+		if repoStatus != 0 && repoStatus != http.StatusOK {
+			handlers[GetReposByOwnerByRepo] = mockResponse(t, repoStatus, "boom")
+		} else {
+			handlers[GetReposByOwnerByRepo] = mockResponse(t, http.StatusOK, map[string]any{
+				"name":    "repo",
+				"private": isPrivate,
+			})
+		}
+		return MockHTTPClientWithHandlers(handlers)
+	}
+
+	req := map[string]any{
+		"owner":        "owner",
+		"repo":         "repo",
+		"issue_number": float64(769),
+	}
+
+	t.Run("flag disabled omits ifc label", func(t *testing.T) {
+		deps := BaseDeps{Client: mustNewGHClient(t, makeClient(false, 0))}
+		handler := serverTool.Handler(deps)
+		request := createMCPRequest(req)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		assert.Nil(t, result.Meta)
+	})
+
+	t.Run("flag enabled on public repo emits public untrusted", func(t *testing.T) {
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeClient(false, 0)),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+		request := createMCPRequest(req)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		require.NotNil(t, result.Meta)
+		ifcMap := unmarshalIFC(t, result.Meta["ifc"])
+		assert.Equal(t, "untrusted", ifcMap["integrity"])
+		assert.Equal(t, "public", ifcMap["confidentiality"])
+	})
+
+	t.Run("flag enabled on private repo emits private trusted", func(t *testing.T) {
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeClient(true, 0)),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+		request := createMCPRequest(req)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		require.NotNil(t, result.Meta)
+		ifcMap := unmarshalIFC(t, result.Meta["ifc"])
+		assert.Equal(t, "trusted", ifcMap["integrity"])
+		assert.Equal(t, "private", ifcMap["confidentiality"])
+	})
+
+	t.Run("visibility lookup failure omits label but still succeeds", func(t *testing.T) {
+		deps := BaseDeps{
+			Client:         mustNewGHClient(t, makeClient(false, http.StatusInternalServerError)),
+			featureChecker: featureCheckerFor(FeatureFlagIFCLabels),
+		}
+		handler := serverTool.Handler(deps)
+		request := createMCPRequest(req)
+		result, err := handler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		require.False(t, result.IsError, "tool call should still succeed when visibility lookup fails")
+		if result.Meta != nil {
+			_, hasIFC := result.Meta["ifc"]
+			assert.False(t, hasIFC, "label must be omitted on visibility lookup failure")
+		}
+	})
+}

--- a/pkg/github/find_duplicate_test.go
+++ b/pkg/github/find_duplicate_test.go
@@ -101,7 +101,7 @@ func Test_FindDuplicate_RankedResults(t *testing.T) {
 	assert.Equal(t, "1", capturedURL.Query().Get("page"))
 
 	text := getTextResult(t, result)
-	var candidates []duplicateIssueResult
+	var candidates []duplicateCandidate
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &candidates))
 	require.Len(t, candidates, 2)
 
@@ -109,16 +109,10 @@ func Test_FindDuplicate_RankedResults(t *testing.T) {
 	assert.True(t, candidates[0].LikelyDuplicate)
 	require.NotNil(t, candidates[0].Score)
 	assert.InDelta(t, 0.95, *candidates[0].Score, 0.0001)
-	var firstIssue struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		State  string `json:"state"`
-		URL    string `json:"html_url"`
-	}
-	require.NoError(t, json.Unmarshal(candidates[0].Issue, &firstIssue))
-	assert.Equal(t, 456, firstIssue.Number)
-	assert.Equal(t, "open", firstIssue.State)
-	assert.NotEmpty(t, firstIssue.URL)
+	assert.Equal(t, 456, candidates[0].Issue.Number)
+	assert.Equal(t, "Example failure when saving", candidates[0].Issue.Title)
+	assert.Equal(t, "open", candidates[0].Issue.State)
+	assert.Equal(t, "https://github.com/owner/repo/issues/456", candidates[0].Issue.URL)
 
 	// A null score must decode successfully.
 	assert.Nil(t, candidates[1].Score)
@@ -176,7 +170,7 @@ func Test_FindDuplicate_EmptyResults(t *testing.T) {
 	require.False(t, result.IsError, "empty results is a successful search")
 
 	text := getTextResult(t, result)
-	var candidates []duplicateIssueResult
+	var candidates []duplicateCandidate
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &candidates))
 	assert.Empty(t, candidates)
 }

--- a/pkg/github/find_duplicate_test.go
+++ b/pkg/github/find_duplicate_test.go
@@ -1,0 +1,246 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/github/github-mcp-server/internal/toolsnaps"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const endpointSemanticallySimilar = EndpointPattern("GET /repos/{owner}/{repo}/issues/{issue_number}/semantically_similar")
+
+func Test_FindDuplicate(t *testing.T) {
+	// Verify tool definition once (flag-gated variant snap).
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+	tool := serverTool.Tool
+	require.NoError(t, toolsnaps.Test(tool.Name+"_ff_"+FeatureFlagDuplicateDetection, tool))
+	require.Equal(t, FeatureFlagDuplicateDetection, serverTool.FeatureFlagEnable)
+
+	assert.Equal(t, "find_duplicate", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.True(t, tool.Annotations.ReadOnlyHint)
+	assert.ElementsMatch(t, serverTool.RequiredScopes, []string{"repo"})
+
+	schema := tool.InputSchema.(*jsonschema.Schema)
+	assert.Contains(t, schema.Properties, "owner")
+	assert.Contains(t, schema.Properties, "repo")
+	assert.Contains(t, schema.Properties, "issue_number")
+	assert.Contains(t, schema.Properties, "confidence_threshold")
+	assert.Contains(t, schema.Properties, "page")
+	assert.Contains(t, schema.Properties, "perPage")
+	assert.ElementsMatch(t, schema.Required, []string{"owner", "repo", "issue_number"})
+}
+
+func Test_FindDuplicate_RankedResults(t *testing.T) {
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+
+	rankedResults := []map[string]any{
+		{
+			"issue": map[string]any{
+				"number":   456,
+				"title":    "Example failure when saving",
+				"state":    "open",
+				"html_url": "https://github.com/owner/repo/issues/456",
+			},
+			"score":            0.95,
+			"confidence":       "high",
+			"likely_duplicate": true,
+		},
+		{
+			"issue": map[string]any{
+				"number":   789,
+				"title":    "Possibly related",
+				"state":    "closed",
+				"html_url": "https://github.com/owner/repo/issues/789",
+			},
+			"score":            nil, // score is nullable
+			"confidence":       "low",
+			"likely_duplicate": false,
+		},
+	}
+
+	var capturedURL *url.URL
+	var capturedMethod string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL
+		capturedMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(MustMarshal(rankedResults))
+	}
+
+	client := mustNewGHClient(t, NewMockedHTTPClient(WithRequestMatchHandler(endpointSemanticallySimilar, http.HandlerFunc(handler))))
+	deps := BaseDeps{Client: client}
+	toolHandler := serverTool.Handler(deps)
+
+	request := createMCPRequest(map[string]any{
+		"owner":                "owner",
+		"repo":                 "repo",
+		"issue_number":         float64(123),
+		"confidence_threshold": float64(0.8),
+		"perPage":              float64(10),
+		"page":                 float64(1),
+	})
+	result, err := toolHandler(ContextWithDeps(context.Background(), deps), &request)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "expected result to not be an error")
+
+	// The tool must be read-only: only a GET is issued.
+	assert.Equal(t, http.MethodGet, capturedMethod)
+
+	// confidence_threshold maps to threshold; perPage maps to per_page; page is forwarded.
+	require.NotNil(t, capturedURL)
+	assert.Equal(t, "0.8", capturedURL.Query().Get("threshold"))
+	assert.Equal(t, "10", capturedURL.Query().Get("per_page"))
+	assert.Equal(t, "1", capturedURL.Query().Get("page"))
+
+	text := getTextResult(t, result)
+	var candidates []duplicateIssueResult
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &candidates))
+	require.Len(t, candidates, 2)
+
+	assert.Equal(t, "high", candidates[0].Confidence)
+	assert.True(t, candidates[0].LikelyDuplicate)
+	require.NotNil(t, candidates[0].Score)
+	assert.InDelta(t, 0.95, *candidates[0].Score, 0.0001)
+	var firstIssue struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		State  string `json:"state"`
+		URL    string `json:"html_url"`
+	}
+	require.NoError(t, json.Unmarshal(candidates[0].Issue, &firstIssue))
+	assert.Equal(t, 456, firstIssue.Number)
+	assert.Equal(t, "open", firstIssue.State)
+	assert.NotEmpty(t, firstIssue.URL)
+
+	// A null score must decode successfully.
+	assert.Nil(t, candidates[1].Score)
+	assert.Equal(t, "low", candidates[1].Confidence)
+	assert.False(t, candidates[1].LikelyDuplicate)
+}
+
+func Test_FindDuplicate_OmitsUnsetParams(t *testing.T) {
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+
+	var capturedURL *url.URL
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}
+
+	client := mustNewGHClient(t, NewMockedHTTPClient(WithRequestMatchHandler(endpointSemanticallySimilar, http.HandlerFunc(handler))))
+	deps := BaseDeps{Client: client}
+	toolHandler := serverTool.Handler(deps)
+
+	request := createMCPRequest(map[string]any{
+		"owner":        "owner",
+		"repo":         "repo",
+		"issue_number": float64(123),
+	})
+	result, err := toolHandler(ContextWithDeps(context.Background(), deps), &request)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	require.NotNil(t, capturedURL)
+	q := capturedURL.Query()
+	_, hasThreshold := q["threshold"]
+	_, hasPerPage := q["per_page"]
+	_, hasPage := q["page"]
+	assert.False(t, hasThreshold, "threshold should be omitted when unset")
+	assert.False(t, hasPerPage, "per_page should be omitted when unset")
+	assert.False(t, hasPage, "page should be omitted when unset")
+}
+
+func Test_FindDuplicate_EmptyResults(t *testing.T) {
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+
+	client := mustNewGHClient(t, NewMockedHTTPClient(WithRequestMatch(endpointSemanticallySimilar, []map[string]any{})))
+	deps := BaseDeps{Client: client}
+	toolHandler := serverTool.Handler(deps)
+
+	request := createMCPRequest(map[string]any{
+		"owner":        "owner",
+		"repo":         "repo",
+		"issue_number": float64(123),
+	})
+	result, err := toolHandler(ContextWithDeps(context.Background(), deps), &request)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "empty results is a successful search")
+
+	text := getTextResult(t, result)
+	var candidates []duplicateIssueResult
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &candidates))
+	assert.Empty(t, candidates)
+}
+
+func Test_FindDuplicate_LegacyBareIssueResponse(t *testing.T) {
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+
+	// When ranked duplicate detection is disabled the endpoint returns bare
+	// issue resources (no ranking metadata), which must fail clearly.
+	bareIssues := []map[string]any{
+		{
+			"number":   456,
+			"title":    "Example",
+			"state":    "open",
+			"html_url": "https://github.com/owner/repo/issues/456",
+		},
+	}
+
+	client := mustNewGHClient(t, NewMockedHTTPClient(WithRequestMatch(endpointSemanticallySimilar, bareIssues)))
+	deps := BaseDeps{Client: client}
+	toolHandler := serverTool.Handler(deps)
+
+	request := createMCPRequest(map[string]any{
+		"owner":        "owner",
+		"repo":         "repo",
+		"issue_number": float64(123),
+	})
+	result, err := toolHandler(ContextWithDeps(context.Background(), deps), &request)
+	require.NoError(t, err)
+	getErrorResult(t, result)
+}
+
+func Test_FindDuplicate_Errors(t *testing.T) {
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+
+	t.Run("missing required param", func(t *testing.T) {
+		client := mustNewGHClient(t, NewMockedHTTPClient())
+		deps := BaseDeps{Client: client}
+		toolHandler := serverTool.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"owner": "owner",
+			"repo":  "repo",
+		})
+		result, err := toolHandler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		getErrorResult(t, result)
+	})
+
+	t.Run("API error is surfaced", func(t *testing.T) {
+		client := mustNewGHClient(t, NewMockedHTTPClient(
+			WithRequestMatchHandler(endpointSemanticallySimilar, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+			})),
+		))
+		deps := BaseDeps{Client: client}
+		toolHandler := serverTool.Handler(deps)
+		request := createMCPRequest(map[string]any{
+			"owner":        "owner",
+			"repo":         "repo",
+			"issue_number": float64(123),
+		})
+		result, err := toolHandler(ContextWithDeps(context.Background(), deps), &request)
+		require.NoError(t, err)
+		getErrorResult(t, result)
+	})
+}

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -228,6 +228,7 @@ func AllTools(t translations.TranslationHelperFunc) []inventory.ServerTool {
 		SubIssueWrite(t),
 		IssueDependencyRead(t),
 		IssueDependencyWrite(t),
+		FindDuplicate(t),
 
 		// User tools
 		SearchUsers(t),


### PR DESCRIPTION
## Summary
Adds a read-only `find_duplicate` MCP tool that returns ranked duplicate candidates for an existing issue, gated behind a new opt-in `duplicate_detection` feature flag.

## Why
Enables agents to answer "what likely duplicates this issue?" using GitHub's semantic-similarity endpoint, without adding schema cost to agents that haven't opted into duplicate detection. Semantic ranking stays server-side; the tool is a thin, read-only client.

Closes https://github.com/github/plan-track-agentic-toolkit/issues/690

## What changed
- Add `find_duplicate` tool (Issues toolset, read-only) calling `GET /repos/{owner}/{repo}/issues/{issue_number}/semantically_similar`
- Add `duplicate_detection` feature flag to `AllowedFeatureFlags` (deliberately not in `InsidersFeatureFlags` so it's never implicitly enabled)
- Map `confidence_threshold`→`threshold`, `perPage`→`per_page`, `page`; omit optional params when unset so the API's high-precision defaults apply. No client-side bounds on `confidence_threshold` — the API owns the scale (observed scores exceed 1)
- Return a trimmed candidate — issue `{ number, title, state, url }` (via the existing `MinimalIssueRef`) plus ranking metadata (`score` nullable, `confidence`, `likely_duplicate`) — rather than the full issue/repository payload
- Surface a clear error for legacy bare-issue responses instead of a success-shaped empty list
- Add unit tests, tool snapshot, and regenerate `docs/feature-flags.md`

## MCP impact
- [x] New tool added
  - Adds `find_duplicate` to the Issues toolset. It is non-default and only registered when the `duplicate_detection` feature flag is enabled via `--features` or `X-MCP-Features`.

## Prompts tested (tool changes only)
Tested against a local build (`--features duplicate_detection`, `repo`-scoped PAT), via both Agent-mode prompts and direct JSON-RPC calls:

- Gating: `find_duplicate` is absent by default and present in `tools/list` only with the flag.
- "Using find_duplicate, find likely duplicates of issue 769 in github/issues-agentic-sandbox" → returned 585 ("Improve the onboarding flow for new users"), score ~1.93, confidence "high", likely_duplicate true.
- "Show the top 5 possible duplicates of issue 769 in that repo" (exercises `perPage`/`confidence_threshold`) → API returned the single genuine candidate; no error.
- Empty case — issue with no similar issues → `[]` (successful, not an error).
- Error case — a repo/issue where the endpoint isn't accessible → API `404` surfaced as an MCP tool error (`isError: true`), not a success-shaped empty result.

## Security / limits
- [x] Auth / permissions considered
  - Uses the caller's existing GitHub authentication; repository visibility and issue authorization are enforced by the API. The tool is read-only and mutates nothing.
- [x] Data exposure, filtering, or token/size limits considered
  - Results are scoped to the source issue's repository (API-enforced), trimmed to a compact candidate shape to limit response size, and support pagination via `perPage`/`page`.

## Tool renaming
- [x] I am not renaming tools as part of this PR

## Lint & tests
- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs
- [x] Updated (README / docs / examples)
  - Regenerated `docs/feature-flags.md` (documents the `duplicate_detection` opt-in and the read-only, single-repository `find_duplicate` tool). README needs no change — gated tools are intentionally excluded from its tool listing.