### PR TITLE
Add context-cost badge (transparency for the default toolset's schema size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/github/github-mcp-server)](https://goreportcard.com/report/github.com/github/github-mcp-server)
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fgithub.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
 
 # GitHub MCP Server
 


### PR DESCRIPTION
One line: a shields.io badge showing what the server's tool schemas cost in context tokens — currently **54,422 tokens across 44 tools** for the default Docker toolset (measured 2026-08-16). This is transparency users repeatedly ask for when budgeting context windows, and the number is already widely discussed in the ecosystem — a badge makes it accurate, versioned, and linked to a reproducible method instead of folklore.

Framing note: this is not a judgment — a full-platform server can be worth every token, and toolset filtering exists precisely for cost control. The per-tool breakdown may be independently useful: the top 5 tools (`issue_write` 1,890, `list_issues` 1,783, `pull_request_read` 1,737, `pull_request_review_write` 1,681, `search_issues` 1,678) carry a large share, mostly in inputSchema depth — [results/github/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/github/measurement.json) has the full capture.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to the methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from the published measurement. Numbers you can refute beat numbers people quote.

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).