### PR TITLE
fix(actions): avoid malformed response on log download failure

### DIFF
--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -146,11 +146,11 @@ func getJobLogData(ctx context.Context, client *github.Client, owner, repo strin
 		// Download and return the actual log content
 		content, originalLength, httpResp, err := downloadLogContent(ctx, url.String(), tailLines, contentWindowSize) //nolint:bodyclose // Response body is closed in downloadLogContent, but we need to return httpResp
 		if err != nil {
-			// To keep the return value consistent wrap the response as a GitHub Response
-			ghRes := &github.Response{
-				Response: httpResp,
+			var ghResp *github.Response
+			if httpResp != nil {
+				ghResp = &github.Response{Response: httpResp}
 			}
-			return nil, ghRes, fmt.Errorf("failed to download log content for job %d: %w", jobID, err)
+			return nil, ghResp, fmt.Errorf("failed to download log content for job %d: %w", jobID, err)
 		}
 		result["logs_content"] = content
 		result["message"] = "Job logs content retrieved successfully"

--- a/pkg/github/actions_test.go
+++ b/pkg/github/actions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/github/github-mcp-server/internal/toolsnaps"
@@ -622,6 +623,25 @@ func Test_ActionsGetJobLogs_SingleJob(t *testing.T) {
 		assert.Contains(t, response, "logs_url")
 		assert.Equal(t, "Job logs are available for download", response["message"])
 	})
+}
+
+func TestGetJobLogData_DownloadTransportErrorReturnsNilResponse(t *testing.T) {
+	logServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	logURL := logServer.URL
+	logServer.Close()
+
+	client := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+		GetReposActionsJobsLogsByOwnerByRepoByJobID: func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Location", logURL)
+			w.WriteHeader(http.StatusFound)
+		},
+	}))
+
+	_, resp, err := getJobLogData(t.Context(), client, "owner", "repo", 123, "", true, 100, 5000)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to download log content for job 123")
 }
 
 func Test_ActionsGetJobLogs_FailedJobs(t *testing.T) {


### PR DESCRIPTION
## Summary

- return a nil GitHub response when downloading workflow job logs fails before receiving an HTTP response
- preserve response metadata when an HTTP response is available
- add a regression test for transport failures

This prevents consumers such as `github-mcp-server-remote` from receiving a non-nil `*github.Response` whose embedded `*http.Response` is nil. Companion defensive fix: github/github-mcp-server-remote#926.