### PR TITLE
fix: allow public_repo for public repository write tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,7 +892,8 @@ The following sets of tools are available:
 <summary><picture><source media="(prefers-color-scheme: dark)" srcset="pkg/octicons/icons/issue-opened-dark.png"><source media="(prefers-color-scheme: light)" srcset="pkg/octicons/icons/issue-opened-light.png"><img src="pkg/octicons/icons/issue-opened-light.png" width="20" height="20" alt="issue-opened"></picture> Issues</summary>
 
 - **add_issue_comment** - Add comment to issue or pull request
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - `body`: Comment content. Required unless reaction is provided. (string, optional)
   - `comment_id`: The numeric ID of the issue or pull request comment to react to. Use this for reactions to comments; omit it to react to the issue or pull request itself. Cannot be combined with body. (integer, optional)
   - `issue_number`: Issue or pull request number to comment on or react to. (number, required)
@@ -923,7 +924,8 @@ The following sets of tools are available:
   - `repo`: The name of the repository (string, required)
 
 - **issue_write** - Create or update issue/pull request
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - `assignees`: Usernames to assign to this issue (string[], optional)
   - `body`: Issue body content (string, optional)
   - `duplicate_of`: Issue number that this issue is a duplicate of. Required when state_reason is 'duplicate'. (number, optional)
@@ -1173,7 +1175,8 @@ The following sets of tools are available:
   - `repo`: Repository name (string, required)
 
 - **create_pull_request** - Open new pull request
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - `base`: Branch to merge into (string, required)
   - `body`: PR description (string, optional)
   - `draft`: Create as draft PR (boolean, optional)
@@ -1276,7 +1279,8 @@ The following sets of tools are available:
 <summary><picture><source media="(prefers-color-scheme: dark)" srcset="pkg/octicons/icons/repo-dark.png"><source media="(prefers-color-scheme: light)" srcset="pkg/octicons/icons/repo-light.png"><img src="pkg/octicons/icons/repo-light.png" width="20" height="20" alt="repo"></picture> Repositories</summary>
 
 - **create_branch** - Create branch
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - `branch`: Name for new branch (string, required)
   - `from_branch`: Source branch (defaults to repo default) (string, optional)
   - `owner`: Repository owner (string, required)
@@ -1315,7 +1319,8 @@ The following sets of tools are available:
   - `repo`: Repository name (string, required)
 
 - **fork_repository** - Fork repository
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - `organization`: Organization to fork to (string, optional)
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
@@ -1399,7 +1404,8 @@ The following sets of tools are available:
   - `repo`: Repository name (string, required)
 
 - **push_files** - Push files to repository
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - `branch`: Branch to push to (string, required)
   - `files`: Array of file objects to push, each object with path (string) and content (string) (object[], required)
   - `message`: Commit message (string, required)

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -35,7 +35,8 @@ runtime behavior (such as output formatting) won't appear here.
 ### `remote_mcp_ui_apps`
 
 - **create_pull_request** - Open new pull request
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - **MCP App UI**: `ui://github-mcp-server/pr-write`
   - `base`: Branch to merge into (string, required)
   - `body`: PR description (string, optional)
@@ -52,7 +53,8 @@ runtime behavior (such as output formatting) won't appear here.
   - No parameters required
 
 - **issue_write** - Create or update issue/pull request
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - **MCP App UI**: `ui://github-mcp-server/issue-write`
   - `assignees`: Usernames to assign to this issue (string[], optional)
   - `body`: Issue body content (string, optional)

--- a/docs/insiders-features.md
+++ b/docs/insiders-features.md
@@ -29,7 +29,8 @@ The list below is generated from the Go source. It covers tool **inventory and s
 ### `remote_mcp_ui_apps`
 
 - **create_pull_request** - Open new pull request
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - **MCP App UI**: `ui://github-mcp-server/pr-write`
   - `base`: Branch to merge into (string, required)
   - `body`: PR description (string, optional)
@@ -46,7 +47,8 @@ The list below is generated from the Go source. It covers tool **inventory and s
   - No parameters required
 
 - **issue_write** - Create or update issue/pull request
