### PR TITLE
fix: make consolidated method errors actionable

### DIFF
--- a/pkg/github/__toolsnaps__/sub_issue_write.snap
+++ b/pkg/github/__toolsnaps__/sub_issue_write.snap
@@ -21,6 +21,11 @@
       },
       "method": {
         "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\nWrites issue hierarchy. To move a sub-issue to a new parent, use `add` with `replace_parent=true`; there is no writable parent field.\n",
+        "enum": [
+          "add",
+          "remove",
+          "reprioritize"
+        ],
         "type": "string"
       },
       "owner": {

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -397,7 +397,7 @@ Use this tool to list workflows in a repository, or list workflow runs, jobs, an
 				result, payload, err := listWorkflowArtifacts(ctx, client, owner, repo, resourceIDInt, pagination)
 				return attachIFC(result), payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, actionsMethodListWorkflows, actionsMethodListWorkflowRuns, actionsMethodListWorkflowJobs, actionsMethodListWorkflowArtifacts), nil, nil
 			}
 		},
 	)
@@ -519,7 +519,7 @@ Use this tool to get details about individual workflows, workflow runs, jobs, an
 				result, payload, err := getWorkflowRunLogsURL(ctx, client, owner, repo, resourceIDInt)
 				return attachIFC(result), payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, actionsMethodGetWorkflow, actionsMethodGetWorkflowRun, actionsMethodGetWorkflowJob, actionsMethodDownloadWorkflowArtifact, actionsMethodGetWorkflowRunUsage, actionsMethodGetWorkflowRunLogsURL), nil, nil
 			}
 		},
 	)
@@ -636,7 +636,7 @@ func ActionsRunTrigger(t translations.TranslationHelperFunc) inventory.ServerToo
 			case actionsMethodDeleteWorkflowRunLogs:
 				return deleteWorkflowRunLogs(ctx, client, owner, repo, int64(runID))
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, actionsMethodRunWorkflow, actionsMethodRerunWorkflowRun, actionsMethodRerunFailedJobs, actionsMethodCancelWorkflowRun, actionsMethodDeleteWorkflowRunLogs), nil, nil
 			}
 		},
 	)

