### PR TITLE
fix: set destructiveHint: false on notification-subscription tools

### DIFF
--- a/pkg/github/__toolsnaps__/manage_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_notification_subscription.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": false,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Manage notification subscription"

--- a/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
+++ b/pkg/github/__toolsnaps__/manage_repository_notification_subscription.snap
@@ -1,5 +1,6 @@
 {
   "annotations": {
+    "destructiveHint": false,
     "idempotentHint": false,
     "readOnlyHint": false,
     "title": "Manage repository notification subscription"

--- a/pkg/github/notifications.go
+++ b/pkg/github/notifications.go
@@ -413,8 +413,9 @@ func ManageNotificationSubscription(t translations.TranslationHelperFunc) invent
 			Name:        "manage_notification_subscription",
 			Description: t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a notification subscription: ignore, watch, or delete a notification thread subscription."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(false),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
@@ -509,8 +510,9 @@ func ManageRepositoryNotificationSubscription(t translations.TranslationHelperFu
 			Name:        "manage_repository_notification_subscription",
 			Description: t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_DESCRIPTION", "Manage a repository notification subscription: ignore, watch, or delete repository notifications subscription for the provided repository."),
 			Annotations: &mcp.ToolAnnotations{
-				Title:        t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
-				ReadOnlyHint: false,
+				Title:           t("TOOL_MANAGE_REPOSITORY_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage repository notification subscription"),
+				ReadOnlyHint:    false,
+				DestructiveHint: jsonschema.Ptr(false),
 			},
 			InputSchema: &jsonschema.Schema{
 				Type: "object",


### PR DESCRIPTION
## Problem

`manage_notification_subscription` and `manage_repository_notification_subscription` both emit `readOnlyHint: false` but omit `destructiveHint`. Under MCP schema 2025-06-18, an omitted `destructiveHint` defaults to `true`, so a spec-conformant client renders both as destructive — even though they only update the caller's own subscription state (`watch`/`ignore`/remove the subscription preference) and don't modify thread or repository content. This makes consent UIs over-warn on what are actually low-risk, per-user preference toggles.

## Fix

Set `destructiveHint: false` explicitly on both, per #2841.

## Testing

`go build ./...` and `go test ./...` (full suite, all packages) pass. Regenerated the two affected toolsnaps via `UPDATE_TOOLSNAPS=true go test ./...` as instructed in CONTRIBUTING.md, and re-ran `script/generate-docs` (no doc changes needed — hints aren't rendered in the generated docs). `gofmt` clean on the changed file.

Fixes #2841