### PR TITLE
fix(issues): allow delete:false in issue_write issue_fields

### DIFF
--- a/pkg/github/__toolsnaps__/issue_write.snap
+++ b/pkg/github/__toolsnaps__/issue_write.snap
@@ -37,10 +37,7 @@
           "additionalProperties": false,
           "properties": {
             "delete": {
-              "description": "Set to true to clear this field's current value on the issue. Cannot be combined with 'value' or 'field_option_name'.",
-              "enum": [
-                true
-              ],
+              "description": "Set to true to clear this field's current value on the issue. Cannot be combined with 'value' or 'field_option_name'. Omit this property, or set it to false, to leave the field's current value unchanged.",
               "type": "boolean"
             },
             "field_name": {

--- a/pkg/github/__toolsnaps__/issue_write.snap
+++ b/pkg/github/__toolsnaps__/issue_write.snap
@@ -37,7 +37,7 @@
           "additionalProperties": false,
           "properties": {
             "delete": {
-              "description": "Set to true to clear this field's current value on the issue. Cannot be combined with 'value' or 'field_option_name'. Omit this property, or set it to false, to leave the field's current value unchanged.",
+              "description": "Set to true to clear this field's current value on the issue. When false or omitted, this property is ignored. Cannot be true when 'value' or 'field_option_name' is provided.",
               "type": "boolean"
             },
             "field_name": {
@@ -45,11 +45,11 @@
               "type": "string"
             },
             "field_option_name": {
-              "description": "Option name for single-select fields. Validated against the field's options before the API call. Cannot be combined with 'value' or 'delete'.",
+              "description": "Option name for single-select fields. Validated against the field's options before the API call. Cannot be combined with 'value' or 'delete: true'.",
               "type": "string"
             },
             "value": {
-              "description": "Value to set. Use for text, number, and date fields (date as YYYY-MM-DD). For single-select fields, prefer 'field_option_name' so the option is validated before the API call. Cannot be combined with 'field_option_name' or 'delete'.",
+              "description": "Value to set. Use for text, number, and date fields (date as YYYY-MM-DD). For single-select fields, prefer 'field_option_name' so the option is validated before the API call. Cannot be combined with 'field_option_name' or 'delete: true'.",
               "type": [
                 "string",
                 "number",

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -2447,9 +2447,10 @@ Options are:
 								},
 								"delete": {
 									Type: "boolean",
-									Enum: []any{true},
 									Description: "Set to true to clear this field's current value on the " +
-										"issue. Cannot be combined with 'value' or 'field_option_name'.",
+										"issue. Cannot be combined with 'value' or 'field_option_name'. " +
+										"Omit this property, or set it to false, to leave the field's " +
+										"current value unchanged.",
 								},
 							},
 							Required: []string{"field_name"},

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -265,7 +265,10 @@ func optionalIssueWriteFields(args map[string]any) ([]issueWriteFieldInput, erro
 			return nil, err
 		}
 
-		deleteField, _ := OptionalParam[bool](itemMap, "delete")
+		deleteField, err := OptionalParam[bool](itemMap, "delete")
+		if err != nil {
+			return nil, err
+		}
 		value, hasValue := itemMap["value"]
 		if hasValue && value == nil {
 			return nil, fmt.Errorf("value cannot be null for field %q", fieldName)
@@ -2437,20 +2440,19 @@ Options are:
 									Description: "Value to set. Use for text, number, and date fields " +
 										"(date as YYYY-MM-DD). For single-select fields, prefer " +
 										"'field_option_name' so the option is validated before the API " +
-										"call. Cannot be combined with 'field_option_name' or 'delete'.",
+										"call. Cannot be combined with 'field_option_name' or 'delete: true'.",
 								},
 								"field_option_name": {
 									Type: "string",
 									Description: "Option name for single-select fields. Validated against " +
 										"the field's options before the API call. Cannot be combined with " +
-										"'value' or 'delete'.",
+										"'value' or 'delete: true'.",
 								},
 								"delete": {
 									Type: "boolean",
 									Description: "Set to true to clear this field's current value on the " +
-										"issue. Cannot be combined with 'value' or 'field_option_name'. " +
-										"Omit this property, or set it to false, to leave the field's " +
-										"current value unchanged.",
+										"issue. When false or omitted, this property is ignored. Cannot " +
+										"be true when 'value' or 'field_option_name' is provided.",
 								},
 							},
 							Required: []string{"field_name"},

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -1840,8 +1840,8 @@ func Test_CreateIssue(t *testing.T) {
 				"repo":   "repo",
 				"title":  "Issue with fields",
 				"issue_fields": []any{
-					map[string]any{"field_name": "Priority", "field_option_name": "P1"},
-					map[string]any{"field_name": "Customer", "value": "Acme"},
+					map[string]any{"field_name": "Priority", "field_option_name": "P1", "delete": false},
+					map[string]any{"field_name": "Customer", "value": "Acme", "delete": false},
 				},
 			},
 			expectError: false,
@@ -1883,6 +1883,21 @@ func Test_CreateIssue(t *testing.T) {
 			},
 			expectError:    false,
 			expectedErrMsg: "cannot specify both value and field_option_name",
+		},
+		{
+			name:         "issue_fields rejects delete true with value",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{}),
+			requestArgs: map[string]any{
+				"method": "create",
+				"owner":  "owner",
+				"repo":   "repo",
+				"title":  "Invalid fields",
+				"issue_fields": []any{
+					map[string]any{"field_name": "Start date", "value": "2026-08-14", "delete": true},
+				},
+			},
+			expectError:    false,
+			expectedErrMsg: "cannot specify 'delete' together with 'value' or 'field_option_name'",
 		},
 	}
 
