### PR TITLE
feat: add Agent Plugins 1.0 package

### DIFF
--- a/agent-plugin/mcp.json
+++ b/agent-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "github": {
+      "type": "streamable-http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "github-mcp-server",
+  "description": "Work with GitHub repositories, issues, pull requests, reviews, and code search through MCP.",
+  "author": {
+    "name": "GitHub",
+    "url": "https://github.com/"
+  },
+  "homepage": "https://github.com/github/github-mcp-server",
+  "repository": "https://github.com/github/github-mcp-server",
+  "license": "MIT",
+  "keywords": ["code-search", "github", "issues", "mcp", "pull-requests"]
+}

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-  "name": "github-mcp-server",
+  "name": "github",
   "description": "Work with GitHub repositories, issues, pull requests, reviews, and code search through MCP.",
   "author": {
     "name": "GitHub",


### PR DESCRIPTION
## Summary

- add a portable Agent Plugins 1.0 package under `agent-plugin/`
- point `mcp.json` at the existing hosted GitHub MCP endpoint
- keep existing installation methods unchanged

Closes #3168.

## Verification

- `plugin.json` and `mcp.json` pass the Agent Plugins 1.0 schemas
- exact fork commit `14092de9940741511d224e0d7071ac02910bda11` passed add, info, and remove with agentplugins 0.1.18
- package tree: `sha256:277d1d6ac82febff8dcb43808f158308f04f57eb03f9621163bd0d1941d8e7a0`
- manifest: `sha256:4500bfe9a78f736c0300fde137595bc47d16582b12727aef062eb0f2b86735f1`
- isolated config-only profiles covered Codex, Cursor, and Kiro
- evidence: https://github.com/777genius/universal-agent-plugins/actions/runs/33115759932

These checks prove package ingestion and lifecycle. GitHub tool runtime and authentication were not executed.