### PR TITLE
fix(http): apply CORS headers to all top-level responses

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -211,9 +211,15 @@ func RunHTTPServer(cfg ServerConfig) error {
 		return fmt.Errorf("failed to create OAuth handler: %w", err)
 	}
 
-	r.Group(func(r chi.Router) {
-		r.Use(middleware.SetCorsHeaders)
+	// CORS headers are applied at the top level so that every response —
+	// including the OAuth protected resource metadata endpoints and the
+	// router's 404 fallback — is readable by browser-based clients. Without
+	// this, browsers mask the real error (e.g. a 401 auth challenge or 404)
+	// behind an opaque "missing CORS headers" failure, which made hosted
+	// servers appear unreachable from web clients (see issue #3095).
+	r.Use(middleware.SetCorsHeaders)
 
+	r.Group(func(r chi.Router) {
 		// Register Middleware First, needs to be before route registration
 		handler.RegisterMiddleware(r)
 

--- a/pkg/http/server_cors_test.go
+++ b/pkg/http/server_cors_test.go
@@ -1,0 +1,127 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/http/middleware"
+	"github.com/github/github-mcp-server/pkg/http/oauth"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/github/github-mcp-server/pkg/utils"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCORSTestServer builds the same top-level router layout as RunHTTPServer
+// (MCP routes + OAuth metadata routes under a shared CORS middleware) without
+// binding a real port, so tests can assert on CORS behavior for every response
+// class: MCP auth challenges (401), OAuth metadata (200), and unmatched paths
+// (404).
+func newCORSTestServer(t *testing.T) http.Handler {
+	t.Helper()
+
+	dotcomHost, err := utils.NewAPIHost("https://api.github.com")
+	require.NoError(t, err)
+
+	handler := NewHTTPMcpHandler(
+		context.Background(),
+		&ServerConfig{Version: "test"},
+		nil, // deps not exercised by these routes
+		translations.NullTranslationHelper,
+		slog.Default(),
+		dotcomHost,
+	)
+
+	oauthHandler, err := oauth.NewAuthHandler(&oauth.Config{
+		BaseURL: "https://api.example.com",
+	}, dotcomHost)
+	require.NoError(t, err)
+
+	r := chi.NewRouter()
+	r.Use(middleware.SetCorsHeaders)
+
+	r.Group(func(r chi.Router) {
+		handler.RegisterMiddleware(r)
+		handler.RegisterRoutes(r)
+	})
+	r.Group(func(r chi.Router) {
+		oauthHandler.RegisterRoutes(r)
+	})
+	return r
+}
+
+func TestTopLevelCORSHeadersOnAllResponses(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		wantStatus   int
+		wantACAO     string // Access-Control-Allow-Origin
+		wantExposeWW bool   // WWW-Authenticate must be exposed via Access-Control-Expose-Headers
+	}{
+		{
+			name:         "MCP endpoint without token returns 401 challenge with CORS headers",
+			method:       http.MethodPost,
+			path:         "/mcp",
+			wantStatus:   http.StatusUnauthorized,
+			wantACAO:     "*",
+			wantExposeWW: true,
+		},
+		{
+			name:         "OAuth protected resource metadata returns 200 with CORS headers",
+			method:       http.MethodGet,
+			path:         "/.well-known/oauth-protected-resource",
+			wantStatus:   http.StatusOK,
+			wantACAO:     "*",
+			wantExposeWW: false,
+		},
+		{
+			name:         "unmatched path falls through to root-mounted MCP handler's 401 with CORS headers",
+			method:       http.MethodGet,
+			path:         "/definitely-not-a-route",
+			wantStatus:   http.StatusUnauthorized,
+			wantACAO:     "*",
+			wantExposeWW: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newCORSTestServer(t)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+
+			resp := rr.Result()
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+			assert.Equal(t, tt.wantACAO, resp.Header.Get("Access-Control-Allow-Origin"))
+			if tt.wantExposeWW {
+				assert.NotEmpty(t, resp.Header.Get("WWW-Authenticate"),
+					"401 challenge should carry WWW-Authenticate per MCP spec")
+				assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "WWW-Authenticate",
+					"WWW-Authenticate must be readable cross-origin")
+			}
+		})
+	}
+}
+
+func TestTopLevelCORSPreflightOnMetadataRoute(t *testing.T) {
+	srv := newCORSTestServer(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/.well-known/oauth-protected-resource", nil)
+	req.Header.Set("Origin", "https://client.example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"preflight against the metadata route should short-circuit with 200, not fall through to 405/404")
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Methods"), "GET")
+}


### PR DESCRIPTION
Closes #3095.

## Problem

#3095 reports that browser-based MCP clients see `"This MCP server doesn't support web access. Missing CORS headers."` when connecting to the hosted server — even though a raw `OPTIONS` preflight succeeds with the right headers. The reporter's follow-up captures it precisely: the **preflight passes**, but subsequent non-2xx responses (`401` from the auth challenge, and errors from unauthenticated metadata lookups) come back **without CORS headers**, so the browser hides the real error behind an opaque CORS failure.

## Root cause

In `pkg/http/server.go`, `middleware.SetCorsHeaders` was mounted only on the MCP route group:

- The OAuth protected resource metadata group (`/.well-known/oauth-protected-resource*`) had **no** CORS middleware, so every response from the discovery flow browsers must complete before authenticating was unreadable cross-origin.
- Any router-level fall-through (e.g. an error surfaced before reaching the MCP handler) also lacked the headers.

The MCP endpoints themselves were fine — which is why curl-based checks passed while real browser clients failed.

## Fix

Move `r.Use(middleware.SetCorsHeaders)` from the MCP group to the **top-level chi router**, so every response class carries CORS headers:

| Response | Before | After |
|---|---|---|
| MCP endpoint without token → 401 + `WWW-Authenticate` | CORS ✅ | CORS ✅ |
| `GET /.well-known/oauth-protected-resource` → 200 | ❌ no ACAO | CORS ✅ |
| Preflight `OPTIONS` on the metadata route | fell through to 405/404 without CORS | 200 short-circuit ✅ |

Wildcard origins remain safe at this layer: the server authenticates via bearer tokens, not cookies, so cross-origin requests cannot exploit ambient credentials (unchanged rationale from the original middleware).

## Testing

New `TestTopLevelCORSHeadersOnAllResponses` + `TestTopLevelCORSPreflightOnMetadataRoute` in `pkg/http/server_cors_test.go`, building the same two-group router layout as `RunHTTPServer`:

- 401 auth challenge carries `Access-Control-Allow-Origin` and exposes `WWW-Authenticate` via `Access-Control-Expose-Headers`
- OAuth metadata 200 carries `Access-Control-Allow-Origin`
- unmatched path falls through to the root-mounted MCP handler's 401 **with** CORS headers (documents actual behavior)
- `OPTIONS` preflight on the metadata route short-circuits with 200 instead of falling through to a CORS-less 404/405

Gates: `go build ./...` clean; `go vet ./pkg/http/...` clean; `go test ./pkg/http/... ./pkg/context/... -count=1` all pass; golangci-lint v2.13.1 reports only the 6 pre-existing gosec hits in `token_test.go` (identical on clean main).

## Note for browser-client authors (re #3095)

With this fix the browser can finally *see* the `401` + `WWW-Authenticate: Bearer resource_metadata="..."` challenge and the RFC 9728 metadata document. Authentication itself is GitHub OAuth outside this repo's scope — clients should implement the standard MCP authorization flow triggered by that challenge.