@@ -2115,11 +2130,17 @@ func Test_issueWriteHasNonFormParams(t *testing.T) {
 	}
 }
 
-// Test_optionalIssueWriteFields covers parsing of issue_write's issue_fields
-// items. The delete:false cases matter because the schema deliberately does not
-// constrain 'delete' to a single value: clients that populate every property of
-// a schema need a way to say "not deleting", and false must be a no-op that
-// falls through to the normal value path.
+func Test_IssueWriteIssueFieldsDeleteSchema(t *testing.T) {
+	t.Parallel()
+
+	inputSchema := IssueWrite(translations.NullTranslationHelper).Tool.InputSchema.(*jsonschema.Schema)
+	deleteSchema := inputSchema.Properties["issue_fields"].Items.Properties["delete"]
+
+	assert.Equal(t, "boolean", deleteSchema.Type)
+	assert.Empty(t, deleteSchema.Enum)
+	assert.Contains(t, deleteSchema.Description, "When false or omitted, this property is ignored")
+}
+
 func Test_optionalIssueWriteFields(t *testing.T) {
 	t.Parallel()
 
@@ -2130,9 +2151,14 @@ func Test_optionalIssueWriteFields(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "delete false alongside a value sets the value",
+			name: "delete false alongside a value is ignored",
 			item: map[string]any{"field_name": "Start date", "value": "2026-08-14", "delete": false, "field_option_name": ""},
 			want: issueWriteFieldInput{FieldName: "Start date", Value: "2026-08-14"},
+		},
+		{
+			name: "delete false alongside field_option_name is ignored",
+			item: map[string]any{"field_name": "Priority", "field_option_name": "High", "delete": false},
+			want: issueWriteFieldInput{FieldName: "Priority", FieldOptionName: "High"},
 		},
 		{
 			name: "delete true alone clears the field",
@@ -2150,9 +2176,19 @@ func Test_optionalIssueWriteFields(t *testing.T) {
 			wantErr: "cannot specify 'delete' together with 'value' or 'field_option_name'",
 		},
 		{
+			name:    "delete true with field_option_name is rejected",
+			item:    map[string]any{"field_name": "Priority", "field_option_name": "High", "delete": true},
+			wantErr: "cannot specify 'delete' together with 'value' or 'field_option_name'",
+		},
+		{
 			name:    "delete false with nothing to set is rejected",
 			item:    map[string]any{"field_name": "Start date", "delete": false},
 			wantErr: "must specify either value or field_option_name",
+		},
+		{
+			name:    "delete with invalid type is rejected",
+			item:    map[string]any{"field_name": "Start date", "delete": "false"},
+			wantErr: "parameter delete is not of type bool",
 		},
 	}
 

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -2115,6 +2115,63 @@ func Test_issueWriteHasNonFormParams(t *testing.T) {
 	}
 }
 
+// Test_optionalIssueWriteFields covers parsing of issue_write's issue_fields
+// items. The delete:false cases matter because the schema deliberately does not
+// constrain 'delete' to a single value: clients that populate every property of
+// a schema need a way to say "not deleting", and false must be a no-op that
+// falls through to the normal value path.
+func Test_optionalIssueWriteFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		item    map[string]any
+		want    issueWriteFieldInput
+		wantErr string
+	}{
+		{
+			name: "delete false alongside a value sets the value",
+			item: map[string]any{"field_name": "Start date", "value": "2026-08-14", "delete": false, "field_option_name": ""},
+			want: issueWriteFieldInput{FieldName: "Start date", Value: "2026-08-14"},
+		},
+		{
+			name: "delete true alone clears the field",
+			item: map[string]any{"field_name": "Start date", "delete": true},
+			want: issueWriteFieldInput{FieldName: "Start date", Delete: true},
+		},
+		{
+			name: "delete omitted with field_option_name",
+			item: map[string]any{"field_name": "Priority", "field_option_name": "High"},
+			want: issueWriteFieldInput{FieldName: "Priority", FieldOptionName: "High"},
+		},
+		{
+			name:    "delete true with a value is rejected",
+			item:    map[string]any{"field_name": "Start date", "value": "2026-08-14", "delete": true},
+			wantErr: "cannot specify 'delete' together with 'value' or 'field_option_name'",
+		},
+		{
+			name:    "delete false with nothing to set is rejected",
+			item:    map[string]any{"field_name": "Start date", "delete": false},
+			wantErr: "must specify either value or field_option_name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := optionalIssueWriteFields(map[string]any{"issue_fields": []any{tc.item}})
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, tc.want, got[0])
+		})
+	}
+}
+
 // Test_issueWriteSchemaClassification fails when a schema property is added
 // without classifying it as either form-resendable (issueWriteFormParams) or
 // known-non-form (knownNonForm below). Without this guard, an unclassified


