### PR TITLE
Add expectedHeadSha pinning to merge_pull_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,7 @@ The following sets of tools are available:
   - **OAuth Challenge Scopes**: `repo`
   - `commit_message`: Extra detail for merge commit (string, optional)
   - `commit_title`: Title for merge commit (string, optional)
+  - `expectedHeadSha`: The expected SHA of the pull request's HEAD ref (string, optional)
   - `merge_method`: Merge method (string, optional)
   - `owner`: Repository owner (string, required)
   - `pullNumber`: Pull request number (number, required)

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -357,7 +357,7 @@ runtime behavior (such as output formatting) won't appear here.
 ### `thread_resolution_reason`
 
 - **pull_request_review_write** - Write operations (create, submit, delete) on pull request reviews
-  - **Required OAuth Scopes**: `repo`
+  - **OAuth Challenge Scopes**: `repo`
   - `body`: Review comment text (string, optional)
   - `commitID`: SHA of commit to review (string, optional)
   - `event`: Review action to perform. (string, optional)

--- a/pkg/github/__toolsnaps__/merge_pull_request.snap
+++ b/pkg/github/__toolsnaps__/merge_pull_request.snap
@@ -27,6 +27,10 @@
         "description": "Title for merge commit",
         "type": "string"
       },
+      "expectedHeadSha": {
+        "description": "The expected SHA of the pull request's HEAD ref",
+        "type": "string"
+      },
       "merge_method": {
         "description": "Merge method",
         "enum": [

--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -1513,6 +1513,10 @@ func MergePullRequest(t translations.TranslationHelperFunc) inventory.ServerTool
 				Description: "Merge method",
 				Enum:        []any{"merge", "squash", "rebase"},
 			},
+			"expectedHeadSha": {
+				Type:        "string",
+				Description: "The expected SHA of the pull request's HEAD ref",
+			},
 		},
 		Required: []string{"owner", "repo", "pullNumber"},
 	}
@@ -1555,9 +1559,14 @@ func MergePullRequest(t translations.TranslationHelperFunc) inventory.ServerTool
 			if err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
+			expectedHeadSHA, err := OptionalParam[string](args, "expectedHeadSha")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
 
 			options := &github.PullRequestOptions{
 				CommitTitle: commitTitle,
+				SHA:         expectedHeadSHA,
 				MergeMethod: mergeMethod,
 			}
 

--- a/pkg/github/pullrequests_sha_pinning_test.go
+++ b/pkg/github/pullrequests_sha_pinning_test.go
@@ -7,17 +7,12 @@ import (
 
 	"github.com/github/github-mcp-server/pkg/translations"
 	"github.com/google/go-github/v89/github"
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_MergePullRequestSHAPinning(t *testing.T) {
 	serverTool := MergePullRequest(translations.NullTranslationHelper)
-
-	schema := serverTool.Tool.InputSchema.(*jsonschema.Schema)
-	require.Contains(t, schema.Properties, "expectedHeadSha")
-	assert.Equal(t, "string", schema.Properties["expectedHeadSha"].Type)
 
 	const pinnedSHA = "0123456789abcdef0123456789abcdef01234567"
 
@@ -44,7 +39,7 @@ func Test_MergePullRequestSHAPinning(t *testing.T) {
 			"owner":           "owner",
 			"repo":            "repo",
 			"pullNumber":      float64(42),
-			"merge_method":     "merge",
+			"merge_method":    "merge",
 			"expectedHeadSha": pinnedSHA,
 		})
 
@@ -81,7 +76,7 @@ func Test_MergePullRequestSHAPinning(t *testing.T) {
 			"owner":           "owner",
 			"repo":            "repo",
 			"pullNumber":      float64(42),
-			"merge_method":     "merge",
+			"merge_method":    "merge",
 			"expectedHeadSha": pinnedSHA,
 		})
 
@@ -92,6 +87,7 @@ func Test_MergePullRequestSHAPinning(t *testing.T) {
 
 		require.NoError(t, err)
 		require.True(t, result.IsError)
+		assert.Contains(t, getErrorResult(t, result).Text, "Head branch was modified")
 		assert.Equal(t, 1, calls, "merge must not retry after a head-SHA mismatch")
 	})
 }

