### PR TITLE
Fix HTML entities in sanitized titles

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -256,8 +256,7 @@ func formatGitHubValidationDetail(validationErr github.Error) string {
 }
 
 func sanitizeGitHubValidationText(value string) string {
-	// Tool errors are plain text; keep quoted branch patterns readable.
-	sanitized := strings.ReplaceAll(sanitize.Sanitize(value), "&#39;", "'")
+	sanitized := sanitize.PlainText(value)
 	return strings.Join(strings.Fields(sanitized), " ")
 }
 

--- a/pkg/errors/error_test.go
+++ b/pkg/errors/error_test.go
@@ -703,13 +703,13 @@ func TestNewGitHubAPIErrorResponse_ValidationMessages(t *testing.T) {
 
 		originalErr := &github.ErrorResponse{
 			Response: response,
-			Message:  "Validation <script>secret-script</script>Failed\u202e",
+			Message:  "Validation <script>secret-script</script>Failed\u202e for AT&T",
 			Errors: []github.Error{
 				{
 					Resource: "GitRef",
 					Field:    "ref",
 					Code:     "custom",
-					Message:  "ref name does not match the required pattern 'feature/*'\u202e",
+					Message:  `ref name does not match the required pattern 'feature/*' or "release/*"` + "\u202e",
 				},
 			},
 			DocumentationURL: "https://docs.github.test/private?token=secret-doc-token",
@@ -724,7 +724,8 @@ func TestNewGitHubAPIErrorResponse_ValidationMessages(t *testing.T) {
 		)
 
 		text := requireErrorText(t, result)
-		assert.Equal(t, "failed to create branch: Validation Failed\nGitRef.ref (custom): ref name does not match the required pattern 'feature/*'", text)
+		assert.Equal(t, `failed to create branch: Validation Failed for AT&T
+GitRef.ref (custom): ref name does not match the required pattern 'feature/*' or "release/*"`, text)
 		assert.NotContains(t, text, "create ref")
 		assert.NotContains(t, text, "https://")
 		assert.NotContains(t, text, "secret-")

--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -100,7 +100,7 @@ type WithCategoryNoOrder struct {
 func fragmentToDiscussion(fragment NodeFragment) *github.Discussion {
 	return &github.Discussion{
 		Number:    github.Ptr(int(fragment.Number)),
-		Title:     github.Ptr(sanitize.Sanitize(string(fragment.Title))),
+		Title:     github.Ptr(sanitize.PlainText(string(fragment.Title))),
 		HTMLURL:   github.Ptr(string(fragment.URL)),
 		CreatedAt: &github.Timestamp{Time: fragment.CreatedAt.Time},
 		UpdatedAt: &github.Timestamp{Time: fragment.UpdatedAt.Time},
@@ -361,7 +361,7 @@ func GetDiscussion(t translations.TranslationHelperFunc) inventory.ServerTool {
 			// like ListDiscussions and GetDiscussionComments).
 			response := map[string]any{
 				"number":     int(d.Number),
-				"title":      sanitize.Sanitize(string(d.Title)),
+				"title":      sanitize.PlainText(string(d.Title)),
 				"body":       sanitize.Sanitize(string(d.Body)),
 				"url":        string(d.URL),
 				"closed":     bool(d.Closed),

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -1194,7 +1194,7 @@ func GetIssueParent(ctx context.Context, client *githubv4.Client, deps ToolDepen
 	return MarshalledTextResult(map[string]any{
 		"parent": map[string]any{
 			"number":     int(parent.Number),
-			"title":      sanitize.Sanitize(string(parent.Title)),
+			"title":      sanitize.PlainText(string(parent.Title)),
 			"state":      string(parent.State),
 			"url":        string(parent.URL),
 			"repository": string(parent.Repository.NameWithOwner),
@@ -1995,7 +1995,7 @@ func sanitizeIssueTitleAndBody(issue *github.Issue) {
 		return
 	}
 	if issue.Title != nil {
-		issue.Title = github.Ptr(sanitize.Sanitize(*issue.Title))
+		issue.Title = github.Ptr(sanitize.PlainText(*issue.Title))
 	}
 	if issue.Body != nil {
 		issue.Body = github.Ptr(sanitize.Sanitize(*issue.Body))

--- a/pkg/github/minimal_types.go
+++ b/pkg/github/minimal_types.go
@@ -622,7 +622,7 @@ type MinimalPullRequestRef struct {
 func newMinimalPullRequestRef(number int, title, state, url, repository string) MinimalPullRequestRef {
 	return MinimalPullRequestRef{
 		Number:     number,
-		Title:      sanitize.Sanitize(title),
+		Title:      sanitize.PlainText(title),
 		State:      state,
 		URL:        url,
 		Repository: repository,
@@ -646,7 +646,7 @@ type MinimalIssueRef struct {
 func newMinimalIssueRef(number int, title, state, url, repository string) MinimalIssueRef {
 	return MinimalIssueRef{
 		Number:     number,
-		Title:      sanitize.Sanitize(title),
+		Title:      sanitize.PlainText(title),
 		State:      state,
 		URL:        url,
 		Repository: repository,
@@ -814,7 +814,7 @@ func convertToMinimalPullRequestReview(review *github.PullRequestReview) Minimal
 func convertToMinimalIssue(issue *github.Issue) MinimalIssue {
 	m := MinimalIssue{
 		Number:            issue.GetNumber(),
-		Title:             sanitize.Sanitize(issue.GetTitle()),
+		Title:             sanitize.PlainText(issue.GetTitle()),
 		Body:              sanitize.Sanitize(issue.GetBody()),
 		State:             issue.GetState(),
 		StateReason:       issue.GetStateReason(),
@@ -925,7 +925,7 @@ func fragmentToMinimalIssue(fragment IssueFragment) MinimalIssue {
 func fragmentWithoutFieldValuesToMinimalIssue(fragment issueFragmentWithoutFieldValues) MinimalIssue {
 	m := MinimalIssue{
 		Number:    int(fragment.Number),
-		Title:     sanitize.Sanitize(string(fragment.Title)),
+		Title:     sanitize.PlainText(string(fragment.Title)),
 		Body:      sanitize.Sanitize(string(fragment.Body)),
 		State:     string(fragment.State),
 		Comments:  int(fragment.Comments.TotalCount),
@@ -1084,7 +1084,7 @@ func convertToMinimalFileContentResponse(resp *github.RepositoryContentResponse)
 func convertToMinimalPullRequest(pr *github.PullRequest) MinimalPullRequest {
 	m := MinimalPullRequest{
 		Number:         pr.GetNumber(),
-		Title:          sanitize.Sanitize(pr.GetTitle()),
+		Title:          sanitize.PlainText(pr.GetTitle()),
 		Body:           sanitize.Sanitize(pr.GetBody()),
 		State:          pr.GetState(),
 		Draft:          pr.GetDraft(),
@@ -1279,7 +1279,7 @@ func convertIssueToMinimalProjectItemContent(issue *github.Issue) *MinimalProjec
 		ID:          issue.GetID(),
 		NodeID:      issue.GetNodeID(),
 		Number:      issue.GetNumber(),
-		Title:       sanitize.Sanitize(issue.GetTitle()),
+		Title:       sanitize.PlainText(issue.GetTitle()),
 		State:       issue.GetState(),
 		StateReason: issue.GetStateReason(),
 		HTMLURL:     issue.GetHTMLURL(),
@@ -1316,7 +1316,7 @@ func convertPullRequestToMinimalProjectItemContent(pr *github.PullRequest) *Mini
 		ID:         pr.GetID(),
 		NodeID:     pr.GetNodeID(),
 		Number:     pr.GetNumber(),
-		Title:      sanitize.Sanitize(pr.GetTitle()),
+		Title:      sanitize.PlainText(pr.GetTitle()),
 		State:      pr.GetState(),
 		HTMLURL:    pr.GetHTMLURL(),
 		Repository: pullRequestRepositoryFullName(pr),
@@ -1353,7 +1353,7 @@ func convertDraftIssueToMinimalProjectItemContent(draftIssue *github.ProjectV2Dr
 	m := &MinimalProjectItemContent{
 		ID:        draftIssue.GetID(),
 		NodeID:    draftIssue.GetNodeID(),
-		Title:     sanitize.Sanitize(draftIssue.GetTitle()),
+		Title:     sanitize.PlainText(draftIssue.GetTitle()),
 		CreatedAt: formatProjectTimestamp(draftIssue.CreatedAt),
 		UpdatedAt: formatProjectTimestamp(draftIssue.UpdatedAt),
 	}
@@ -1612,7 +1612,7 @@ func minimalProjectPullRequestRefFromPullRequest(pr *github.PullRequest) minimal
 	}
 	return minimalProjectPullRequestRef{
 		Number:     pr.GetNumber(),
-		Title:      sanitize.Sanitize(pr.GetTitle()),
+		Title:      sanitize.PlainText(pr.GetTitle()),
 		State:      pr.GetState(),
 		HTMLURL:    pr.GetHTMLURL(),
 		Repository: pullRequestRepositoryFullName(pr),
@@ -1634,7 +1634,7 @@ func minimalProjectPullRequestRefFromMap(value map[string]any) minimalProjectPul
 
 	return minimalProjectPullRequestRef{
 		Number:     intFromAny(value["number"]),
-		Title:      sanitize.Sanitize(stringFromMap(value, "title")),
+		Title:      sanitize.PlainText(stringFromMap(value, "title")),
 		State:      stringFromMap(value, "state"),
 		HTMLURL:    htmlURL,
 		Repository: repository,
@@ -2038,7 +2038,7 @@ func convertToMinimalRelease(release *github.RepositoryRelease) MinimalRelease {
 	m := MinimalRelease{
 		ID:         release.GetID(),
 		TagName:    release.GetTagName(),
-		Name:       sanitize.Sanitize(release.GetName()),
+		Name:       sanitize.PlainText(release.GetName()),
 		Body:       sanitize.Sanitize(release.GetBody()),
 		HTMLURL:    release.GetHTMLURL(),
 		Prerelease: release.GetPrerelease(),

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -2981,7 +2981,7 @@ func GetFileBlame(t translations.TranslationHelperFunc) inventory.ServerTool {
 					SHA: sha,
 					// Sanitized after truncation so the headline is cut at the author's real
 					// first line break rather than one introduced by sanitization.
-					MessageHeadline: sanitize.Sanitize(headline),
+					MessageHeadline: sanitize.PlainText(headline),
 					CommittedDate:   r.Commit.CommittedDate.Format("2006-01-02T15:04:05Z"),
 					Author: BlameAuthor{
 						Name:  string(r.Commit.Author.Name),

--- a/pkg/github/sanitize_coverage_test.go
+++ b/pkg/github/sanitize_coverage_test.go
@@ -13,19 +13,19 @@ import (
 )
 
 // maliciousText contains an HTML payload plus invisible/hidden-instruction characters,
-// mirroring the classes of untrusted content pkg/sanitize.Sanitize is meant to strip:
+// mirroring the classes of untrusted content the shared sanitizers are meant to strip:
 // disallowed HTML tags and zero-width/BiDi control characters that can hide instructions
 // from a human reviewer while still being interpreted by a model.
 const maliciousText = "<script>alert(1)</script>Hello\u200BWorld"
 
-// sanitizedText is what maliciousText becomes after sanitize.Sanitize: the <script> tag
-// (and its content) is stripped by the HTML policy, and the zero-width space is removed.
+// sanitizedText is what maliciousText becomes after sanitization: the <script> tag and
+// its content are stripped by the HTML policy, and the zero-width space is removed.
 const sanitizedText = "HelloWorld"
 
 // Test_MinimalConverters_SanitizeUserAuthoredText is a table-driven regression test asserting
 // that every convertToMinimal* helper which surfaces untrusted, user-authored prose (issue and
-// PR titles/bodies, comments, reviews, review comments, releases, commit messages) applies
-// pkg/sanitize.Sanitize consistently. This guards against the inconsistent coverage described in
+// PR titles/bodies, comments, reviews, review comments, releases, commit messages) applies the
+// appropriate shared sanitizer consistently. This guards against the inconsistent coverage described in
 // https://github.com/github/github-mcp-server/issues/3106.
 func Test_MinimalConverters_SanitizeUserAuthoredText(t *testing.T) {
 	tests := []struct {
@@ -255,6 +255,23 @@ func Test_SearchIssueResult_SanitizesTitleAndBody(t *testing.T) {
 
 	assert.Equal(t, sanitizedText, decoded.Title)
 	assert.Equal(t, sanitizedText, decoded.Body)
+}
+
+func Test_TitleSanitizationPreservesToolOutputText(t *testing.T) {
+	issue := convertToMinimalIssue(&github.Issue{
+		Title: github.Ptr(`can't "quote" AT&T`),
+		Body:  github.Ptr(`<b>"quoted"</b>`),
+	})
+
+	result := MarshalledTextResult(map[string]string{
+		"body":  issue.Body,
+		"title": issue.Title,
+	})
+
+	assert.Equal(t,
+		`{"body":"\u003cb\u003e\u0026#34;quoted\u0026#34;\u003c/b\u003e","title":"can't \"quote\" AT\u0026T"}`,
+		getTextResult(t, result).Text,
+	)
 }
 
 // Test_SanitizeIssueTitleAndBody exercises the shared helper directly, including its nil-safety,

--- a/pkg/sanitize/sanitize.go
+++ b/pkg/sanitize/sanitize.go
@@ -1,16 +1,23 @@
 package sanitize
 
 import (
+	stdhtml "html"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/microcosm-cc/bluemonday"
+	nethtml "golang.org/x/net/html"
 )
 
-var policy *bluemonday.Policy
-var policyOnce sync.Once
+var (
+	policy              *bluemonday.Policy
+	policyOnce          sync.Once
+	plainTextPolicy     *bluemonday.Policy
+	plainTextPolicyOnce sync.Once
+)
 
 func Sanitize(input string) string {
 	// The invisible-character and code-fence filters both run before and after
@@ -34,6 +41,106 @@ func Sanitize(input string) string {
 		return normalized
 	}
 	return FilterCodeFenceMetadata(FilterInvisibleCharacters(normalized))
+}
+
+// PlainText sanitizes user-authored text that must not contain HTML.
+func PlainText(input string) string {
+	filtered := FilterCodeFenceMetadata(FilterInvisibleCharacters(input))
+	if filtered == "" {
+		return ""
+	}
+
+	tokenizer := nethtml.NewTokenizer(strings.NewReader(filtered))
+	var marked strings.Builder
+	var text []string
+	for {
+		tokenType := tokenizer.Next()
+		if tokenType == nethtml.ErrorToken {
+			break
+		}
+		if tokenType == nethtml.TextToken {
+			marker := plainTextMarker(len(text))
+			marked.WriteString(marker)
+			text = append(text, neutralizePlainTextAngles(tokenizer.Token().Data))
+			continue
+		}
+		marked.Write(tokenizer.Raw())
+	}
+
+	sanitized := restorePlainText(getPlainTextPolicy().Sanitize(marked.String()), text)
+	return FilterCodeFenceMetadata(FilterInvisibleCharacters(sanitized))
+}
+
+const plainTextMarkerPrefix = "githubmcpplaintexttoken"
+
+func plainTextMarker(index int) string {
+	return plainTextMarkerPrefix + strconv.Itoa(index) + "x"
+}
+
+func restorePlainText(marked string, values []string) string {
+	var restored strings.Builder
+	for marked != "" {
+		start := strings.Index(marked, plainTextMarkerPrefix)
+		if start < 0 {
+			restored.WriteString(marked)
+			break
+		}
+		restored.WriteString(marked[:start])
+		marked = marked[start+len(plainTextMarkerPrefix):]
+
+		end := strings.IndexByte(marked, 'x')
+		if end < 0 {
+			restored.WriteString(plainTextMarkerPrefix)
+			restored.WriteString(marked)
+			break
+		}
+		index, err := strconv.Atoi(marked[:end])
+		if err != nil || index < 0 || index >= len(values) {
+			restored.WriteString(plainTextMarkerPrefix)
+			restored.WriteString(marked[:end+1])
+		} else {
+			restored.WriteString(values[index])
+		}
+		marked = marked[end+1:]
+	}
+	return restored.String()
+}
+
+func neutralizePlainTextAngles(input string) string {
+	input = FilterInvisibleCharacters(input)
+	input = strings.ReplaceAll(input, "\x00", string(utf8.RuneError))
+	input = strings.ReplaceAll(input, "\r\n", "\n")
+	input = strings.ReplaceAll(input, "\r", "\n")
+	input = neutralizeNestedEntities(input)
+	input = strings.ReplaceAll(input, "<", "&lt;")
+	return strings.ReplaceAll(input, ">", "&gt;")
+}
+
+func neutralizeNestedEntities(input string) string {
+	var neutralized strings.Builder
+	for {
+		start := strings.IndexByte(input, '&')
+		if start < 0 {
+			neutralized.WriteString(input)
+			return neutralized.String()
+		}
+		neutralized.WriteString(input[:start])
+		input = input[start:]
+
+		end := strings.IndexByte(input[1:], '&')
+		if end < 0 {
+			end = len(input)
+		} else {
+			end++
+		}
+		if candidate := input[:end]; stdhtml.UnescapeString(candidate) != candidate {
+			neutralized.WriteString("&amp;")
+			input = input[1:]
+		} else {
+			neutralized.WriteByte('&')
+			input = input[1:]
+		}
+	}
 }
 
 // FilterInvisibleCharacters removes invisible or control characters that should not appear
@@ -333,6 +440,13 @@ func getPolicy() *bluemonday.Policy {
 		policy = p
 	})
 	return policy
+}
+
+func getPlainTextPolicy() *bluemonday.Policy {
+	plainTextPolicyOnce.Do(func() {
+		plainTextPolicy = bluemonday.StrictPolicy()
+	})
+	return plainTextPolicy
 }
 
 func shouldRemoveRune(r rune) bool {

--- a/pkg/sanitize/sanitize_test.go
+++ b/pkg/sanitize/sanitize_test.go
@@ -365,6 +365,123 @@ func TestSanitizeRemovesInvisibleCodeFenceMetadata(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestPlainText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "visible punctuation",
+			input:    `can't "quote" AT&T`,
+			expected: `can't "quote" AT&T`,
+		},
+		{
+			name:     "named punctuation entities",
+			input:    `can&apos;t &quot;quote&quot; AT&amp;T`,
+			expected: `can't "quote" AT&T`,
+		},
+		{
+			name:     "decimal punctuation entities",
+			input:    "can&#39;t &#34;quote&#34; AT&#38;T",
+			expected: `can't "quote" AT&T`,
+		},
+		{
+			name:     "hexadecimal punctuation entities",
+			input:    "can&#x27;t &#x22;quote&#x22; AT&#x26;T",
+			expected: `can't "quote" AT&T`,
+		},
+		{
+			name:     "raw unsafe element",
+			input:    "before<script>alert(1)</script>after",
+			expected: "beforeafter",
+		},
+		{
+			name:     "raw formatting element",
+			input:    "<b>bold</b> and <em>italic</em>",
+			expected: "bold and italic",
+		},
+		{
+			name:     "named entity encoded element remains inert",
+			input:    "&lt;script&gt;alert(1)&lt;/script&gt;",
+			expected: "&lt;script&gt;alert(1)&lt;/script&gt;",
+		},
+		{
+			name:     "decimal entity encoded element remains inert",
+			input:    "&#60;script&#62;alert(1)&#60;/script&#62;",
+			expected: "&lt;script&gt;alert(1)&lt;/script&gt;",
+		},
+		{
+			name:     "hexadecimal entity encoded element remains inert",
+			input:    "&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;",
+			expected: "&lt;script&gt;alert(1)&lt;/script&gt;",
+		},
+		{
+			name:     "double encoded element remains inert",
+			input:    "&amp;lt;script&amp;gt;",
+			expected: "&amp;lt;script&amp;gt;",
+		},
+		{
+			name:     "triply encoded element remains inert",
+			input:    "&amp;amp;lt;script&amp;amp;gt;",
+			expected: "&amp;amp;lt;script&amp;amp;gt;",
+		},
+		{
+			name:     "double encoded punctuation remains encoded once",
+			input:    "can&amp;#39;t",
+			expected: "can&amp;#39;t",
+		},
+		{
+			name:     "malformed element is stripped",
+			input:    "before <script",
+			expected: "before ",
+		},
+		{
+			name:     "internal marker text is preserved",
+			input:    "githubmcpplaintexttoken1x<b>bold</b>",
+			expected: "githubmcpplaintexttoken1xbold",
+		},
+		{
+			name:     "literal angle brackets are neutralized",
+			input:    "1 < 2 > 0",
+			expected: "1 &lt; 2 &gt; 0",
+		},
+		{
+			name:     "literal invisible and bidi characters",
+			input:    "Hello\u200B\u202EWorld",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "encoded invisible and bidi characters",
+			input:    "Hello&#8203;&#x202E;World",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "nul characters are normalized",
+			input:    "Hello\x00&#0;World",
+			expected: "Hello��World",
+		},
+		{
+			name:     "malformed utf8 is normalized",
+			input:    "Hello\xffWorld",
+			expected: "Hello\uFFFDWorld",
+		},
+		{
+			name:     "code fence metadata",
+			input:    "```steal secrets\ncode\n```",
+			expected: "```\ncode\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PlainText(tt.input)
+			require.Equal(t, tt.expected, result)
+			require.Equal(t, result, PlainText(result))
+		})
+	}
+}
+
 // TestSanitizeFiltersInvisibleCharactersAfterEntityDecoding covers the core
 // regression from issue #3101: invisible/bidi characters encoded as HTML
 // character entities are decoded by FilterHTMLTags, so the invisible-character
@@ -663,6 +780,25 @@ func TestSanitizeIsIdempotent(t *testing.T) {
 		once := Sanitize(in)
 		require.Equal(t, once, Sanitize(once), "Sanitize not idempotent on %q", in)
 	}
+}
+
+func TestPlainTextIsIdempotent(t *testing.T) {
+	for _, in := range invariantCorpus {
+		once := PlainText(in)
+		require.Equal(t, once, PlainText(once), "PlainText not idempotent on %q", in)
+	}
+}
+
+func FuzzPlainTextIsIdempotent(f *testing.F) {
+	for _, seed := range invariantCorpus {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		once := PlainText(in)
+		if twice := PlainText(once); twice != once {
+			t.Fatalf("PlainText not idempotent on %q: first %q, second %q", in, once, twice)
+		}
+	})
 }
 
 // TestSanitizeDoesNotAllocateForCleanASCII pins the allocation contract from


### PR DESCRIPTION
## Summary
- add an entity-aware plain-text sanitizer that preserves visible quotes, apostrophes, and ampersands
- apply it to issue, pull request, discussion, release, headline, and validation-text surfaces without changing Markdown body sanitization
- cover raw and encoded HTML, character entities, malformed input, invisible characters, idempotence, and exact tool output

## Testing
- `script/lint`
- `script/test`

Fixes #3214