### PR DESCRIPTION
## Summary

Removes `Enum: []any{true}` from the `delete` property of `issue_write`'s `issue_fields` item schema, so `delete: false` is a legal no-op instead of a schema-validation error.

## Why

`delete` was declared `{"type": "boolean", "enum": [true]}`. The property is optional, but a client that fills every property of a schema — common, since OpenAI-style strict function calling requires every property to appear in `required` — had no way to say "not deleting this field": there is no `false` in the enum and no `null` in the type. The sibling `value` property offers no alternative either, being typed `["string","number","boolean"]` with no `null`, and `issues.go` explicitly rejects `value: null`.

This is not only cosmetic. The MCP Go SDK validates arguments against the resolved input schema before the handler runs (`go-sdk@v1.7.0/mcp/server.go`, `applySchema`), so `delete: false` was rejected at validation and never reached `optionalIssueWriteFields`. Clients that fill every property instead sent `delete: true` alongside a `value` and hit the handler's mutual-exclusion check, so `issue_write` could never set an issue field for them.

## What changed
  
- `pkg/github/issues.go`: dropped `Enum: []any{true}` from the `delete` property of the `issue_fields` item schema; extended its description to state that omitting the property, or setting it to `false`, leaves the field's current value unchanged.
- `pkg/github/__toolsnaps__/issue_write.snap`: regenerated via `UPDATE_TOOLSNAPS=true`.
- `pkg/github/issues_test.go`: added `Test_optionalIssueWriteFields`, covering `delete: false` alongside a value, `delete: true` alone, `delete` omitted, and both existing error paths. This function previously had no test coverage.

No handler logic changed. `optionalIssueWriteFields` already reads `OptionalParam[bool](itemMap, "delete")` and branches on `if deleteField`, so `false` falls through to the normal value path, and the `delete: true` mutual-exclusion check still applies.

## MCP impact

- [ ] No tool or API changes
- [x] Tool schema or behavior changed
- [ ] New tool added

`issue_write.issue_fields[].delete` widens from `enum: [true]` to any boolean, and its description gains the no-op case. Strictly a relaxation: every payload valid before is still valid and behaves identically.

## Prompts tested (tool changes only)
  
- Worked against a live GitHub repository with org-level issue fields configured.
- Coverage is the new unit tests over `optionalIssueWriteFields` plus the regenerated schema snapshot.
- The reproducing payload, from an agent framework against `api.githubcopilot.com/mcp/`, was `{"method": "update", "issue_number": 5, "issue_fields": [{"field_name": "Start date", "value": "2026-08-14", "delete": true, "field_option_name": ""}]}` — rejected with `issue field "Start date" cannot specify 'delete' together with 'value' or 'field_option_name'` on seven consecutive calls across two runs. That client also sent `milestone: 0`, `duplicate_of: 0`, and `field_option_name: ""`; only `delete` had no benign value. The equivalent prompt is "Set the Start date field on issue #5 to 2026-08-14".
- Caveat: this does not guarantee such a client starts succeeding. Whether a given model emits `false` rather than `true` is unverified, and one copying its own prior call will keep sending `true`. The change removes a schema construct that *forces* failure on an otherwise recoverable mistake.

## Security / limits

- [x] No security or limits impact

Input validation is relaxed for one boolean that routes to an existing code path. No auth, permission, data-exposure, or size-limit surface is touched, and the mutual-exclusion check that prevents `delete: true` from being combined with `value` is unchanged.

## Tool renaming
  
- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

## Lint & tests
  
- [x] Linted locally with `./script/lint` — `0 issues.`
- [x] Tested locally with `./script/test` — full suite passes, including the snapshot check without `UPDATE_TOOLSNAPS` set.
  
## Docs
  
- [x] Not needed
- [ ] Updated (README / docs / examples)
  
Ran `./script/generate-docs`; it produced no diff. The generated tables do not include nested item-property descriptions, and a repo-wide grep found the old description only in `issue_write.snap`.


Fixes #2904.
