### PR TITLE
refactor: condense lockdown comments in GetPullRequestCommits

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -412,12 +412,9 @@ func GetPullRequestFiles(ctx context.Context, client *github.Client, deps ToolDe
 	return MarshalledTextResult(minimalFiles), nil
 }
 
-// GetPullRequestCommits returns the commits on a pull request. Commit messages
-// are user-authored content like the PR diff and files, so under lockdown mode
-// this applies the same PR-author check as GetPullRequestDiff/GetPullRequestFiles
-// rather than filtering individual commits: all commits on a pull request are
-// part of the same untrusted head branch, so a single check on the PR author is
-// sufficient and avoids an extra permission lookup per commit.
+// GetPullRequestCommits returns the commits on a pull request. Under lockdown
+// mode it checks the PR author once rather than per commit, since every
+// commit on the PR belongs to the same untrusted head branch.
 func GetPullRequestCommits(ctx context.Context, client *github.Client, deps ToolDependencies, owner, repo string, pullNumber int, pagination PaginationParams) (*mcp.CallToolResult, error) {
 	if restricted, err := enforcePullRequestLockdown(ctx, client, deps, owner, repo, pullNumber); restricted != nil || err != nil {
 		return restricted, err

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -1539,9 +1539,6 @@ func Test_GetPullRequestCommits(t *testing.T) {
 			expectedCommits: mockCommits,
 		},
 		{
-			// Trusted bot logins (e.g. github-actions[bot], copilot) are treated as
-			// safe content sources regardless of push access, matching the
-			// intentional exception documented for lockdown mode.
 			name: "lockdown enabled - trusted bot author lacks push access",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				GetReposPullsByOwnerByRepoByPullNumber: mockResponse(t, http.StatusOK, &github.PullRequest{


### PR DESCRIPTION
Focused comment cleanup, no behavior changes.

- `pkg/github/pullrequests.go`: condensed the `GetPullRequestCommits` doc comment to two concise sentences, keeping only the non-obvious invariant (a single PR-author check suffices since all commits share the same untrusted head branch).
- `pkg/github/pullrequests_test.go`: removed a comment on a test case that only restated the test name.

`script/lint` and `script/test` pass.