--- a/pkg/github/pullrequests_sha_pinning_test.go
+++ b/pkg/github/pullrequests_sha_pinning_test.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/google/go-github/v89/github"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MergePullRequestSHAPinning(t *testing.T) {
+	serverTool := MergePullRequest(translations.NullTranslationHelper)
+
+	schema := serverTool.Tool.InputSchema.(*jsonschema.Schema)
+	require.Contains(t, schema.Properties, "expectedHeadSha")
+	assert.Equal(t, "string", schema.Properties["expectedHeadSha"].Type)
+
+	const pinnedSHA = "0123456789abcdef0123456789abcdef01234567"
+
+	mockMergeResult := &github.PullRequestMergeResult{
+		SHA:     github.Ptr("merge-result-sha"),
+		Merged:  github.Ptr(true),
+		Message: github.Ptr("Pull Request successfully merged"),
+	}
+
+	t.Run("expected head SHA is sent as REST sha", func(t *testing.T) {
+		client := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			PutReposPullsMergeByOwnerByRepoByPullNumber: expectRequestBody(t, map[string]any{
+				"merge_method": "merge",
+				"sha":          pinnedSHA,
+			}).andThen(
+				mockResponse(t, http.StatusOK, mockMergeResult),
+			),
+		}))
+
+		deps := BaseDeps{Client: client}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":           "owner",
+			"repo":            "repo",
+			"pullNumber":      float64(42),
+			"merge_method":     "merge",
+			"expectedHeadSha": pinnedSHA,
+		})
+
+		result, err := handler(
+			ContextWithDeps(context.Background(), deps),
+			&request,
+		)
+
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+	})
+
+	t.Run("head mismatch fails closed without retry", func(t *testing.T) {
+		calls := 0
+
+		client := mustNewGHClient(t, MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
+			PutReposPullsMergeByOwnerByRepoByPullNumber: expectRequestBody(t, map[string]any{
+				"merge_method": "merge",
+				"sha":          pinnedSHA,
+			}).andThen(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(
+					`{"message":"Head branch was modified. Review and try the merge again."}`,
+				))
+			}),
+		}))
+
+		deps := BaseDeps{Client: client}
+		handler := serverTool.Handler(deps)
+
+		request := createMCPRequest(map[string]any{
+			"owner":           "owner",
+			"repo":            "repo",
+			"pullNumber":      float64(42),
+			"merge_method":     "merge",
+			"expectedHeadSha": pinnedSHA,
+		})
+
+		result, err := handler(
+			ContextWithDeps(context.Background(), deps),
+			&request,
+		)
+
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		assert.Equal(t, 1, calls, "merge must not retry after a head-SHA mismatch")
+	})
+}

--- a/pkg/github/pullrequests_test.go
+++ b/pkg/github/pullrequests_test.go
@@ -760,6 +760,7 @@ func Test_MergePullRequest(t *testing.T) {
 	assert.Contains(t, schema.Properties, "commit_title")
 	assert.Contains(t, schema.Properties, "commit_message")
 	assert.Contains(t, schema.Properties, "merge_method")
+	assert.Contains(t, schema.Properties, "expectedHeadSha")
 	assert.ElementsMatch(t, schema.Required, []string{"owner", "repo", "pullNumber"})
 
 	// Setup mock merge result for success case
@@ -778,7 +779,7 @@ func Test_MergePullRequest(t *testing.T) {
 		expectedErrMsg      string
 	}{
 		{
-			name: "successful merge",
+			name: "successful merge without expected head SHA",
 			mockedClient: MockHTTPClientWithHandlers(map[string]http.HandlerFunc{
 				PutReposPullsMergeByOwnerByRepoByPullNumber: expectRequestBody(t, map[string]any{
 					"commit_title":   "Merge PR #42",


### PR DESCRIPTION
## Summary

Adds optional `expectedHeadSha` pinning to `merge_pull_request`.

The value is forwarded to `github.PullRequestOptions.SHA`, which
`go-github` serializes as the GitHub REST merge endpoint's optional
`sha` field.

This closes the TOCTOU gap between reviewing a pull request HEAD and merging
it: if the HEAD changes, GitHub rejects the merge instead of merging the new
commit.

## Changes

- add optional `expectedHeadSha` to the `merge_pull_request` schema;
- pass it to `PullRequestOptions.SHA`;
- verify the value reaches the REST request as `sha`;
- verify a 409 head mismatch fails closed with no retry;
- update the merge tool schema snapshot;
- regenerate project docs when local Go tooling is available.

## Backward compatibility

The new field is optional. Existing callers that omit
`expectedHeadSha` retain the current behavior.

## Local validation

- Go tests: `SKIPPED_GO_NOT_INSTALLED`
- generated docs: `SKIPPED_GO_NOT_INSTALLED`
- golangci-lint: `SKIPPED_GOLANGCI_LINT_NOT_INSTALLED`
- `git diff --check`: PASS

Fixes #3181
