### PR TITLE
Spell perPage the same way in every paginated tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,7 @@ The following sets of tools are available:
   - `method`: The action to perform (string, required)
   - `owner`: The owner (user or organization login). The name is not case sensitive. (string, required)
   - `owner_type`: Owner type (user or org). If not provided, will automatically try both. (string, optional)
-  - `per_page`: Results per page (max 50) (number, optional)
+  - `perPage`: Results per page (max 50) (number, optional)
   - `project_number`: The project's number. Required for 'list_project_fields', 'list_project_items', 'list_project_views', and 'list_project_status_updates' methods. (number, optional)
   - `query`: Filter/query string. For list_projects: filter by title text and state (e.g. "roadmap is:open"). For list_project_items: advanced filtering using GitHub's project filtering syntax. (string, optional)
 

--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ The following sets of tools are available:
   - `method`: The action to perform (string, required)
   - `owner`: Repository owner (string, required)
   - `page`: Page number for pagination (default: 1) (number, optional)
-  - `per_page`: Results per page for pagination (default: 30, max: 100) (number, optional)
+  - `perPage`: Results per page for pagination (default: 30, max: 100) (number, optional)
   - `repo`: Repository name (string, required)
   - `resource_id`: The unique identifier of the resource. This will vary based on the "method" provided, so ensure you provide the correct ID:
     - Do not provide any resource ID for 'list_workflows' method.

--- a/pkg/github/__toolsnaps__/actions_list.snap
+++ b/pkg/github/__toolsnaps__/actions_list.snap
@@ -26,7 +26,7 @@
         "minimum": 1,
         "type": "number"
       },
-      "per_page": {
+      "perPage": {
         "description": "Results per page for pagination (default: 30, max: 100)",
         "maximum": 100,
         "minimum": 1,

--- a/pkg/github/__toolsnaps__/projects_list.snap
+++ b/pkg/github/__toolsnaps__/projects_list.snap
@@ -52,7 +52,7 @@
         ],
         "type": "string"
       },
-      "per_page": {
+      "perPage": {
         "description": "Results per page (max 50)",
         "type": "number"
       },

--- a/pkg/github/actions.go
+++ b/pkg/github/actions.go
@@ -313,7 +313,7 @@ Use this tool to list workflows in a repository, or list workflow runs, jobs, an
 						Description: "Page number for pagination (default: 1)",
 						Minimum:     jsonschema.Ptr(1.0),
 					},
-					"per_page": {
+					"perPage": {
 						Type:        "number",
 						Description: "Results per page for pagination (default: 30, max: 100)",
 						Minimum:     jsonschema.Ptr(1.0),

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -341,7 +341,7 @@ Use this tool to list projects for a user or organization, or list project field
 							Type: "string",
 						},
 					},
