### PR TITLE
fix(scopes): allow public_repo scope for public repository write tools

### DIFF
--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1403,7 +1403,7 @@ func AddIssueComment(t translations.TranslationHelperFunc) inventory.ServerTool 
 				Required: []string{"owner", "repo", "issue_number"},
 			},
 		},
-		scopes.RequireAll(scopes.Repo),
+		scopes.RequireAll(scopes.PublicRepo),
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {
@@ -2524,7 +2524,7 @@ Options are:
 				Required: []string{"method", "owner", "repo"},
 			},
 		},
-		scopes.RequireAll(scopes.Repo),
+		scopes.RequireAll(scopes.PublicRepo),
 		func(ctx context.Context, deps ToolDependencies, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			method, err := RequiredParam[string](args, "method")
 			if err != nil {

--- a/pkg/github/public_repo_scope_test.go
+++ b/pkg/github/public_repo_scope_test.go
@@ -1,0 +1,103 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/scopes"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPublicRepoWriteToolsDeclareLeastPrivilegeScopes asserts that the public
+// repository write tools advertise `public_repo` as their required scope while
+// still accepting a full `repo` token (via the scope hierarchy). This enables
+// least-privilege, public-only OAuth deployments instead of forcing the broad
+// `repo` scope, which also grants private-repository access.
+// See https://github.com/github/github-mcp-server/issues/3136
+func TestPublicRepoWriteToolsDeclareLeastPrivilegeScopes(t *testing.T) {
+	t.Parallel()
+
+	builders := map[string]func(translations.TranslationHelperFunc) *inventory.ServerTool{
+		"add_issue_comment":   wrapToolBuilder(AddIssueComment),
+		"issue_write":         wrapToolBuilder(IssueWrite),
+		"create_branch":       wrapToolBuilder(CreateBranch),
+		"push_files":          wrapToolBuilder(PushFiles),
+		"create_pull_request": wrapToolBuilder(CreatePullRequest),
+		"fork_repository":     wrapToolBuilder(ForkRepository),
+	}
+
+	for name, build := range builders {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			st := build(translations.NullTranslationHelper)
+
+			require.NotNil(t, st.ScopeAccess.Challenge)
+			args := map[string]any(nil)
+			wantScopes := []string{string(scopes.PublicRepo)}
+			if name == "push_files" {
+				args = map[string]any{"files": []any{map[string]any{"path": "README.md"}}}
+				wantScopes = append(wantScopes, string(scopes.Workflow))
+			}
+			assert.Equal(t, wantScopes, st.ScopeAccess.Scopes,
+				"%s should expose the least-privilege scope upper bound", name)
+			assert.Empty(t, st.ScopeAccess.Challenge(args, []string{string(scopes.PublicRepo)}),
+				"%s should accept a public_repo token", name)
+			assert.Empty(t, st.ScopeAccess.Challenge(args, []string{string(scopes.Repo)}),
+				"%s should accept a parent repo token", name)
+			if name == "push_files" {
+				workflowArgs := map[string]any{"files": []any{map[string]any{"path": ".github/workflows/ci.yml"}}}
+				assert.Equal(t, []string{string(scopes.PublicRepo), string(scopes.Workflow)},
+					st.ScopeAccess.Challenge(workflowArgs, []string{string(scopes.PublicRepo)}),
+					"push_files should additionally challenge for workflow when needed")
+			}
+		})
+	}
+}
+
+// TestPublicRepoWriteToolsVisibleToPublicRepoToken asserts the PAT tool filter
+// shows these tools to a public_repo-only token and keeps them visible for a
+// full repo token.
+func TestPublicRepoWriteToolsVisibleToPublicRepoToken(t *testing.T) {
+	t.Parallel()
+
+	publicRepoToken := []string{string(scopes.PublicRepo)}
+	repoToken := []string{string(scopes.Repo)}
+
+	filterForPublicToken := CreateToolScopeFilter(publicRepoToken)
+	filterForRepoToken := CreateToolScopeFilter(repoToken)
+
+	builders := map[string]func(translations.TranslationHelperFunc) *inventory.ServerTool{
+		"add_issue_comment":   wrapToolBuilder(AddIssueComment),
+		"issue_write":         wrapToolBuilder(IssueWrite),
+		"create_branch":       wrapToolBuilder(CreateBranch),
+		"push_files":          wrapToolBuilder(PushFiles),
+		"create_pull_request": wrapToolBuilder(CreatePullRequest),
+		"fork_repository":     wrapToolBuilder(ForkRepository),
+	}
+
+	for name, build := range builders {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			st := build(translations.NullTranslationHelper)
+
+			allowed, err := filterForPublicToken(t.Context(), st)
+			require.NoError(t, err)
+			assert.True(t, allowed, "%s should be visible with a public_repo-only token", name)
+
+			allowed, err = filterForRepoToken(t.Context(), st)
+			require.NoError(t, err)
+			assert.True(t, allowed, "%s should remain visible with a full repo token", name)
+		})
+	}
+}
+
+func wrapToolBuilder(fn func(translations.TranslationHelperFunc) inventory.ServerTool) func(translations.TranslationHelperFunc) *inventory.ServerTool {
+	return func(t translations.TranslationHelperFunc) *inventory.ServerTool {
+		st := fn(t)
+		return &st
+	}
+}

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -706,7 +706,7 @@ func CreatePullRequest(t translations.TranslationHelperFunc) inventory.ServerToo
 				Required: []string{"owner", "repo", "title", "head", "base"},
 			},
 		},
