### PR TITLE
docs: use Claude MCP env option in Docker examples

### DIFF
--- a/docs/installation-guides/install-claude.md
+++ b/docs/installation-guides/install-claude.md
@@ -67,7 +67,7 @@ claude mcp add-json github "{`"type`":`"http`",`"url`":`"https://api.githubcopil
 Log in with OAuth instead of a token. On github.com the official image already includes the app credentials, so you provide none yourself — the server opens a browser login on first use and keeps the token in memory only. In Docker, publish a fixed callback port to loopback. Run the following command in the terminal (not in Claude Code CLI):
 
 ```bash
-claude mcp add github -e GITHUB_OAUTH_CALLBACK_PORT=8085 -- docker run -i --rm -p 127.0.0.1:8085:8085 -e GITHUB_OAUTH_CALLBACK_PORT ghcr.io/github/github-mcp-server
+claude mcp add github --env GITHUB_OAUTH_CALLBACK_PORT=8085 -- docker run -i --rm -p 127.0.0.1:8085:8085 -e GITHUB_OAUTH_CALLBACK_PORT ghcr.io/github/github-mcp-server
 ```
 
 See **[Local Server OAuth Login](../oauth-login.md)** for the native-binary flow (no fixed port), headless/device-code fallback, GitHub Enterprise, and bringing your own OAuth or GitHub App.
@@ -75,12 +75,12 @@ See **[Local Server OAuth Login](../oauth-login.md)** for the native-binary flow
 To authenticate with a Personal Access Token instead (it takes precedence over OAuth):
 1. Run the following command in the terminal (not in Claude Code CLI):
 ```bash
-claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PAT -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
+claude mcp add github --env GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PAT -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
 ```
 
 With an environment variable:
 ```bash
-claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=$(grep GITHUB_PAT .env | cut -d '=' -f2) -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
+claude mcp add github --env GITHUB_PERSONAL_ACCESS_TOKEN=$(grep GITHUB_PAT .env | cut -d '=' -f2) -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server
 ```
 2. Restart Claude Code
 3. Run `claude mcp list` to see if the GitHub server is configured


### PR DESCRIPTION
## Summary

Fixes #3032.

The Claude Code CLI documents `--env KEY=value` for environment variables passed to a local MCP server. The Docker examples used the Copilot-style `-e` shorthand before the command separator, which Claude rejects as an unknown option.

This updates all three Claude Docker examples to use `--env` while leaving Docker's own `-e` arguments after `--` unchanged.

## Validation

- Compared the command shape with Anthropic's current Claude Code MCP documentation.
- Confirmed no `claude mcp add github -e` examples remain in the guide.
- `git diff --check`

AI assistance was used to locate the affected examples and cross-check the CLI syntax. I reviewed the final documentation diff.
