### PR TITLE
Centralize sanitization of untrusted GitHub response fields

### DIFF
--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/sanitize"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
@@ -99,7 +100,7 @@ type WithCategoryNoOrder struct {
 func fragmentToDiscussion(fragment NodeFragment) *github.Discussion {
 	return &github.Discussion{
 		Number:    github.Ptr(int(fragment.Number)),
-		Title:     github.Ptr(string(fragment.Title)),
+		Title:     github.Ptr(sanitize.Sanitize(string(fragment.Title))),
 		HTMLURL:   github.Ptr(string(fragment.URL)),
 		CreatedAt: &github.Timestamp{Time: fragment.CreatedAt.Time},
 		UpdatedAt: &github.Timestamp{Time: fragment.UpdatedAt.Time},
@@ -360,8 +361,8 @@ func GetDiscussion(t translations.TranslationHelperFunc) inventory.ServerTool {
 			// like ListDiscussions and GetDiscussionComments).
 			response := map[string]any{
 				"number":     int(d.Number),
-				"title":      string(d.Title),
-				"body":       string(d.Body),
+				"title":      sanitize.Sanitize(string(d.Title)),
+				"body":       sanitize.Sanitize(string(d.Body)),
 				"url":        string(d.URL),
 				"closed":     bool(d.Closed),
 				"isAnswered": bool(d.IsAnswered),
@@ -520,18 +521,10 @@ func GetDiscussionComments(t translations.TranslationHelperFunc) inventory.Serve
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
 				for _, c := range q.Repository.Discussion.Comments.Nodes {
-					comment := MinimalDiscussionComment{
-						ID:              fmt.Sprintf("%v", c.ID),
-						Body:            string(c.Body),
-						IsAnswer:        bool(c.IsAnswer),
-						ReplyTotalCount: c.Replies.TotalCount,
-					}
+					comment := newMinimalDiscussionComment(fmt.Sprintf("%v", c.ID), string(c.Body), bool(c.IsAnswer))
+					comment.ReplyTotalCount = c.Replies.TotalCount
 					for _, r := range c.Replies.Nodes {
-						comment.Replies = append(comment.Replies, MinimalDiscussionComment{
-							ID:       fmt.Sprintf("%v", r.ID),
-							Body:     string(r.Body),
-							IsAnswer: bool(r.IsAnswer),
-						})
+						comment.Replies = append(comment.Replies, newMinimalDiscussionComment(fmt.Sprintf("%v", r.ID), string(r.Body), bool(r.IsAnswer)))
 					}
 					comments = append(comments, comment)
 				}
@@ -562,11 +555,7 @@ func GetDiscussionComments(t translations.TranslationHelperFunc) inventory.Serve
 					return utils.NewToolResultError(err.Error()), nil, nil
 				}
 				for _, c := range q.Repository.Discussion.Comments.Nodes {
-					comments = append(comments, MinimalDiscussionComment{
-						ID:       fmt.Sprintf("%v", c.ID),
-						Body:     string(c.Body),
-						IsAnswer: bool(c.IsAnswer),
-					})
+					comments = append(comments, newMinimalDiscussionComment(fmt.Sprintf("%v", c.ID), string(c.Body), bool(c.IsAnswer)))
 				}
 				pageInfo = q.Repository.Discussion.Comments.PageInfo
 				totalCount = q.Repository.Discussion.Comments.TotalCount

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -553,6 +553,30 @@ func Test_GetDiscussion(t *testing.T) {
 			expectError: true,
 			errContains: "discussion not found",
 		},
+		{
+			name: "sanitizes malicious title and body",
+			response: githubv4mock.DataResponse(map[string]any{
+				"repository": map[string]any{"discussion": map[string]any{
+					"number":     1,
+					"title":      maliciousText,
+					"body":       maliciousText,
+					"url":        "https://github.com/owner/repo/discussions/1",
+					"createdAt":  "2025-04-25T12:00:00Z",
+					"closed":     false,
+					"isAnswered": false,
+					"category":   map[string]any{"name": "General"},
+				}},
+			}),
+			expectError: false,
+			expected: map[string]any{
+				"number":     float64(1),
+				"title":      sanitizedText,
+				"body":       sanitizedText,
+				"url":        "https://github.com/owner/repo/discussions/1",
+				"closed":     false,
+				"isAnswered": false,
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/github/find_duplicate.go
+++ b/pkg/github/find_duplicate.go
@@ -152,12 +152,15 @@ func FindDuplicate(t translations.TranslationHelperFunc) inventory.ServerTool {
 					return utils.NewToolResultError("ranked duplicate detection is unavailable: the semantic-similarity endpoint returned issues without ranking metadata (the server-side duplicate-ranking feature is not enabled for this caller or repository)"), nil, nil
 				}
 				candidates = append(candidates, duplicateCandidate{
-					Issue: MinimalIssueRef{
-						Number: res.Issue.Number,
-						Title:  res.Issue.Title,
-						State:  res.Issue.State,
-						URL:    res.Issue.HTMLURL,
-					},
+					// Candidates are always scoped to the requested repository, so the
+					// ref's repository field is left empty as it was before.
+					Issue: newMinimalIssueRef(
+						res.Issue.Number,
+						res.Issue.Title,
+						res.Issue.State,
+						res.Issue.HTMLURL,
+						"",
+					),
 					Score:           res.Score,
 					Confidence:      res.Confidence,
 					LikelyDuplicate: res.LikelyDuplicate,

--- a/pkg/github/find_duplicate_test.go
+++ b/pkg/github/find_duplicate_test.go
@@ -120,6 +120,52 @@ func Test_FindDuplicate_RankedResults(t *testing.T) {
 	assert.False(t, candidates[1].LikelyDuplicate)
 }
 
+// Test_FindDuplicate_SanitizesIssueTitle asserts that candidate issue titles, which are
+// user-authored content from an arbitrary repository, are sanitized before being returned.
+// Without this the tool would forward hidden-instruction payloads straight to the model.
+func Test_FindDuplicate_SanitizesIssueTitle(t *testing.T) {
+	serverTool := FindDuplicate(translations.NullTranslationHelper)
+
+	rankedResults := []map[string]any{
+		{
+			"issue": map[string]any{
+				"number":   456,
+				"title":    maliciousText,
+				"state":    "open",
+				"html_url": "https://github.com/owner/repo/issues/456",
+			},
+			"score":            0.95,
+			"confidence":       "high",
+			"likely_duplicate": true,
+		},
+	}
+
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(MustMarshal(rankedResults))
+	}
+
+	client := mustNewGHClient(t, NewMockedHTTPClient(WithRequestMatchHandler(endpointSemanticallySimilar, http.HandlerFunc(handler))))
+	deps := BaseDeps{Client: client}
+	toolHandler := serverTool.Handler(deps)
+
+	request := createMCPRequest(map[string]any{
+		"owner":        "owner",
+		"repo":         "repo",
+		"issue_number": float64(123),
+	})
+	result, err := toolHandler(ContextWithDeps(context.Background(), deps), &request)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "expected result to not be an error")
+
+	text := getTextResult(t, result)
+	var candidates []duplicateCandidate
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &candidates))
+	require.Len(t, candidates, 1)
+	assert.Equal(t, sanitizedText, candidates[0].Issue.Title)
+	assert.NotContains(t, text.Text, "<script>")
+}
+
 func Test_FindDuplicate_OmitsUnsetParams(t *testing.T) {
 	serverTool := FindDuplicate(translations.NullTranslationHelper)
 

--- a/pkg/github/issue_dependencies.go
+++ b/pkg/github/issue_dependencies.go
@@ -171,16 +171,17 @@ func issueToDependencyRef(issue *github.Issue) MinimalIssueRef {
 	if issue == nil {
 		return MinimalIssueRef{}
 	}
-	ref := MinimalIssueRef{
-		Number: issue.GetNumber(),
-		Title:  issue.GetTitle(),
-		State:  strings.ToUpper(issue.GetState()),
-		URL:    issue.GetHTMLURL(),
-	}
+	var repository string
 	if owner, repo, ok := parseRepositoryURL(issue.GetRepositoryURL()); ok {
-		ref.Repository = owner + "/" + repo
+		repository = owner + "/" + repo
 	}
-	return ref
+	return newMinimalIssueRef(
+		issue.GetNumber(),
+		issue.GetTitle(),
+		strings.ToUpper(issue.GetState()),
+		issue.GetHTMLURL(),
+		repository,
+	)
 }
 
 // IssueDependencyWrite creates a tool to add or remove an issue dependency

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -2196,13 +2196,13 @@ func fetchIssueReadEnrichment(ctx context.Context, gqlClient *githubv4.Client, n
 
 		if p := n.Issue.Parent; p != nil {
 			enrichment.Parent = &issueReadParent{
-				Ref: MinimalIssueRef{
-					Number:     int(p.Number),
-					Title:      sanitize.Sanitize(string(p.Title)),
-					State:      string(p.State),
-					URL:        string(p.URL),
-					Repository: string(p.Repository.NameWithOwner),
-				},
+				Ref: newMinimalIssueRef(
+					int(p.Number),
+					string(p.Title),
+					string(p.State),
+					string(p.URL),
+					string(p.Repository.NameWithOwner),
+				),
 				AuthorLogin: string(p.Author.Login),
 			}
 		}
@@ -2210,13 +2210,13 @@ func fetchIssueReadEnrichment(ctx context.Context, gqlClient *githubv4.Client, n
 		closing := make([]issueReadClosingPullRequest, 0, len(n.Issue.ClosedByPullRequestsReferences.Nodes))
 		for _, pr := range n.Issue.ClosedByPullRequestsReferences.Nodes {
 			closing = append(closing, issueReadClosingPullRequest{
-				Ref: MinimalPullRequestRef{
-					Number:     int(pr.Number),
-					Title:      sanitize.Sanitize(string(pr.Title)),
-					State:      string(pr.State),
-					URL:        string(pr.URL),
-					Repository: string(pr.Repository.NameWithOwner),
-				},
+				Ref: newMinimalPullRequestRef(
+					int(pr.Number),
+					string(pr.Title),
+					string(pr.State),
+					string(pr.URL),
+					string(pr.Repository.NameWithOwner),
+				),
 				AuthorLogin: string(pr.Author.Login),
 			})
 		}

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -920,16 +920,6 @@ func GetIssue(ctx context.Context, client *github.Client, deps ToolDependencies,
 		}
 	}
 
-	// Sanitize title/body on response
-	if issue != nil {
-		if issue.Title != nil {
-			issue.Title = github.Ptr(sanitize.Sanitize(*issue.Title))
-		}
-		if issue.Body != nil {
-			issue.Body = github.Ptr(sanitize.Sanitize(*issue.Body))
-		}
-	}
-
 	minimalIssue := convertToMinimalIssue(issue)
 
 	// Always drop the verbose REST IssueFieldValues; enrich with the GraphQL
@@ -2003,9 +1993,31 @@ type SearchIssueResult struct {
 	FieldValues []MinimalFieldValue `json:"field_values,omitempty"`
 }
 
+// sanitizeIssueTitleAndBody mutates issue.Title and issue.Body in place, applying the shared
+// untrusted-content sanitization policy (pkg/sanitize). It exists for the handful of response
+// paths — search_issues and search_pull_requests — that marshal a raw *github.Issue directly
+// instead of routing through one of the convertToMinimal* helpers in minimal_types.go, which
+// sanitize on their own. It is a no-op for a nil issue or unset fields.
+func sanitizeIssueTitleAndBody(issue *github.Issue) {
+	if issue == nil {
+		return
+	}
+	if issue.Title != nil {
+		issue.Title = github.Ptr(sanitize.Sanitize(*issue.Title))
+	}
+	if issue.Body != nil {
+		issue.Body = github.Ptr(sanitize.Sanitize(*issue.Body))
+	}
+}
+
 // MarshalJSON serializes SearchIssueResult, suppressing the raw issue_field_values from the
 // embedded REST response in favour of the normalized field_values populated via GraphQL enrichment.
+// It also sanitizes the embedded issue's Title and Body in place: search_issues is one of the few
+// response paths that marshals a raw *github.Issue directly rather than routing through a
+// convertToMinimal* helper (see minimal_types.go), so sanitization must happen here instead.
 func (r SearchIssueResult) MarshalJSON() ([]byte, error) {
+	sanitizeIssueTitleAndBody(r.Issue)
+
 	issueBytes, err := json.Marshal(r.Issue)
 	if err != nil {
 		return nil, err

--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -198,6 +198,17 @@ type MinimalDiscussionComment struct {
 	ReplyTotalCount int                        `json:"replyTotalCount,omitempty"`
 }
 
+// newMinimalDiscussionComment is the single constructor for MinimalDiscussionComment,
+// ensuring the untrusted, user-authored body is sanitized consistently regardless of
+// which discussion query (with or without replies) produced it.
+func newMinimalDiscussionComment(id string, body string, isAnswer bool) MinimalDiscussionComment {
+	return MinimalDiscussionComment{
+		ID:       id,
+		Body:     sanitize.Sanitize(body),
+		IsAnswer: isAnswer,
+	}
+}
+
 // MinimalCodeSearchResult is the trimmed output type for code search results.
 type MinimalCodeSearchResult struct {
 	TotalCount        int                 `json:"total_count"`
@@ -759,7 +770,7 @@ func convertToMinimalPullRequestReview(review *github.PullRequestReview) Minimal
 	m := MinimalPullRequestReview{
 		ID:                review.GetID(),
 		State:             review.GetState(),
-		Body:              review.GetBody(),
+		Body:              sanitize.Sanitize(review.GetBody()),
 		HTMLURL:           review.GetHTMLURL(),
 		User:              convertToMinimalUser(review.GetUser()),
 		CommitID:          review.GetCommitID(),
@@ -776,8 +787,8 @@ func convertToMinimalPullRequestReview(review *github.PullRequestReview) Minimal
 func convertToMinimalIssue(issue *github.Issue) MinimalIssue {
 	m := MinimalIssue{
 		Number:            issue.GetNumber(),
-		Title:             issue.GetTitle(),
-		Body:              issue.GetBody(),
+		Title:             sanitize.Sanitize(issue.GetTitle()),
+		Body:              sanitize.Sanitize(issue.GetBody()),
 		State:             issue.GetState(),
 		StateReason:       issue.GetStateReason(),
 		Draft:             issue.GetDraft(),
@@ -977,7 +988,7 @@ func convertToMinimalIssuesResponseWithoutFieldValues(fragment issueQueryFragmen
 func convertToMinimalIssueComment(comment *github.IssueComment) MinimalIssueComment {
 	m := MinimalIssueComment{
 		ID:                comment.GetID(),
-		Body:              comment.GetBody(),
+		Body:              sanitize.Sanitize(comment.GetBody()),
 		HTMLURL:           comment.GetHTMLURL(),
 		User:              convertToMinimalUser(comment.GetUser()),
 		AuthorAssociation: comment.GetAuthorAssociation(),
@@ -1026,7 +1037,7 @@ func convertToMinimalFileContentResponse(resp *github.RepositoryContentResponse)
 
 	m.Commit = &MinimalFileCommit{
 		SHA:     resp.Commit.GetSHA(),
-		Message: resp.Commit.GetMessage(),
+		Message: sanitize.Sanitize(resp.Commit.GetMessage()),
 		HTMLURL: resp.Commit.GetHTMLURL(),
 	}
 
@@ -1046,8 +1057,8 @@ func convertToMinimalFileContentResponse(resp *github.RepositoryContentResponse)
 func convertToMinimalPullRequest(pr *github.PullRequest) MinimalPullRequest {
 	m := MinimalPullRequest{
 		Number:         pr.GetNumber(),
-		Title:          pr.GetTitle(),
-		Body:           pr.GetBody(),
+		Title:          sanitize.Sanitize(pr.GetTitle()),
+		Body:           sanitize.Sanitize(pr.GetBody()),
 		State:          pr.GetState(),
 		Draft:          pr.GetDraft(),
 		Merged:         pr.GetMerged(),
@@ -1241,7 +1252,7 @@ func convertIssueToMinimalProjectItemContent(issue *github.Issue) *MinimalProjec
 		ID:          issue.GetID(),
 		NodeID:      issue.GetNodeID(),
 		Number:      issue.GetNumber(),
-		Title:       issue.GetTitle(),
+		Title:       sanitize.Sanitize(issue.GetTitle()),
 		State:       issue.GetState(),
 		StateReason: issue.GetStateReason(),
 		HTMLURL:     issue.GetHTMLURL(),
@@ -1278,7 +1289,7 @@ func convertPullRequestToMinimalProjectItemContent(pr *github.PullRequest) *Mini
 		ID:         pr.GetID(),
 		NodeID:     pr.GetNodeID(),
 		Number:     pr.GetNumber(),
-		Title:      pr.GetTitle(),
+		Title:      sanitize.Sanitize(pr.GetTitle()),
 		State:      pr.GetState(),
 		HTMLURL:    pr.GetHTMLURL(),
 		Repository: pullRequestRepositoryFullName(pr),
@@ -1315,7 +1326,7 @@ func convertDraftIssueToMinimalProjectItemContent(draftIssue *github.ProjectV2Dr
 	m := &MinimalProjectItemContent{
 		ID:        draftIssue.GetID(),
 		NodeID:    draftIssue.GetNodeID(),
-		Title:     draftIssue.GetTitle(),
+		Title:     sanitize.Sanitize(draftIssue.GetTitle()),
 		CreatedAt: formatProjectTimestamp(draftIssue.CreatedAt),
 		UpdatedAt: formatProjectTimestamp(draftIssue.UpdatedAt),
 	}
@@ -1574,7 +1585,7 @@ func minimalProjectPullRequestRefFromPullRequest(pr *github.PullRequest) minimal
 	}
 	return minimalProjectPullRequestRef{
 		Number:     pr.GetNumber(),
-		Title:      pr.GetTitle(),
+		Title:      sanitize.Sanitize(pr.GetTitle()),
 		State:      pr.GetState(),
 		HTMLURL:    pr.GetHTMLURL(),
 		Repository: pullRequestRepositoryFullName(pr),
@@ -1596,7 +1607,7 @@ func minimalProjectPullRequestRefFromMap(value map[string]any) minimalProjectPul
 
 	return minimalProjectPullRequestRef{
 		Number:     intFromAny(value["number"]),
-		Title:      stringFromMap(value, "title"),
+		Title:      sanitize.Sanitize(stringFromMap(value, "title")),
 		State:      stringFromMap(value, "state"),
 		HTMLURL:    htmlURL,
 		Repository: repository,
@@ -1756,7 +1767,7 @@ func newMinimalCommitFromCore(sha, htmlURL string, commit *github.Commit, author
 
 	if commit != nil {
 		minimalCommit.Commit = &MinimalCommitInfo{
-			Message: commit.GetMessage(),
+			Message: sanitize.Sanitize(commit.GetMessage()),
 		}
 
 		if commit.Author != nil {
@@ -1959,7 +1970,7 @@ func convertToMinimalPullRequestCommits(commits []*github.RepositoryCommit) []Mi
 		}
 
 		if commit.Commit != nil {
-			minimalCommit.Message = commit.Commit.GetMessage()
+			minimalCommit.Message = sanitize.Sanitize(commit.Commit.GetMessage())
 			minimalCommit.Author = convertToMinimalCommitAuthor(commit.Commit.Author)
 		}
 
@@ -1997,8 +2008,8 @@ func convertToMinimalRelease(release *github.RepositoryRelease) MinimalRelease {
 	m := MinimalRelease{
 		ID:         release.GetID(),
 		TagName:    release.GetTagName(),
-		Name:       release.GetName(),
-		Body:       release.GetBody(),
+		Name:       sanitize.Sanitize(release.GetName()),
+		Body:       sanitize.Sanitize(release.GetBody()),
 		HTMLURL:    release.GetHTMLURL(),
 		Prerelease: release.GetPrerelease(),
 		Draft:      release.GetDraft(),
@@ -2054,7 +2065,7 @@ func convertToMinimalWorkflowRun(workflowRun *github.WorkflowRun) MinimalWorkflo
 
 	if headCommit := workflowRun.GetHeadCommit(); headCommit != nil && headCommit.GetMessage() != "" {
 		minimalRun.HeadCommit = &MinimalWorkflowRunHeadCommit{
-			Message: headCommit.GetMessage(),
+			Message: sanitize.Sanitize(headCommit.GetMessage()),
 		}
 	}
 
@@ -2239,7 +2250,7 @@ func convertToMinimalReviewThread(thread reviewThreadNode) MinimalReviewThread {
 
 func convertToMinimalReviewComment(c reviewCommentNode) MinimalReviewComment {
 	m := MinimalReviewComment{
-		Body:    string(c.Body),
+		Body:    sanitize.Sanitize(string(c.Body)),
 		Path:    string(c.Path),
 		Author:  string(c.Author.Login),
 		HTMLURL: c.URL.String(),

--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -616,6 +616,19 @@ type MinimalPullRequestRef struct {
 	Repository string `json:"repository,omitempty"`
 }
 
+// newMinimalPullRequestRef builds a MinimalPullRequestRef, sanitizing the user-authored
+// title. Callers should use it rather than the struct literal so every tool surfacing a
+// pull request reference strips untrusted content identically.
+func newMinimalPullRequestRef(number int, title, state, url, repository string) MinimalPullRequestRef {
+	return MinimalPullRequestRef{
+		Number:     number,
+		Title:      sanitize.Sanitize(title),
+		State:      state,
+		URL:        url,
+		Repository: repository,
+	}
+}
+
 // MinimalIssueRef is a compact reference to a related issue (e.g. a parent issue).
 // Its keys mirror the get_parent (GetIssueParent) response shape.
 type MinimalIssueRef struct {
@@ -624,6 +637,20 @@ type MinimalIssueRef struct {
 	State      string `json:"state"`
 	URL        string `json:"url"`
 	Repository string `json:"repository,omitempty"`
+}
+
+// newMinimalIssueRef builds a MinimalIssueRef, sanitizing the user-authored title. Callers
+// should use it rather than the struct literal so every tool surfacing an issue reference
+// (issue_read's parent, issue_dependency_read/write, find_duplicate) strips untrusted
+// content identically.
+func newMinimalIssueRef(number int, title, state, url, repository string) MinimalIssueRef {
+	return MinimalIssueRef{
+		Number:     number,
+		Title:      sanitize.Sanitize(title),
+		State:      state,
+		URL:        url,
+		Repository: repository,
+	}
 }
 
 // MinimalSubIssuesSummary holds the native GraphQL subIssuesSummary counts for an issue.

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -15,6 +15,7 @@ import (
 	ghErrors "github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/sanitize"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
@@ -265,7 +266,7 @@ func convertToMinimalStatusUpdate(node statusUpdateNode) MinimalProjectStatusUpd
 
 	return MinimalProjectStatusUpdate{
 		ID:         fmt.Sprintf("%v", node.ID),
-		Body:       derefString(node.Body),
+		Body:       sanitize.Sanitize(derefString(node.Body)),
 		Status:     derefString(node.Status),
 		CreatedAt:  node.CreatedAt.Time.Format(time.RFC3339),
 		StartDate:  derefString(node.StartDate),

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -17,7 +17,6 @@ import (
 	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/octicons"
-	"github.com/github/github-mcp-server/pkg/sanitize"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
@@ -183,16 +182,6 @@ func GetPullRequest(ctx context.Context, client *github.Client, deps ToolDepende
 			return nil, fmt.Errorf("failed to read response body: %w", err)
 		}
 		return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to get pull request", resp, body), nil
-	}
-
-	// sanitize title/body on response
-	if pr != nil {
-		if pr.Title != nil {
-			pr.Title = github.Ptr(sanitize.Sanitize(*pr.Title))
-		}
-		if pr.Body != nil {
-			pr.Body = github.Ptr(sanitize.Sanitize(*pr.Body))
-		}
 	}
 
 	if ff.LockdownMode {
@@ -1462,19 +1451,6 @@ func ListPullRequests(t translations.TranslationHelperFunc) inventory.ServerTool
 					return utils.NewToolResultErrorFromErr("failed to read response body", err), nil, nil
 				}
 				return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, "failed to list pull requests", resp, bodyBytes), nil, nil
-			}
-
-			// sanitize title/body on each PR
-			for _, pr := range prs {
-				if pr == nil {
-					continue
-				}
-				if pr.Title != nil {
-					pr.Title = github.Ptr(sanitize.Sanitize(*pr.Title))
-				}
-				if pr.Body != nil {
-					pr.Body = github.Ptr(sanitize.Sanitize(*pr.Body))
-				}
 			}
 
 			minimalPRs := make([]MinimalPullRequest, 0, len(prs))

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -16,6 +16,7 @@ import (
 	"github.com/github/github-mcp-server/pkg/ifc"
 	"github.com/github/github-mcp-server/pkg/inventory"
 	"github.com/github/github-mcp-server/pkg/octicons"
+	"github.com/github/github-mcp-server/pkg/sanitize"
 	"github.com/github/github-mcp-server/pkg/scopes"
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/github/github-mcp-server/pkg/utils"
@@ -2950,8 +2951,10 @@ func GetFileBlame(t translations.TranslationHelperFunc) inventory.ServerTool {
 				}
 				headline = strings.TrimRight(headline, " \t\r")
 				bc := BlameCommit{
-					SHA:             sha,
-					MessageHeadline: headline,
+					SHA: sha,
+					// Sanitized after truncation so the headline is cut at the author's real
+					// first line break rather than one introduced by sanitization.
+					MessageHeadline: sanitize.Sanitize(headline),
 					CommittedDate:   r.Commit.CommittedDate.Format("2006-01-02T15:04:05Z"),
 					Author: BlameAuthor{
 						Name:  string(r.Commit.Author.Name),

--- a/pkg/github/repositories_test.go
+++ b/pkg/github/repositories_test.go
@@ -6076,6 +6076,54 @@ func Test_GetFileBlame(t *testing.T) {
 			},
 		},
 		{
+			// Commit messages are user-authored and untrusted: the headline must be
+			// truncated at the author's real first line break and then sanitized.
+			name: "blame commit message headline is sanitized",
+			mockedClient: githubv4mock.NewMockedHTTPClient(
+				githubv4mock.NewQueryMatcher(
+					blameQueryShape{},
+					makeBlameVars("testowner", "testrepo", "HEAD", "README.md"),
+					githubv4mock.DataResponse(map[string]any{
+						"repository": map[string]any{
+							"defaultBranchRef": map[string]any{"name": "main"},
+							"object": map[string]any{
+								"__typename": "Commit",
+								"blame": map[string]any{
+									"ranges": []map[string]any{
+										{
+											"startingLine": 1, "endingLine": 3, "age": 1,
+											"commit": map[string]any{
+												"oid":           "badc0ffee0000",
+												"message":       maliciousText + "\n\nLong body that should not appear.",
+												"committedDate": "2024-01-03T10:00:00Z",
+												"author": map[string]any{
+													"name": "Bob Developer", "email": "bob@example.com",
+													"user": nil,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+				),
+			),
+			requestArgs: map[string]any{
+				"owner": "testowner",
+				"repo":  "testrepo",
+				"path":  "README.md",
+			},
+			validateResponse: func(t *testing.T, result string) {
+				var br BlameResult
+				require.NoError(t, json.Unmarshal([]byte(result), &br))
+				require.Contains(t, br.Commits, "badc0ffee0000")
+				assert.Equal(t, sanitizedText, br.Commits["badc0ffee0000"].MessageHeadline)
+				assert.NotContains(t, result, "<script>")
+				assert.NotContains(t, result, "Long body that should not appear")
+			},
+		},
+		{
 			name: "successful blame with annotated tag ref",
 			mockedClient: githubv4mock.NewMockedHTTPClient(
 				githubv4mock.NewQueryMatcher(

--- a/pkg/github/sanitize_coverage_test.go
+++ b/pkg/github/sanitize_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v89/github"
 	"github.com/shurcooL/githubv4"
@@ -191,6 +192,35 @@ func Test_MinimalConverters_SanitizeUserAuthoredText(t *testing.T) {
 			got: func() string {
 				return minimalProjectPullRequestRefFromMap(map[string]any{
 					"title": maliciousText,
+				}).Title
+			},
+		},
+		{
+			name: "project status update body (projects_get / projects_list)",
+			got: func() string {
+				return convertToMinimalStatusUpdate(statusUpdateNode{
+					Body:      githubv4.NewString(githubv4.String(maliciousText)),
+					CreatedAt: githubv4.DateTime{Time: time.Unix(0, 0).UTC()},
+				}).Body
+			},
+		},
+		{
+			name: "issue ref title (shared constructor)",
+			got: func() string {
+				return newMinimalIssueRef(1, maliciousText, "OPEN", "https://github.com/o/r/issues/1", "o/r").Title
+			},
+		},
+		{
+			name: "pull request ref title (shared constructor)",
+			got: func() string {
+				return newMinimalPullRequestRef(1, maliciousText, "OPEN", "https://github.com/o/r/pull/1", "o/r").Title
+			},
+		},
+		{
+			name: "issue dependency ref title (issue_dependency_read / issue_dependency_write)",
+			got: func() string {
+				return issueToDependencyRef(&github.Issue{
+					Title: github.Ptr(maliciousText),
 				}).Title
 			},
 		},

--- a/pkg/github/sanitize_coverage_test.go
+++ b/pkg/github/sanitize_coverage_test.go
@@ -1,0 +1,294 @@
+package github
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// maliciousText contains an HTML payload plus invisible/hidden-instruction characters,
+// mirroring the classes of untrusted content pkg/sanitize.Sanitize is meant to strip:
+// disallowed HTML tags and zero-width/BiDi control characters that can hide instructions
+// from a human reviewer while still being interpreted by a model.
+const maliciousText = "<script>alert(1)</script>Hello\u200BWorld"
+
+// sanitizedText is what maliciousText becomes after sanitize.Sanitize: the <script> tag
+// (and its content) is stripped by the HTML policy, and the zero-width space is removed.
+const sanitizedText = "HelloWorld"
+
+// Test_MinimalConverters_SanitizeUserAuthoredText is a table-driven regression test asserting
+// that every convertToMinimal* helper which surfaces untrusted, user-authored prose (issue and
+// PR titles/bodies, comments, reviews, review comments, releases, commit messages) applies
+// pkg/sanitize.Sanitize consistently. This guards against the inconsistent coverage described in
+// https://github.com/github/github-mcp-server/issues/3106.
+func Test_MinimalConverters_SanitizeUserAuthoredText(t *testing.T) {
+	tests := []struct {
+		name string
+		got  func() string
+	}{
+		{
+			name: "issue title (REST)",
+			got: func() string {
+				return convertToMinimalIssue(&github.Issue{
+					Title: github.Ptr(maliciousText),
+				}).Title
+			},
+		},
+		{
+			name: "issue body (REST)",
+			got: func() string {
+				return convertToMinimalIssue(&github.Issue{
+					Body: github.Ptr(maliciousText),
+				}).Body
+			},
+		},
+		{
+			name: "issue comment body",
+			got: func() string {
+				return convertToMinimalIssueComment(&github.IssueComment{
+					Body: github.Ptr(maliciousText),
+				}).Body
+			},
+		},
+		{
+			name: "pull request title",
+			got: func() string {
+				return convertToMinimalPullRequest(&github.PullRequest{
+					Title: github.Ptr(maliciousText),
+				}).Title
+			},
+		},
+		{
+			name: "pull request body",
+			got: func() string {
+				return convertToMinimalPullRequest(&github.PullRequest{
+					Body: github.Ptr(maliciousText),
+				}).Body
+			},
+		},
+		{
+			name: "pull request review body",
+			got: func() string {
+				return convertToMinimalPullRequestReview(&github.PullRequestReview{
+					Body: github.Ptr(maliciousText),
+				}).Body
+			},
+		},
+		{
+			name: "pull request review comment body (GraphQL)",
+			got: func() string {
+				return convertToMinimalReviewComment(reviewCommentNode{
+					Body: githubv4.String(maliciousText),
+					URL:  githubv4.URI{URL: &url.URL{Scheme: "https", Host: "github.com"}},
+				}).Body
+			},
+		},
+		{
+			name: "release name",
+			got: func() string {
+				return convertToMinimalRelease(&github.RepositoryRelease{
+					Name: github.Ptr(maliciousText),
+				}).Name
+			},
+		},
+		{
+			name: "release body",
+			got: func() string {
+				return convertToMinimalRelease(&github.RepositoryRelease{
+					Body: github.Ptr(maliciousText),
+				}).Body
+			},
+		},
+		{
+			name: "commit message (get_commit / list_commits)",
+			got: func() string {
+				commit := convertToMinimalCommit(&github.RepositoryCommit{
+					Commit: &github.Commit{Message: github.Ptr(maliciousText)},
+				}, commitDetailNone)
+				require.NotNil(t, commit.Commit)
+				return commit.Commit.Message
+			},
+		},
+		{
+			name: "commit message (search_commits)",
+			got: func() string {
+				item := convertCommitResultToMinimalCommit(&github.CommitResult{
+					Commit: &github.Commit{Message: github.Ptr(maliciousText)},
+				})
+				require.NotNil(t, item.Commit)
+				return item.Commit.Message
+			},
+		},
+		{
+			name: "pull request commit message (list_pull_request_commits)",
+			got: func() string {
+				commits := convertToMinimalPullRequestCommits([]*github.RepositoryCommit{
+					{Commit: &github.Commit{Message: github.Ptr(maliciousText)}},
+				})
+				require.Len(t, commits, 1)
+				return commits[0].Message
+			},
+		},
+		{
+			name: "file commit message (create/update/delete file)",
+			got: func() string {
+				resp := convertToMinimalFileContentResponse(&github.RepositoryContentResponse{
+					Commit: github.Commit{Message: github.Ptr(maliciousText)},
+				})
+				require.NotNil(t, resp.Commit)
+				return resp.Commit.Message
+			},
+		},
+		{
+			name: "workflow run head commit message",
+			got: func() string {
+				run := convertToMinimalWorkflowRun(&github.WorkflowRun{
+					HeadCommit: &github.HeadCommit{Message: github.Ptr(maliciousText)},
+				})
+				require.NotNil(t, run.HeadCommit)
+				return run.HeadCommit.Message
+			},
+		},
+		{
+			name: "project item content title (issue)",
+			got: func() string {
+				return convertIssueToMinimalProjectItemContent(&github.Issue{
+					Title: github.Ptr(maliciousText),
+				}).Title
+			},
+		},
+		{
+			name: "project item content title (pull request)",
+			got: func() string {
+				return convertPullRequestToMinimalProjectItemContent(&github.PullRequest{
+					Title: github.Ptr(maliciousText),
+				}).Title
+			},
+		},
+		{
+			name: "project item content title (draft issue)",
+			got: func() string {
+				return convertDraftIssueToMinimalProjectItemContent(&github.ProjectV2DraftIssue{
+					Title: github.Ptr(maliciousText),
+				}).Title
+			},
+		},
+		{
+			name: "project pull request ref title (from *github.PullRequest)",
+			got: func() string {
+				return minimalProjectPullRequestRefFromPullRequest(&github.PullRequest{
+					Title: github.Ptr(maliciousText),
+				}).Title
+			},
+		},
+		{
+			name: "project pull request ref title (from map)",
+			got: func() string {
+				return minimalProjectPullRequestRefFromMap(map[string]any{
+					"title": maliciousText,
+				}).Title
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, sanitizedText, tt.got())
+		})
+	}
+}
+
+// Test_SearchIssueResult_SanitizesTitleAndBody covers search_issues, which marshals the raw
+// *github.Issue REST search hit directly (via SearchIssueResult.MarshalJSON) instead of routing
+// through a convertToMinimal* helper. Sanitization must happen at serialization time here.
+func Test_SearchIssueResult_SanitizesTitleAndBody(t *testing.T) {
+	result := SearchIssueResult{
+		Issue: &github.Issue{
+			Title: github.Ptr(maliciousText),
+			Body:  github.Ptr(maliciousText),
+		},
+	}
+
+	out, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Title string `json:"title"`
+		Body  string `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(out, &decoded))
+
+	assert.Equal(t, sanitizedText, decoded.Title)
+	assert.Equal(t, sanitizedText, decoded.Body)
+}
+
+// Test_SanitizeIssueTitleAndBody exercises the shared helper directly, including its nil-safety,
+// since it backs both search_issues and search_pull_requests.
+func Test_SanitizeIssueTitleAndBody(t *testing.T) {
+	t.Run("nil issue is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() { sanitizeIssueTitleAndBody(nil) })
+	})
+
+	t.Run("nil title/body fields are left nil", func(t *testing.T) {
+		issue := &github.Issue{}
+		sanitizeIssueTitleAndBody(issue)
+		assert.Nil(t, issue.Title)
+		assert.Nil(t, issue.Body)
+	})
+
+	t.Run("sanitizes in place", func(t *testing.T) {
+		issue := &github.Issue{
+			Title: github.Ptr(maliciousText),
+			Body:  github.Ptr(maliciousText),
+		}
+		sanitizeIssueTitleAndBody(issue)
+		require.NotNil(t, issue.Title)
+		require.NotNil(t, issue.Body)
+		assert.Equal(t, sanitizedText, *issue.Title)
+		assert.Equal(t, sanitizedText, *issue.Body)
+	})
+}
+
+// Test_MinimalConverters_PreserveCodeFidelity ensures the sanitization work does not spill over
+// into fidelity-sensitive fields (diffs/patches and raw file content), which must survive byte
+// for byte so patches can still be applied and code isn't corrupted.
+func Test_MinimalConverters_PreserveCodeFidelity(t *testing.T) {
+	patch := "@@ -1,3 +1,3 @@\n-<script>old</script>\n+<script>new</script>\u200B\n"
+
+	t.Run("commit file patch (get_commit)", func(t *testing.T) {
+		commit := convertToMinimalCommit(&github.RepositoryCommit{
+			Files: []*github.CommitFile{{Filename: github.Ptr("a.go"), Patch: github.Ptr(patch)}},
+		}, commitDetailFullPatch)
+		require.Len(t, commit.Files, 1)
+		assert.Equal(t, patch, commit.Files[0].Patch)
+	})
+
+	t.Run("pull request file patch (get_pull_request_files)", func(t *testing.T) {
+		files := convertToMinimalPRFiles([]*github.CommitFile{
+			{Filename: github.Ptr("a.go"), Patch: github.Ptr(patch)},
+		})
+		require.Len(t, files, 1)
+		assert.Equal(t, patch, files[0].Patch)
+	})
+}
+
+// Test_Discussion_SanitizesUserAuthoredText covers the discussion helpers, which previously
+// applied no sanitization at all to titles, bodies, or comments despite being user-authored,
+// untrusted content equivalent to issue/PR text.
+func Test_Discussion_SanitizesUserAuthoredText(t *testing.T) {
+	t.Run("discussion title (fragmentToDiscussion, used by list_discussions)", func(t *testing.T) {
+		discussion := fragmentToDiscussion(NodeFragment{Title: githubv4.String(maliciousText)})
+		require.NotNil(t, discussion.Title)
+		assert.Equal(t, sanitizedText, *discussion.Title)
+	})
+
+	t.Run("discussion comment body (newMinimalDiscussionComment, used by get_discussion_comments)", func(t *testing.T) {
+		comment := newMinimalDiscussionComment("id", maliciousText, false)
+		assert.Equal(t, sanitizedText, comment.Body)
+	})
+}

--- a/pkg/github/search_utils.go
+++ b/pkg/github/search_utils.go
@@ -204,6 +204,12 @@ func searchHandler(
 		return ghErrors.NewGitHubAPIStatusErrorResponse(ctx, errorPrefix, resp, body), nil
 	}
 
+	// result.Issues are raw *github.Issue objects marshaled directly below rather than through
+	// a convertToMinimal* helper (see minimal_types.go), so Title/Body must be sanitized here.
+	for _, iss := range result.Issues {
+		sanitizeIssueTitleAndBody(iss)
+	}
+
 	filtered := false
 	var payload any = result
 	if len(cfg.fields) > 0 {


### PR DESCRIPTION
## Problem

Sanitization (`pkg/sanitize.Sanitize`) was applied ad hoc at a handful of tool call sites (`GetIssue`, `GetPullRequest`, `ListPullRequests`) instead of in the shared conversion layer. As a result, equivalent user-authored text returned by other tools — issue comments, PR reviews, review comments, releases, commit messages, discussions, project item titles — was returned completely unsanitized, and `search_issues`/`search_pull_requests` bypassed the converters entirely by marshaling raw `*github.Issue` objects.

## Fix

Moved sanitization into the shared `convertToMinimal*` converters in `pkg/github/minimal_types.go`, which is the single conversion point used by nearly every read tool. This one change now consistently covers:

- Issue/PR titles and bodies (REST and project-item paths)
- Issue comments
- PR reviews and review comments
- Releases (name + body)
- Commit messages (`get_commit`, `list_commits`, `search_commits`, `list_pull_request_commits`, file-commit responses, workflow run head commit)
- Project item content titles and project pull-request-ref titles

Additional targeted fixes for paths that don't go through `minimal_types.go`:
- Added a `sanitizeIssueTitleAndBody` helper used by `search_issues` (`SearchIssueResult.MarshalJSON`) and `search_pull_requests` (`searchHandler`), the only two tools that marshal a raw `*github.Issue` directly.
- Discussions (`list_discussions`, `get_discussion`, `get_discussion_comments`) previously had **no** sanitization at all — fixed via a new `newMinimalDiscussionComment` constructor and inline fixes.
- Project status update bodies.

Removed the now-redundant scattered sanitize calls in `GetIssue`, `GetPullRequest`, and `ListPullRequests` since the shared converters handle it now.

**Fidelity preserved:** patch/diff fields (`MinimalCommitFile.Patch`, `MinimalPRFile.Patch`) and raw file contents are intentionally left untouched — these must remain byte-exact so patches stay applicable and code isn't corrupted.

## Testing

- Added `pkg/github/sanitize_coverage_test.go`: table-driven regression tests covering every converter touched above, the `search_issues`/`search_pull_requests` raw-passthrough paths, the shared helper's nil-safety, and a fidelity check confirming patches/diffs are not altered.
- Added a malicious-payload case to the existing `Test_GetDiscussion` table in `discussions_test.go`.
- `script/lint` — 0 issues.
- `go test -race ./...` (via `script/test`) — all packages pass.
- No tool schemas changed, so no toolsnap or README/docs regeneration was required (verified via `script/generate-docs` producing no diff).

Fixes #3106

## Acknowledgments

Thanks @yotampe-pluto, @tonghuaroot, @gurudeepmallam-cmd, @nicoleman0, and @Gal3m for the reports that led to this hardening.