### PR TITLE
docs(claude): fix Docker install commands for claude mcp add

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ To keep your GitHub PAT secure and reusable across different MCP hosts:
 
    ```bash
    # CLI usage
-   claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PAT -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
+   export GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_PAT"
+   claude mcp add github -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
 
    # In config files (where supported)
    "env": {

--- a/docs/installation-guides/install-claude.md
+++ b/docs/installation-guides/install-claude.md
@@ -67,7 +67,7 @@ claude mcp add-json github "{`"type`":`"http`",`"url`":`"https://api.githubcopil
 Log in with OAuth instead of a token. On github.com the official image already includes the app credentials, so you provide none yourself — the server opens a browser login on first use and keeps the token in memory only. In Docker, publish a fixed callback port to loopback. Run the following command in the terminal (not in Claude Code CLI):
 
 ```bash
-claude mcp add github -e GITHUB_OAUTH_CALLBACK_PORT=8085 -- docker run -i --rm -p 127.0.0.1:8085:8085 -e GITHUB_OAUTH_CALLBACK_PORT ghcr.io/github/github-mcp-server
+claude mcp add github -- docker run -i --rm -p 127.0.0.1:8085:8085 -e GITHUB_OAUTH_CALLBACK_PORT=8085 ghcr.io/github/github-mcp-server
 ```
 
 See **[Local Server OAuth Login](../oauth-login.md)** for the native-binary flow (no fixed port), headless/device-code fallback, GitHub Enterprise, and bringing your own OAuth or GitHub App.
@@ -75,12 +75,13 @@ See **[Local Server OAuth Login](../oauth-login.md)** for the native-binary flow
 To authenticate with a Personal Access Token instead (it takes precedence over OAuth):
 1. Run the following command in the terminal (not in Claude Code CLI):
 ```bash
-claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PAT -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
+claude mcp add github -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PAT ghcr.io/github/github-mcp-server
 ```
 
 With an environment variable:
 ```bash
-claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=$(grep GITHUB_PAT .env | cut -d '=' -f2) -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
+export GITHUB_PERSONAL_ACCESS_TOKEN="$(grep '^GITHUB_PAT=' .env | cut -d '=' -f2-)"
+claude mcp add github -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
 ```
 2. Restart Claude Code
 3. Run `claude mcp list` to see if the GitHub server is configured


### PR DESCRIPTION
## Summary

Fix incorrect `claude mcp add` Docker install examples that pass `-e` flags to the Claude CLI, which fails with `error: unknown option '-e'`. Environment variables are now passed through `docker run` after `--`.

## Motivation

Fixes #3032. Users following the Claude Docker setup docs hit CLI errors because `claude mcp add` does not accept `-e`; only `docker run` should receive environment flags for containerized servers.

## Changes

- **docs/installation-guides/install-claude.md**
  - OAuth example: remove `-e` from `claude mcp add`; set `GITHUB_OAUTH_CALLBACK_PORT=8085` on `docker run`
  - PAT example: pass `GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PAT` via `docker run -e`
  - Env-var example: export token first, then use `docker run -e GITHUB_PERSONAL_ACCESS_TOKEN` pass-through
- **README.md**
  - Align CLI example with the same pattern and map `GITHUB_PAT` → `GITHUB_PERSONAL_ACCESS_TOKEN` before running Docker

## Tests

Documentation-only change. Verified:
- No remaining `claude mcp add ... -e` patterns in modified files
- OAuth command matches `docs/oauth-login.md` port/env conventions

## Notes

Claude Desktop JSON configs in the same guide already pass env vars via `docker run` args and were left unchanged.

Fixes #3032