-  - **Required OAuth Scopes**: `repo`
+  - **Required OAuth Scopes**: `public_repo`
+  - **Accepted OAuth Scopes**: `public_repo`, `repo`
   - **MCP App UI**: `ui://github-mcp-server/issue-write`
   - `assignees`: Usernames to assign to this issue (string[], optional)
   - `body`: Issue body content (string, optional)

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1401,7 +1401,7 @@ func AddIssueComment(t translations.TranslationHelperFunc) inventory.ServerTool 
 				Required: []string{"owner", "repo", "issue_number"},
 			},
 		},
-		[]scopes.Scope{scopes.Repo},
+		[]scopes.Scope{scopes.PublicRepo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {
@@ -2511,7 +2511,7 @@ Options are:
 				Required: []string{"method", "owner", "repo"},
 			},
 		},
-		[]scopes.Scope{scopes.Repo},
+		[]scopes.Scope{scopes.PublicRepo},
 		func(ctx context.Context, deps ToolDependencies, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			method, err := RequiredParam[string](args, "method")
 			if err != nil {

--- a/pkg/github/public_repo_scopes_test.go
+++ b/pkg/github/public_repo_scopes_test.go
@@ -1,0 +1,31 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/scopes"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublicRepositoryWriteToolsUsePublicRepoScope(t *testing.T) {
+	tests := []struct {
+		name string
+		tool inventory.ServerTool
+	}{
+		{name: "add_issue_comment", tool: AddIssueComment(translations.NullTranslationHelper)},
+		{name: "issue_write", tool: IssueWrite(translations.NullTranslationHelper)},
+		{name: "create_branch", tool: CreateBranch(translations.NullTranslationHelper)},
+		{name: "push_files", tool: PushFiles(translations.NullTranslationHelper)},
+		{name: "create_pull_request", tool: CreatePullRequest(translations.NullTranslationHelper)},
+		{name: "fork_repository", tool: ForkRepository(translations.NullTranslationHelper)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, []string{string(scopes.PublicRepo)}, tt.tool.RequiredScopes)
+			assert.ElementsMatch(t, []string{string(scopes.PublicRepo), string(scopes.Repo)}, tt.tool.AcceptedScopes)
+		})
+	}
+}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -706,7 +706,7 @@ func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 				Required: []string{"owner", "repo", "title", "head", "base"},
 			},
 		},
-		[]scopes.Scope{scopes.Repo},
+		[]scopes.Scope{scopes.PublicRepo},
 		func(ctx context.Context, deps ToolDependencies, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1222,7 +1222,7 @@ func ForkRepository(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo"},
 			},
 		},
-		[]scopes.Scope{scopes.Repo},
+		[]scopes.Scope{scopes.PublicRepo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {
@@ -1509,7 +1509,7 @@ func CreateBranch(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo", "branch"},
 			},
 		},
-		[]scopes.Scope{scopes.Repo},
+		[]scopes.Scope{scopes.PublicRepo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {
@@ -1641,7 +1641,7 @@ func PushFiles(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo", "branch", "files", "message"},
 			},
 		},
-		[]scopes.Scope{scopes.Repo},
+		[]scopes.Scope{scopes.PublicRepo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {


### PR DESCRIPTION
Closes #3136

## Summary

Several public-repository write tools currently require the broad `repo` OAuth scope. That means a server authenticated with the narrower `public_repo` scope cannot expose those tools even though GitHub permits the corresponding operations on public repositories.

This changes the required scope to `public_repo` for:

- `add_issue_comment`
- `issue_write`
- `create_branch`
- `push_files`
- `create_pull_request`
- `fork_repository`

The existing scope hierarchy treats `repo` as a parent of `public_repo`, so tokens with full `repo` scope remain accepted. This only lets public-only OAuth deployments use the least privilege needed for these operations; GitHub still enforces the token's actual repository permissions.

A focused regression test asserts each tool now advertises `public_repo` as its required scope and accepts both `public_repo` and `repo`.

Generated scope documentation is updated with the repository's existing docs generator.

## Validation

- focused regression test fails on current `main` before the scope changes and passes afterwards
- `UPDATE_TOOLSNAPS=true go test ./...` ✅
- `script/lint` ✅ — 0 issues
- `script/generate-docs` ✅
- `go test ./...` ✅ after generated docs
- `git diff --check` ✅

No GitHub API handlers or authorization checks are bypassed or changed.