### PR TITLE
fix(copilot): explain review request denials instead of forwarding a bare 404

### DIFF
--- a/pkg/github/copilot.go
+++ b/pkg/github/copilot.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -900,7 +901,7 @@ func RequestCopilotReview(t translations.TranslationHelperFunc) inventory.Server
 			)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,
-					copilotReviewErrMsg(ctx, client, "failed to request copilot review", owner, repo, pullNumber, resp),
+					copilotReviewErrMsg(ctx, client, "failed to request copilot review", owner, repo, pullNumber, resp, err),
 					resp,
 					err,
 				), nil, nil
@@ -920,31 +921,32 @@ func RequestCopilotReview(t translations.TranslationHelperFunc) inventory.Server
 		})
 }
 
-// copilotReviewErrMsg explains the opaque failures of the review request
-// endpoint used by request_copilot_review.
-//
-// Requesting a reviewer needs write access to the repository. Being the author
-// of the pull request does not grant it, which is why a fork contributor can be
-// offered a Copilot review by the web UI and still be refused by the API. See
+// copilotReviewErrMsg disambiguates the bare 404 this endpoint returns when the
+// caller lacks write access, which is otherwise indistinguishable from a missing
+// repository or pull request. Authoring the pull request does not grant write
+// access, so fork contributors are refused here even though the website offers
+// them a Copilot review.
 // https://docs.github.com/en/pull-requests/reference/pull-request-reviews#requesting-and-requiring-reviews