--- a/pkg/github/dispatch_errors_test.go
+++ b/pkg/github/dispatch_errors_test.go
@@ -1,0 +1,183 @@
+package github
+
+import (
+	"context"
+	"maps"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAffectedDispatchersReportSupportedMethods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		tool       func() inventory.ServerTool
+		requestArg map[string]any
+	}{
+		{
+			name: "pull request read",
+			tool: func() inventory.ServerTool {
+				return PullRequestRead(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(1),
+			},
+		},
+		{
+			name: "issue read",
+			tool: func() inventory.ServerTool {
+				return IssueRead(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+			},
+		},
+		{
+			name: "sub issue write",
+			tool: func() inventory.ServerTool {
+				return SubIssueWrite(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":        "owner",
+				"repo":         "repo",
+				"issue_number": float64(1),
+				"sub_issue_id": float64(2),
+			},
+		},
+		{
+			name: "actions list",
+			tool: func() inventory.ServerTool {
+				return ActionsList(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":       "owner",
+				"repo":        "repo",
+				"resource_id": "1",
+			},
+		},
+		{
+			name: "actions get",
+			tool: func() inventory.ServerTool {
+				return ActionsGet(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":       "owner",
+				"repo":        "repo",
+				"resource_id": "1",
+			},
+		},
+		{
+			name: "actions run",
+			tool: func() inventory.ServerTool {
+				return ActionsRunTrigger(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":  "owner",
+				"repo":   "repo",
+				"run_id": float64(1),
+			},
+		},
+		{
+			name: "projects list",
+			tool: func() inventory.ServerTool {
+				return ProjectsList(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":      "owner",
+				"owner_type": "org",
+			},
+		},
+		{
+			name: "projects get",
+			tool: func() inventory.ServerTool {
+				return ProjectsGet(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":          "owner",
+				"owner_type":     "org",
+				"project_number": float64(1),
+			},
+		},
+		{
+			name: "projects write",
+			tool: func() inventory.ServerTool {
+				return ProjectsWrite(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner":          "owner",
+				"owner_type":     "org",
+				"project_number": float64(1),
+			},
+		},
+		{
+			name: "ui get",
+			tool: func() inventory.ServerTool {
+				return UIGet(translations.NullTranslationHelper)
+			},
+			requestArg: map[string]any{
+				"owner": "owner",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := tc.tool()
+			schema := tool.Tool.InputSchema.(*jsonschema.Schema)
+			methodSchema := schema.Properties["method"]
+			require.NotNil(t, methodSchema)
+			require.NotEmpty(t, methodSchema.Enum)
+
+			methods := make([]string, len(methodSchema.Enum))
+			for i, method := range methodSchema.Enum {
+				methods[i] = method.(string)
+			}
+
+			args := make(map[string]any, len(tc.requestArg)+1)
+			maps.Copy(args, tc.requestArg)
+			args["method"] = "unknown_method"
+
+			client := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{}))
+			deps := BaseDeps{Client: client, GQLClient: defaultGQLClient}
+			request := createMCPRequest(args)
+			result, err := tool.Handler(deps)(ContextWithDeps(context.Background(), deps), &request)
+
+			require.NoError(t, err)
+			require.True(t, result.IsError)
+			assert.Equal(t,
+				"unknown method: unknown_method. Supported methods are: "+strings.Join(methods, ", "),
+				getErrorResult(t, result).Text,
+			)
+		})
+	}
+}
+
+func TestPullRequestReviewWriteMissingMethodIsRequired(t *testing.T) {
+	t.Parallel()
+
+	tool := PullRequestReviewWrite(translations.NullTranslationHelper)
+	deps := BaseDeps{GQLClient: defaultGQLClient}
+	request := createMCPRequest(map[string]any{
+		"owner":      "owner",
+		"repo":       "repo",
+		"pullNumber": float64(1),
+	})
+
+	result, err := tool.Handler(deps)(ContextWithDeps(context.Background(), deps), &request)
+
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Equal(t, "missing required parameter: method", getErrorResult(t, result).Text)
+}

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -888,7 +888,7 @@ func IssueRead(t translations.TranslationHelperFunc) inventory.ServerTool {
 				result, err := GetIssueLabels(ctx, gqlClient, owner, repo, issueNumber)
 				return attachIFC(result), nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, "get", "get_comments", "get_sub_issues", "get_parent", "get_labels"), nil, nil
 			}
 		})
 }
@@ -1587,6 +1587,7 @@ func SubIssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 							"- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n" +
 							"- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n" +
 							"Writes issue hierarchy. To move a sub-issue to a new parent, use `add` with `replace_parent=true`; there is no writable parent field.\n",
+						Enum: []any{"add", "remove", "reprioritize"},
 					},
 					"owner": {
 						Type:        "string",
@@ -1674,7 +1675,7 @@ func SubIssueWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 				result, err := ReprioritizeSubIssue(ctx, client, owner, repo, issueNumber, subIssueID, afterID, beforeID)
 				return result, nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, "add", "remove", "reprioritize"), nil, nil
 			}
 		})
 	st.FeatureFlagDisable = []string{FeatureFlagIssuesGranular}

--- a/pkg/github/method_errors.go
+++ b/pkg/github/method_errors.go
@@ -1,0 +1,17 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/github/github-mcp-server/pkg/utils"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func unknownMethodError(method string, supportedMethods ...string) *mcp.CallToolResult {
+	return utils.NewToolResultError(fmt.Sprintf(
+		"unknown method: %s. Supported methods are: %s",
+		method,
+		strings.Join(supportedMethods, ", "),
+	))
+}

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -437,10 +437,10 @@ Use this tool to list projects for a user or organization, or list project field
 					result = attachStaticIFCLabel(ctx, deps, result, ifc.LabelProjectContent(isPrivate))
 					return result, payload, err
 				default:
-					return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+					return unknownMethodError(method, projectsMethodListProjects, projectsMethodListProjectFields, projectsMethodListProjectItems, projectsMethodListProjectStatusUpdates, projectsMethodListProjectViews), nil, nil
 				}
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, projectsMethodListProjects, projectsMethodListProjectFields, projectsMethodListProjectItems, projectsMethodListProjectStatusUpdates, projectsMethodListProjectViews), nil, nil
 			}
 		},
 	)
