### PR TITLE
Fix PR branch selector overflow

### DIFF
--- a/ui/src/apps/pr-write/App.tsx
+++ b/ui/src/apps/pr-write/App.tsx
@@ -52,6 +52,22 @@ interface BranchItem {
   protected: boolean;
 }
 
+const branchMenuButtonSx = {
+  width: "100%",
+  minWidth: 0,
+  "& [data-component='buttonContent']": {
+    minWidth: 0,
+    overflow: "hidden",
+    flex: "1 1 auto",
+  },
+  "& [data-component='text']": {
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+} as const;
+
 type ReviewerItem = { kind: "user" | "team"; id: string; text: string; avatar?: string; org?: string };
 
 function reviewerFromValue(value: string): ReviewerItem {
@@ -570,7 +586,11 @@ function CreatePRApp() {
           <Box sx={{ flex: "1 1 120px", minWidth: 0 }}>
             <Text sx={{ fontSize: 0, color: "fg.muted", mb: 1, display: "block" }}>base</Text>
             <ActionMenu>
-              <ActionMenu.Button size="small" leadingVisual={GitBranchIcon} sx={{ width: "100%", "& > span": { overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } }}>
+              <ActionMenu.Button
+                size="small"
+                leadingVisual={GitBranchIcon}
+                sx={branchMenuButtonSx}
+              >
                 {baseBranch || "Select base"}
               </ActionMenu.Button>
               <ActionMenu.Overlay width="medium">
@@ -611,7 +631,11 @@ function CreatePRApp() {
           <Box sx={{ flex: "1 1 120px", minWidth: 0 }}>
             <Text sx={{ fontSize: 0, color: "fg.muted", mb: 1, display: "block" }}>compare</Text>
             <ActionMenu>
-              <ActionMenu.Button size="small" leadingVisual={GitBranchIcon} sx={{ width: "100%", "& > span": { overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } }}>
+              <ActionMenu.Button
+                size="small"
+                leadingVisual={GitBranchIcon}
+                sx={branchMenuButtonSx}
+              >
                 {headBranch || "Select head"}
               </ActionMenu.Button>
               <ActionMenu.Overlay width="medium">


### PR DESCRIPTION
## Summary

Keep long base and compare branch names inside the pull request creation form.

## Why

Primer buttons use `min-width: max-content` by default, so long branch names can push a selector past the form boundary instead of truncating.

Fixes #2979

## What changed

- Allow branch selector buttons and their content to shrink within the form.
- Apply ellipsis to the branch text while preserving the full accessible name and both icons.

## MCP impact

- [x] No tool or API changes

This only changes the MCP App layout.

## Prompts tested (tool changes only)

Not applicable. No tool behavior changed.

## Security / limits

- [x] No security or limits impact

This is a responsive styling fix.

## Tool renaming

- [x] I am not renaming tools as part of this PR

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`
- [x] Ran `cd ui && npm run typecheck`
- [x] Ran `script/build-ui`
- [x] Browser tested branch selectors from 240 px to 1600 px with short, long, Unicode, RTL, and empty branch states. Also verified filtering, selection, keyboard controls, resizing, dark mode, and pull request submission.

## Docs

- [x] Not needed