-					"per_page": {
+					"perPage": {
 						Type:        "number",
 						Description: fmt.Sprintf("Results per page (max %d)", MaxProjectsPerPage),
 					},
@@ -1783,7 +1783,7 @@ func listProjectStatusUpdates(ctx context.Context, gqlClient *githubv4.Client, a
 		return utils.NewToolResultError(err.Error()), false, nil, nil
 	}
 
-	perPage, err := OptionalIntParamWithDefault(args, "per_page", MaxProjectsPerPage)
+	perPage, err := optionalProjectsPerPage(args)
 	if err != nil {
 		return utils.NewToolResultError(err.Error()), false, nil, nil
 	}
@@ -1940,7 +1940,7 @@ func listProjectViews(ctx context.Context, gqlClient *githubv4.Client, args map[
 	if err != nil {
 		return utils.NewToolResultError(err.Error()), false, nil, nil
 	}
-	perPage, err := OptionalIntParamWithDefault(args, "per_page", MaxProjectsPerPage)
+	perPage, err := optionalProjectsPerPage(args)
 	if err != nil {
 		return utils.NewToolResultError(err.Error()), false, nil, nil
 	}
@@ -2512,8 +2512,23 @@ func invalidIssueFieldValue(field *ResolvedField, hint string) error {
 	)
 }
 
+// optionalProjectsPerPage reads the page size for the projects tools.
+//
+// The schema advertises perPage, the name every other paginated tool uses. The
+// projects tools advertised per_page from September 2025 until this change and
+// clients sending it get the size they asked for today, so it is still read when
+// perPage is absent.
+func optionalProjectsPerPage(args map[string]any) (int, error) {
+	if _, ok := args["perPage"]; !ok {
+		if _, legacy := args["per_page"]; legacy {
+			return OptionalIntParamWithDefault(args, "per_page", MaxProjectsPerPage)
+		}
+	}
+	return OptionalIntParamWithDefault(args, "perPage", MaxProjectsPerPage)
+}
+
 func extractPaginationOptionsFromArgs(args map[string]any) (github.ListProjectsPaginationOptions, error) {
-	perPage, err := OptionalIntParamWithDefault(args, "per_page", MaxProjectsPerPage)
+	perPage, err := optionalProjectsPerPage(args)
 	if err != nil {
 		return github.ListProjectsPaginationOptions{}, err
 	}

--- a/pkg/github/projects_test.go
+++ b/pkg/github/projects_test.go
@@ -395,6 +395,43 @@ func Test_ProjectsList_ListProjectItems(t *testing.T) {
 	})
 }
 
+func Test_optionalProjectsPerPage(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want int
+	}{
+		{
+			name: "canonical perPage",
+			args: map[string]any{"perPage": float64(10)},
+			want: 10,
+		},
+		{
+			name: "per_page still read for clients on the previous name",
+			args: map[string]any{"per_page": float64(10)},
+			want: 10,
+		},
+		{
+			name: "perPage wins when both are sent",
+			args: map[string]any{"perPage": float64(10), "per_page": float64(25)},
+			want: 10,
+		},
+		{
+			name: "neither sent falls back to the maximum",
+			args: map[string]any{},
+			want: MaxProjectsPerPage,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := optionalProjectsPerPage(tc.args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func Test_detectOwnerType(t *testing.T) {
 	t.Run("uses organization account type", func(t *testing.T) {
 		mockedClient := MockHTTPClientWithHandlers(map[string]http.HandlerFunc{

--- a/pkg/github/tools_validation_test.go
+++ b/pkg/github/tools_validation_test.go
@@ -71,6 +71,46 @@ func TestAllToolInputSchemasAvoidTopLevelCombinators(t *testing.T) {
 	}
 }
 
+// TestAllToolInputSchemasUseCanonicalPaginationNames keeps pagination properties
+// spelled one way across the whole inventory. The pagination helpers read page,
+// perPage, after and before, so a schema that advertises a case or underscore
+// variant of one of those names promises a knob the handler never turns: whatever
+// the client sends is dropped and the default is used instead. actions_list
+// advertised per_page for months that way.
+func TestAllToolInputSchemasUseCanonicalPaginationNames(t *testing.T) {
+	canonical := map[string]string{
+		"page":    "page",
+		"perpage": "perPage",
+		"after":   "after",
+		"before":  "before",
+	}
+
+	tools := AllTools(stubTranslation)
+	require.NotEmpty(t, tools, "AllTools should return at least one tool")
+
+	for _, serverTool := range tools {
+		tool := serverTool.Tool
+		t.Run(tool.Name, func(t *testing.T) {
+			data, err := json.Marshal(tool.InputSchema)
+			require.NoError(t, err, "Tool %q InputSchema must marshal", tool.Name)
+
+			var schema struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			}
+			require.NoError(t, json.Unmarshal(data, &schema), "Tool %q InputSchema must be a JSON object", tool.Name)
+
+			for name := range schema.Properties {
+				want, ok := canonical[strings.ToLower(strings.ReplaceAll(name, "_", ""))]
+				if !ok {
+					continue
+				}
+				assert.Equal(t, want, name,
+					"Tool %q advertises pagination property %q; the canonical spelling is %q", tool.Name, name, want)
+			}
+		})
+	}
+}
+
 // TestAllResourcesHaveRequiredMetadata validates that all resources have mandatory metadata
 func TestAllResourcesHaveRequiredMetadata(t *testing.T) {
 	// Resources are now stateless - no client functions needed


### PR DESCRIPTION
## Summary

`actions_list` advertised `per_page` while the handler reads pagination through `OptionalPaginationParams`, which looks for `perPage`, so whatever the client sent was dropped and the size fell back to 30. `projects_list` advertises `per_page` too and its handlers do read that name, so it works, but it left one tool spelling pagination differently from the other 30 and that is the gap the actions_list bug slipped through.

## Why

Both schemas now say `perPage`, and a test keeps the rest of the inventory from drifting the same way.

I went over the full inventory rather than grepping for one string: 32 of the 117 tools advertise pagination, 30 of them get it from `WithPagination` / `WithCursorPagination` / `WithUnifiedPagination`, and these two are the only places where the properties are written out by hand. `after_id` and `before_id` on the sub-issue tools are positions rather than pagination, so the test leaves them be.

## What changed

- `pkg/github/actions.go`: `per_page` -> `perPage` in the `actions_list` schema
- `pkg/github/projects.go`: same in the `projects_list` schema, and the three handlers read it through one helper. `per_page` is still read when `perPage` is absent, since the projects tools have advertised that name since September 2025 and clients sending it get the size they ask for today
- `pkg/github/tools_validation_test.go`: `TestAllToolInputSchemasUseCanonicalPaginationNames` walks `AllTools` and rejects case and underscore variants of `page`, `perPage`, `after` and `before`. On main it fails on exactly these two tools
- `pkg/github/projects_test.go`: covers the helper -- `perPage`, legacy `per_page`, both together, neither
- snapshots regenerated with `UPDATE_TOOLSNAPS=true`, README with `script/generate-docs`

The `per_page` fallback in projects is the one judgement call in here. Drop those three lines if you would rather make it a clean break, the test stays green either way

## MCP impact

- [x] Tool schema or behavior changed

Two properties renamed. `actions_list` clients sending `per_page` were already being ignored, and `projects_list` clients sending it keep working through the fallback.

## Prompts tested (tool changes only)

- "List the most recent workflow run in github/github-mcp-server" -- the case that was silently returning 30 items. Over stdio against this branch, `perPage: 1` comes back with 1 run and `per_page: 1` with 30, byte for byte the same response as sending no page size at all
- I did not exercise `projects_list` over stdio, no project at hand. `Test_optionalProjectsPerPage` covers the four cases instead

## Security / limits

- [x] No security or limits impact

## Tool renaming

- [x] I am not renaming tools as part of this PR

## Lint & tests

- [x] Linted locally with `./script/lint`
- [x] Tested locally with `./script/test`

## Docs

- [x] Updated (README / docs / examples)