-		scopes.RequireAll(scopes.Repo),
+		scopes.RequireAll(scopes.PublicRepo),
 		func(ctx context.Context, deps ToolDependencies, req *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -1229,7 +1229,7 @@ func ForkRepository(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo"},
 			},
 		},
-		scopes.RequireAll(scopes.Repo),
+		scopes.RequireAll(scopes.PublicRepo),
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {
@@ -1526,7 +1526,7 @@ func CreateBranch(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo", "branch"},
 			},
 		},
-		scopes.RequireAll(scopes.Repo),
+		scopes.RequireAll(scopes.PublicRepo),
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {
@@ -1658,7 +1658,7 @@ func PushFiles(t translations.TranslationHelperFunc) inventory.ServerTool {
 				Required: []string{"owner", "repo", "branch", "files", "message"},
 			},
 		},
-		scopes.RequireAll(scopes.Repo),
+		scopes.RequireAll(scopes.PublicRepo),
 		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			owner, err := RequiredParam[string](args, "owner")
 			if err != nil {
@@ -1840,7 +1840,7 @@ func PushFiles(t translations.TranslationHelperFunc) inventory.ServerTool {
 		},
 	)
 	tool.ScopeAccess = scopes.DynamicChallenge(
-		[]scopes.Scope{scopes.Repo, scopes.Workflow},
+		[]scopes.Scope{scopes.PublicRepo, scopes.Workflow},
 		tool.ScopeAccess.Visible,
 		workflowScopeChallengeForFiles,
 	)

--- a/pkg/github/repository_path.go
+++ b/pkg/github/repository_path.go
@@ -76,7 +76,7 @@ func workflowScopeChallengeForFiles(arguments map[string]any, activeScopes []str
 		}
 	}
 	if containsWorkflow {
-		return scopes.ChallengeAll(activeScopes, scopes.Repo, scopes.Workflow)
+		return scopes.ChallengeAll(activeScopes, scopes.PublicRepo, scopes.Workflow)
 	}
-	return scopes.ChallengeAll(activeScopes, scopes.Repo)
+	return scopes.ChallengeAll(activeScopes, scopes.PublicRepo)
 }

--- a/pkg/github/repository_path_test.go
+++ b/pkg/github/repository_path_test.go
@@ -84,7 +84,7 @@ func TestFileWriteWorkflowScopeChallenges(t *testing.T) {
 				map[string]any{"path": "README.md"},
 				map[string]any{"path": ".github/workflows/ci.yml"},
 			}},
-			want: []string{"repo", "workflow"},
+			want: []string{"public_repo", "workflow"},
 		},
 		{
 			name: "push validates entries after workflow",

--- a/pkg/github/tool_scopes_test.go
+++ b/pkg/github/tool_scopes_test.go
@@ -105,7 +105,7 @@ func TestDynamicToolScopeMetadataIsExhaustive(t *testing.T) {
 	}{
 		{tool: CreateOrUpdateFile(translations.NullTranslationHelper), maxScopes: []string{"repo", "workflow"}},
 		{tool: DeleteFile(translations.NullTranslationHelper), maxScopes: []string{"repo", "workflow"}},
-		{tool: PushFiles(translations.NullTranslationHelper), maxScopes: []string{"repo", "workflow"}},
+		{tool: PushFiles(translations.NullTranslationHelper), maxScopes: []string{"public_repo", "workflow"}},
 		{tool: ListIssueFields(translations.NullTranslationHelper), maxScopes: []string{"repo", "read:org"}},
 		{tool: ListIssueTypes(translations.NullTranslationHelper), maxScopes: []string{"repo", "read:org"}},
 		{tool: UIGet(translations.NullTranslationHelper), maxScopes: []string{"repo", "read:org"}},


### PR DESCRIPTION
## Summary

Fixes #3136 by lowering the required OAuth scope from `repo` to `public_repo` for the six repository write tools the issue identifies as public-repo-safe:

- `add_issue_comment`
- `issue_write`
- `create_branch`
- `push_files`
- `create_pull_request`
- `fork_repository`

An OAuth deployment that only needs to contribute to public repositories can now request least-privilege `public_repo` instead of the broad `repo` scope, which also grants private-repository access.

## Why this is safe

- The scope hierarchy still lets a full `repo` token satisfy `public_repo`, so existing deployments retain access.
- GitHub continues to enforce actual repository permissions at the API layer; this only stops the tool filter from hiding operations that a public-only token can perform.
- After rebasing onto `main@febc3293`, `push_files` keeps the newer dynamic workflow-path policy: ordinary files require `public_repo`, while `.github/workflows/*` additionally challenges for `workflow`.

## Testing

Exact head: `660bd4f1`

- `go build ./...` — pass
- `go vet ./pkg/github/ ./pkg/scopes/` — pass
- Targeted public-repo, dynamic-scope, and workflow-path tests — pass
- `go test ./pkg/scopes -count=1` — pass
- Full `go test ./pkg/github/ -count=1` has the same six Windows icon-order snapshot failures on pristine `main@febc3293` and this branch; the branch adds no failure.

AI assistance disclosure: Codex assisted with the rebase, conflict adaptation, tests, and drafting; I verified the resulting diff and reported results and take responsibility for the contribution.