@@ -642,7 +642,7 @@ Use this tool to get details about individual projects, project fields, project 
 				}
 				return result, payload, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, projectsMethodGetProject, projectsMethodGetProjectField, projectsMethodGetProjectItem, projectsMethodGetProjectStatusUpdate, projectsMethodGetProjectView), nil, nil
 			}
 		},
 	)
@@ -1037,7 +1037,7 @@ func ProjectsWrite(t translations.TranslationHelperFunc) inventory.ServerTool {
 			case projectsMethodDeleteProjectView:
 				return deleteProjectView(ctx, gqlClient, args, owner, ownerType, projectNumber)
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, projectsMethodAddProjectItem, projectsMethodUpdateProjectItem, projectsMethodUpdateProjectItems, projectsMethodDeleteProjectItem, projectsMethodCreateProjectStatusUpdate, projectsMethodCreateProjectView, projectsMethodUpdateProjectView, projectsMethodDeleteProjectView, projectsMethodCreateProject, projectsMethodCreateIterationField), nil, nil
 			}
 		},
 	)

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -154,7 +154,7 @@ Possible options:
 				result, err := GetPullRequestCheckRuns(ctx, client, owner, repo, pullNumber, pagination)
 				return attachIFC(result), nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, "get", "get_diff", "get_status", "get_files", "get_commits", "get_review_comments", "get_reviews", "get_comments", "get_check_runs"), nil, nil
 			}
 		})
 }
@@ -1836,10 +1836,16 @@ Available methods:
 		},
 		[]scopes.Scope{scopes.Repo},
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			method, err := RequiredParam[string](args, "method")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
 			var params PullRequestReviewWriteParams
 			if err := mapstructure.WeakDecode(args, &params); err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			params.Method = method
 
 			// Given our owner, repo and PR number, lookup the GQL ID of the PR.
 			client, err := deps.GetGQLClient(ctx)
@@ -1864,7 +1870,7 @@ Available methods:
 				result, err := ResolveReviewThread(ctx, client, params.ThreadID, false)
 				return result, nil, err
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", params.Method)), nil, nil
+				return unknownMethodError(params.Method, "create", "submit_pending", "delete_pending", "resolve_thread", "unresolve_thread"), nil, nil
 			}
 		})
 	st.FeatureFlagDisable = []string{FeatureFlagPullRequestsGranular}

--- a/pkg/github/ui_tools.go
+++ b/pkg/github/ui_tools.go
@@ -96,7 +96,7 @@ func UIGet(t translations.TranslationHelperFunc) inventory.ServerTool {
 			case "reviewers":
 				return uiGetReviewers(ctx, deps, args, owner)
 			default:
-				return utils.NewToolResultError(fmt.Sprintf("unknown method: %s", method)), nil, nil
+				return unknownMethodError(method, "labels", "assignees", "milestones", "issue_types", "branches", "issue_fields", "reviewers"), nil, nil
 			}
 		})
 	st.FeatureFlagEnable = MCPAppsFeatureFlag


### PR DESCRIPTION
Fixes #2712

## Summary

Consolidated method-dispatch tools now return actionable errors that list the supported methods when a caller supplies an unknown method. `pull_request_review_write` also reports the missing required `method` parameter before decoding the remaining request fields.

## User impact

MCP clients can recover from a typo or omitted dispatch method without guessing the tool's internal routing options. The behavior is applied consistently to issue, pull request, Actions, Projects, sub-issue, and UI dispatchers.

## What changed

- Added a shared supported-method error formatter.
- Replaced bare unknown-method errors in the affected dispatchers.
- Added the missing `method` validation in `pull_request_review_write`.
- Added the `sub_issue_write` method enum so its schema matches runtime dispatch.
- Added focused handler tests covering all affected dispatchers and the missing-method case.

## Validation

- `go test ./...` - 3398 passed
- `go vet ./...` - clean
- `./script/lint` - 0 issues
- `git diff --check` - clean

AI assistance was used for code exploration and test scaffolding; I reviewed and own the implementation and can explain the behavior and trade-offs.