-//
-// The endpoint is documented to answer a caller who is not a collaborator with
-// 403 or 422, but in practice it answers with 404 Not Found, which on its own
-// is indistinguishable from a repository or pull request that does not exist.
-// Reading the repository tells the two apart, and only runs once the request
-// has already failed.
-func copilotReviewErrMsg(ctx context.Context, client *github.Client, base, owner, repo string, pullNumber int, resp *github.Response) string {
+func copilotReviewErrMsg(ctx context.Context, client *github.Client, base, owner, repo string, pullNumber int, resp *github.Response, err error) string {
 	if resp == nil || (resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusForbidden) {
+		return base
+	}
+
+	// Rate limiting is also reported as 403, and the read below would be refused
+	// for the same reason, so leave the caller with the rate limit message.
+	var rateLimitErr *github.RateLimitError
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &rateLimitErr) || errors.As(err, &abuseErr) {
 		return base
 	}
 
 	repository, _, repoErr := client.Repositories.Get(ctx, owner, repo)
 	switch {
 	case repoErr != nil:
-		return fmt.Sprintf("%s. %s/%s could not be read with the current credentials, so either it does not exist or the credentials cannot reach it. "+
-			"GitHub refuses this endpoint the same way when the authenticated user has no write access to the repository.", base, owner, repo)
+		return fmt.Sprintf("%s. %s/%s could not be read with the current credentials, so it may not exist or the credentials may not reach it. "+
+			"Lacking write access is refused with the same status.", base, owner, repo)
 	case !repository.GetPermissions().GetPush():
-		return fmt.Sprintf("%s. The authenticated user has no write access to %s/%s, and GitHub requires write access to request a reviewer even from the author of the pull request. "+
+		return fmt.Sprintf("%s. The authenticated user has no write access to %s/%s, and GitHub requires write access to request a reviewer, even from the author of the pull request. "+
 			"Request the Copilot review from the pull request page on the GitHub website instead, or ask someone with write access to request it.", base, owner, repo)
 	default:
 		return fmt.Sprintf("%s. The authenticated user has write access to %s/%s, so check that pull request #%d exists there and that Copilot code review is available for the repository. "+

--- a/pkg/github/copilot.go
+++ b/pkg/github/copilot.go
@@ -900,7 +900,7 @@ func RequestCopilotReview(t translations.TranslationHelperFunc) inventory.Server
 			)
 			if err != nil {
 				return ghErrors.NewGitHubAPIErrorResponse(ctx,
-					"failed to request copilot review",
+					copilotReviewErrMsg(ctx, client, "failed to request copilot review", owner, repo, pullNumber, resp),
 					resp,
 					err,
 				), nil, nil
@@ -918,6 +918,38 @@ func RequestCopilotReview(t translations.TranslationHelperFunc) inventory.Server
 			// Return nothing on success, as there's not much value in returning the Pull Request itself
 			return utils.NewToolResultText(""), nil, nil
 		})
+}
+
+// copilotReviewErrMsg explains the opaque failures of the review request
+// endpoint used by request_copilot_review.
+//
+// Requesting a reviewer needs write access to the repository. Being the author
+// of the pull request does not grant it, which is why a fork contributor can be
+// offered a Copilot review by the web UI and still be refused by the API. See
+// https://docs.github.com/en/pull-requests/reference/pull-request-reviews#requesting-and-requiring-reviews
+//
+// The endpoint is documented to answer a caller who is not a collaborator with
+// 403 or 422, but in practice it answers with 404 Not Found, which on its own
+// is indistinguishable from a repository or pull request that does not exist.
+// Reading the repository tells the two apart, and only runs once the request
+// has already failed.
+func copilotReviewErrMsg(ctx context.Context, client *github.Client, base, owner, repo string, pullNumber int, resp *github.Response) string {
+	if resp == nil || (resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusForbidden) {
+		return base
+	}
+
+	repository, _, repoErr := client.Repositories.Get(ctx, owner, repo)
+	switch {
+	case repoErr != nil:
+		return fmt.Sprintf("%s. %s/%s could not be read with the current credentials, so either it does not exist or the credentials cannot reach it. "+
+			"GitHub refuses this endpoint the same way when the authenticated user has no write access to the repository.", base, owner, repo)
+	case !repository.GetPermissions().GetPush():
+		return fmt.Sprintf("%s. The authenticated user has no write access to %s/%s, and GitHub requires write access to request a reviewer even from the author of the pull request. "+
+			"Request the Copilot review from the pull request page on the GitHub website instead, or ask someone with write access to request it.", base, owner, repo)
+	default:
+		return fmt.Sprintf("%s. The authenticated user has write access to %s/%s, so check that pull request #%d exists there and that Copilot code review is available for the repository. "+
+			"Copilot code review is not available on GitHub Enterprise Server.", base, owner, repo, pullNumber)
+	}
 }
 
 func AssignCodingAgentPrompt(t translations.TranslationHelperFunc) inventory.ServerPrompt {

--- a/pkg/github/copilot_test.go
+++ b/pkg/github/copilot_test.go
@@ -886,11 +886,12 @@ func Test_RequestCopilotReview(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		mockedClient   *http.Client
-		requestArgs    map[string]any
-		expectError    bool
-		expectedErrMsg string
+		name             string
+		mockedClient     *http.Client
+		requestArgs      map[string]any
+		expectError      bool
+		expectedErrMsg   string
+		unexpectedErrMsg string
 	}{
 		{
 			name: "successful request",
@@ -927,6 +928,98 @@ func Test_RequestCopilotReview(t *testing.T) {
 			expectError:    true,
 			expectedErrMsg: "failed to request copilot review",
 		},
+		{
+			// The author of a cross-fork pull request has no write access on the
+			// upstream repository, so GitHub refuses the review request with a 404
+			// that says nothing about permissions.
+			name: "pull request author without write access",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: mockResponse(t, http.StatusNotFound, map[string]any{"message": "Not Found"}),
+				GetReposByOwnerByRepo: mockResponse(t, http.StatusOK, &github.Repository{
+					Name: github.Ptr("repo"),
+					Permissions: &github.RepositoryPermissions{
+						Pull: github.Ptr(true),
+						Push: github.Ptr(false),
+					},
+				}),
+			}),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(1),
+			},
+			expectError:    true,
+			expectedErrMsg: "The authenticated user has no write access to owner/repo",
+		},
+		{
+			name: "forbidden is explained the same way as not found",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: mockResponse(t, http.StatusForbidden, map[string]any{"message": "Forbidden"}),
+				GetReposByOwnerByRepo: mockResponse(t, http.StatusOK, &github.Repository{
+					Name: github.Ptr("repo"),
+					Permissions: &github.RepositoryPermissions{
+						Pull: github.Ptr(true),
+						Push: github.Ptr(false),
+					},
+				}),
+			}),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(1),
+			},
+			expectError:    true,
+			expectedErrMsg: "The authenticated user has no write access to owner/repo",
+		},
+		{
+			name: "write access present points at the pull request instead",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: mockResponse(t, http.StatusNotFound, map[string]any{"message": "Not Found"}),
+				GetReposByOwnerByRepo: mockResponse(t, http.StatusOK, &github.Repository{
+					Name: github.Ptr("repo"),
+					Permissions: &github.RepositoryPermissions{
+						Pull: github.Ptr(true),
+						Push: github.Ptr(true),
+					},
+				}),
+			}),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(999),
+			},
+			expectError:    true,
+			expectedErrMsg: "check that pull request #999 exists there",
+		},
+		{
+			name: "unreadable repository",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: mockResponse(t, http.StatusNotFound, map[string]any{"message": "Not Found"}),
+				GetReposByOwnerByRepo: mockResponse(t, http.StatusNotFound, map[string]any{"message": "Not Found"}),
+			}),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(1),
+			},
+			expectError:    true,
+			expectedErrMsg: "owner/repo could not be read with the current credentials",
+		},
+		{
+			// A failure that carries no permission signal keeps the original message.
+			name: "server error is not explained as a permission problem",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: mockResponse(t, http.StatusInternalServerError, map[string]any{"message": "Internal Server Error"}),
+			}),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(1),
+			},
+			expectError:      true,
+			expectedErrMsg:   "failed to request copilot review",
+			unexpectedErrMsg: "write access",
+		},
 	}
 
 	for _, tc := range tests {
@@ -949,6 +1042,9 @@ func Test_RequestCopilotReview(t *testing.T) {
 				require.True(t, result.IsError)
 				errorContent := getErrorResult(t, result)
 				assert.Contains(t, errorContent.Text, tc.expectedErrMsg)
+				if tc.unexpectedErrMsg != "" {
+					assert.NotContains(t, errorContent.Text, tc.unexpectedErrMsg)
+				}
 				return
 			}
 

--- a/pkg/github/copilot_test.go
+++ b/pkg/github/copilot_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/github/github-mcp-server/internal/githubv4mock"
 	"github.com/github/github-mcp-server/internal/toolsnaps"
@@ -929,9 +931,6 @@ func Test_RequestCopilotReview(t *testing.T) {
 			expectedErrMsg: "failed to request copilot review",
 		},
 		{
-			// The author of a cross-fork pull request has no write access on the
-			// upstream repository, so GitHub refuses the review request with a 404
-			// that says nothing about permissions.
 			name: "pull request author without write access",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: mockResponse(t, http.StatusNotFound, map[string]any{"message": "Not Found"}),
@@ -1006,7 +1005,6 @@ func Test_RequestCopilotReview(t *testing.T) {
 			expectedErrMsg: "owner/repo could not be read with the current credentials",
 		},
 		{
-			// A failure that carries no permission signal keeps the original message.
 			name: "server error is not explained as a permission problem",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: mockResponse(t, http.StatusInternalServerError, map[string]any{"message": "Internal Server Error"}),
@@ -1018,6 +1016,28 @@ func Test_RequestCopilotReview(t *testing.T) {
 			},
 			expectError:      true,
 			expectedErrMsg:   "failed to request copilot review",
+			unexpectedErrMsg: "write access",
+		},
+		{
+			name: "rate limited forbidden is not explained as a permission problem",
+			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+				PostReposPullsRequestedReviewersByOwnerByRepoByPullNumber: func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("X-RateLimit-Remaining", "0")
+					w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"message": "API rate limit exceeded"}`))
+				},
+				GetReposByOwnerByRepo: func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("repository should not be read while rate limited")
+				},
+			}),
+			requestArgs: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(1),
+			},
+			expectError:      true,
+			expectedErrMsg:   "rate limit exceeded",
 			unexpectedErrMsg: "write access",
 		},
 	}


### PR DESCRIPTION
## Summary

`request_copilot_review` forwarded GitHub's 404 verbatim, so a caller who simply lacked write access on the target repository got a tool result that read as if the repository or the pull request did not exist. The tool now identifies which cause applies and says so.

## Why

Fixes #3027

The reporter authored a cross-fork pull request into `microsoft/vscode`, requested a Copilot review from the GitHub website successfully, then got `404 Not Found` from the same request through this tool. Nothing in the tool result explained the difference, so the report reasonably concluded the tool was calling the wrong endpoint.

**Root cause.** `POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers` requires write access to the repository, and authoring the pull request does not grant it ([pull request reviews reference](https://docs.github.com/en/pull-requests/reference/pull-request-reviews#requesting-and-requiring-reviews)). The endpoint documents 403 and 422 as its denial responses ([review requests REST reference](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request)), but what it actually returns is a 404 carrying no permission signal. Confirmed against the live API with a token holding full `repo` scope on a repository where `permissions.push` is `false`:

```
POST /repos/github/github-mcp-server/pulls/3038/requested_reviewers
HTTP/2.0 404 Not Found
X-Oauth-Scopes: gist, read:org, repo, workflow
```

The reviewer login was deliberately invalid so the call could not succeed, which also shows the permission check runs before reviewer validation. Token scope is not the problem, repository write access is.

**There is no fallback to add.** GraphQL exposes only `requestReviews` and `requestReviewsByLogin`, and both enforce the same gate. Calling `requestReviewsByLogin` as the same non-write user returns `FORBIDDEN: ... does not have the correct permissions to execute RequestReviewsByLogin`, so GraphQL refuses the same actor for the same reason and is only more honest about it. Whatever path the website uses to offer Copilot to a fork author is not exposed as a public API endpoint, so the fix goes to the error surface.

## What changed

- `copilotReviewErrMsg` in `pkg/github/copilot.go` enriches the failure message when the response is 403 or 404. It reads the repository once, on the failure path only, and reports which cause applies: no write access (pointing at the pull request page on the website, which is what the reporter found working), a repository that cannot be read at all, or a repository the caller can write to (pointing at the pull request number and Copilot availability instead).
- Rate limiting also surfaces as 403. `*github.RateLimitError` and `*github.AbuseRateLimitError` short-circuit to the original message, so a rate-limited caller is not told they lack write access and does not pay a second call that would be refused for the same reason.
- The shape follows `dependabotErrMsg` in `pkg/github/dependabot.go`, the existing helper in this repo that appends a permission hint on 403 or 404. Any other status keeps the original message, so unrelated failures are not mislabelled, and the success path is untouched.
- Scoped to `request_copilot_review` on purpose. The other callers of `RequestReviewers` hit the same platform behavior, but the remedy text here is specific to Copilot code review, so a shared helper would not carry over cleanly.

## MCP impact

- [x] No tool or API changes
- [ ] Tool schema or behavior changed
- [ ] New tool added

The tool schema, name, description and success result are untouched. Only the text of an existing error result changes, so the toolsnap is unchanged.

## Prompts tested (tool changes only)

No tool schema change, so no new prompts. The behavior was exercised through the unit tests below and the underlying API behavior was verified directly against `api.github.com` as shown above.

## Security / limits

- [ ] No security or limits impact
- [x] Auth / permissions considered
- [ ] Data exposure, filtering, or token/size limits considered

The added repository read uses the caller's own client and runs only after a request has already failed, so it grants no access the caller did not have and adds no call to the success path. The message names only the owner and repository the caller supplied, and reports write access as a boolean rather than echoing any response body.

## Tool renaming

- [ ] I am renaming tools as part of this PR (e.g. a part of a consolidation effort)
   - [ ] I have added the new tool aliases in `deprecated_tool_aliases.go`
- [x] I am not renaming tools as part of this PR

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

`./script/lint` reports 0 issues and `./script/test` passes across every package. `./script/generate-docs` produces no diff, confirming the tool surface is unchanged. Six cases were added to `Test_RequestCopilotReview`:

- `pull request author without write access`, the case from the issue: 404 plus a repository whose `permissions.push` is false, asserting the message names the missing write access.
- `forbidden is explained the same way as not found`, so the documented 403 gets the same treatment as the 404 that actually shows up.
- `write access present points at the pull request instead`, asserting the message names pull request 999 rather than blaming permissions.
- `unreadable repository`, where the repository read also fails.
- `server error is not explained as a permission problem`, asserting a 500 keeps the original message and gains no permission text.
- `rate limited forbidden is not explained as a permission problem`, asserting a rate-limited 403 keeps the rate limit message and never reads the repository.

## Docs

- [x] Not needed
- [ ] Updated (README / docs / examples)

The tool description and generated docs are unchanged.