### PR TITLE
Return a clear error for missing owner/repo/issue_number in the copilot assignment tools

### DIFF
--- a/pkg/github/copilot.go
+++ b/pkg/github/copilot.go
@@ -214,6 +214,19 @@ func AssignCopilotToIssue(t translations.TranslationHelperFunc) inventory.Server
 				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
+			// owner, repo and issue_number are required, but WeakDecode zero-fills a
+			// missing value, so a missing arg reached the query as a confusing
+			// "Could not resolve to a Repository" error. Reject the zero values.
+			if params.Owner == "" {
+				return utils.NewToolResultError("missing required parameter: owner"), nil, nil
+			}
+			if params.Repo == "" {
+				return utils.NewToolResultError("missing required parameter: repo"), nil, nil
+			}
+			if params.IssueNumber == 0 {
+				return utils.NewToolResultError("missing required parameter: issue_number"), nil, nil
+			}
+
 			client, err := deps.GetGQLClient(ctx)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to get GitHub client: %w", err)
@@ -586,6 +599,19 @@ func AssignCopilotToIssueWithIntent(t translations.TranslationHelperFunc) invent
 			}
 			if err := mapstructure.WeakDecode(args, &params); err != nil {
 				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// owner, repo and issue_number are required, but WeakDecode zero-fills a
+			// missing value, so reject the zero values (as with rationale/confidence
+			// below) before they reach the query as a confusing repository error.
+			if params.Owner == "" {
+				return utils.NewToolResultError("missing required parameter: owner"), nil, nil
+			}
+			if params.Repo == "" {
+				return utils.NewToolResultError("missing required parameter: repo"), nil, nil
+			}
+			if params.IssueNumber == 0 {
+				return utils.NewToolResultError("missing required parameter: issue_number"), nil, nil
 			}
 
 			// Validate rationale length (rune count, matching the granular assignee tools).

--- a/pkg/github/copilot_test.go
+++ b/pkg/github/copilot_test.go
@@ -60,6 +60,36 @@ func TestAssignCopilotToIssue(t *testing.T) {
 		expectedToolErrMsg string
 	}{
 		{
+			name: "missing owner is rejected",
+			requestArgs: map[string]any{
+				"repo":         "repo",
+				"issue_number": float64(123),
+			},
+			mockedClient:       githubv4mock.NewMockedHTTPClient(),
+			expectToolError:    true,
+			expectedToolErrMsg: "missing required parameter: owner",
+		},
+		{
+			name: "missing repo is rejected",
+			requestArgs: map[string]any{
+				"owner":        "owner",
+				"issue_number": float64(123),
+			},
+			mockedClient:       githubv4mock.NewMockedHTTPClient(),
+			expectToolError:    true,
+			expectedToolErrMsg: "missing required parameter: repo",
+		},
+		{
+			name: "missing issue_number is rejected",
+			requestArgs: map[string]any{
+				"owner": "owner",
+				"repo":  "repo",
+			},
+			mockedClient:       githubv4mock.NewMockedHTTPClient(),
+			expectToolError:    true,
+			expectedToolErrMsg: "missing required parameter: issue_number",
+		},
+		{
 			name: "successful assignment when there are no existing assignees",
 			requestArgs: map[string]any{
 				"owner":        "owner",
@@ -1228,6 +1258,19 @@ func TestAssignCopilotToIssueWithIntent(t *testing.T) {
 		expectedToolErrMsg string
 		expectSuggestion   bool
 	}{
+		{
+			name: "missing owner is rejected",
+			requestArgs: map[string]any{
+				"repo":          "repo",
+				"issue_number":  float64(123),
+				"rationale":     "Well-scoped task.",
+				"confidence":    "HIGH",
+				"is_suggestion": false,
+			},
+			mockedClient:       githubv4mock.NewMockedHTTPClient(),
+			expectToolError:    true,
+			expectedToolErrMsg: "missing required parameter: owner",
+		},
 		{
 			name: "direct assignment with rationale and confidence preserves existing assignees",
 			requestArgs: map[string]any{


### PR DESCRIPTION
## Summary
Return a clear `missing required parameter` error when `owner`, `repo`, or `issue_number` is omitted from `assign_copilot_to_issue` / `assign_copilot_to_issue_with_intent`, instead of a confusing downstream repository error.

## Why
Both handlers decode these required params with `mapstructure.WeakDecode`, which zero-fills a missing value instead of erroring. A missing arg then reached the GraphQL query and surfaced as `failed to get suggested actors: ... Could not resolve to a Repository`, which does not tell the caller what was actually wrong. The input schema already marks these three fields required, so this makes the handler enforce it, matching the existing `is_suggestion` and `rationale`/`confidence` checks in the same handlers and the `RequiredParam` usage in `request_copilot_review`.

## What changed
- After decoding, reject a zero-value `owner`, `repo`, or `issue_number` with `missing required parameter: <name>` in both `AssignCopilotToIssue` and `AssignCopilotToIssueWithIntent`.
- Added table tests for the missing cases.

## MCP impact
- [x] Tool schema or behavior changed
  - No schema change (the three fields were already marked required). The two tools now return a clear `missing required parameter` error for a missing required field instead of a confusing repository-resolution error.

## Prompts tested (tool changes only)
- "Assign Copilot to this issue" with `owner` omitted now returns `missing required parameter: owner`. Verified via the new unit tests in `copilot_test.go`: a request missing each required field asserts the clear error, and without the fix it returns the `Could not resolve to a Repository` 404 instead.

## Security / limits
- [x] No security or limits impact

## Tool renaming
- [x] I am not renaming tools as part of this PR